### PR TITLE
Resolve BeforeTestRun/AfterTestRun hook dependencies from the test run (global) container instead of the test thread container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # [vNext]
 
+* Resolve dependencies of [BeforeTestRun] / [AfterTestRun] hooks from the 
+  test run (global) context instead of the test thread context.
 * Support for PriorityAttribute in MsTest adapter
 * Support for Scenario Outline / DataRowAttribute in MsTest adapter
 

--- a/Plugins/Reqnroll.NUnit.ReqnrollPlugin/NUnitNetFrameworkTestRunSettingsProvider.cs
+++ b/Plugins/Reqnroll.NUnit.ReqnrollPlugin/NUnitNetFrameworkTestRunSettingsProvider.cs
@@ -4,11 +4,11 @@ using Reqnroll.TestFramework;
 
 namespace Reqnroll.NUnit.ReqnrollPlugin
 {
-    public class NUnitNetFrameworkTestRunContext : ITestRunContext
+    public class NUnitNetFrameworkTestRunSettingsProvider : ITestRunSettingsProvider
     {
         private readonly IReqnrollPath _reqnrollPath;
 
-        public NUnitNetFrameworkTestRunContext(IReqnrollPath reqnrollPath)
+        public NUnitNetFrameworkTestRunSettingsProvider(IReqnrollPath reqnrollPath)
         {
             _reqnrollPath = reqnrollPath;
         }

--- a/Plugins/Reqnroll.NUnit.ReqnrollPlugin/RuntimePlugin.cs
+++ b/Plugins/Reqnroll.NUnit.ReqnrollPlugin/RuntimePlugin.cs
@@ -27,7 +27,7 @@ namespace Reqnroll.NUnit.ReqnrollPlugin
         private void RuntimePluginEvents_CustomizeGlobalDependencies(object sender, CustomizeGlobalDependenciesEventArgs e)
         {
 #if NETFRAMEWORK
-            e.ObjectContainer.RegisterTypeAs<NUnitNetFrameworkTestRunContext, ITestRunContext>();
+            e.ObjectContainer.RegisterTypeAs<NUnitNetFrameworkTestRunSettingsProvider, ITestRunSettingsProvider>();
 #endif
         }
 

--- a/Reqnroll/DefaultTestRunContext.cs
+++ b/Reqnroll/DefaultTestRunContext.cs
@@ -9,7 +9,7 @@ public interface ITestRunContext : IReqnrollContext
     string TestDirectory { get; }
 }
 
-public class TestRunContext : ReqnrollContext, ITestRunContext
+public class DefaultTestRunContext : ReqnrollContext, ITestRunContext
 {
     private readonly ITestRunSettingsProvider _testRunSettingsProvider;
 
@@ -17,7 +17,7 @@ public class TestRunContext : ReqnrollContext, ITestRunContext
 
     public string TestDirectory => _testRunSettingsProvider.GetTestDirectory();
 
-    public TestRunContext(IObjectContainer testRunContainer, ITestRunSettingsProvider testRunSettingsProvider)
+    public DefaultTestRunContext(IObjectContainer testRunContainer, ITestRunSettingsProvider testRunSettingsProvider)
     {
         _testRunSettingsProvider = testRunSettingsProvider;
         TestRunContainer = testRunContainer;

--- a/Reqnroll/Infrastructure/DefaultDependencyProvider.cs
+++ b/Reqnroll/Infrastructure/DefaultDependencyProvider.cs
@@ -24,6 +24,7 @@ namespace Reqnroll.Infrastructure
     {
         public virtual void RegisterGlobalContainerDefaults(ObjectContainer container)
         {
+            container.RegisterTypeAs<TestRunContext, ITestRunContext>();
             container.RegisterTypeAs<DefaultRuntimeConfigurationProvider, IRuntimeConfigurationProvider>();
 
             container.RegisterTypeAs<TestRunnerManager, ITestRunnerManager>();
@@ -69,7 +70,7 @@ namespace Reqnroll.Infrastructure
             container.RegisterTypeAs<BinaryFileAccessor, IBinaryFileAccessor>();
             container.RegisterTypeAs<TestPendingMessageFactory, ITestPendingMessageFactory>();
             container.RegisterTypeAs<TestUndefinedMessageFactory, ITestUndefinedMessageFactory>();
-            container.RegisterTypeAs<DefaultTestRunContext, ITestRunContext>();
+            container.RegisterTypeAs<DefaultTestRunSettingsProvider, ITestRunSettingsProvider>();
 
             container.RegisterTypeAs<ReqnrollPath, IReqnrollPath>();
 

--- a/Reqnroll/Infrastructure/DefaultDependencyProvider.cs
+++ b/Reqnroll/Infrastructure/DefaultDependencyProvider.cs
@@ -24,7 +24,7 @@ namespace Reqnroll.Infrastructure
     {
         public virtual void RegisterGlobalContainerDefaults(ObjectContainer container)
         {
-            container.RegisterTypeAs<TestRunContext, ITestRunContext>();
+            container.RegisterTypeAs<DefaultTestRunContext, ITestRunContext>();
             container.RegisterTypeAs<DefaultRuntimeConfigurationProvider, IRuntimeConfigurationProvider>();
 
             container.RegisterTypeAs<TestRunnerManager, ITestRunnerManager>();

--- a/Reqnroll/TestFramework/DefaultTestRunSettingsProvider.cs
+++ b/Reqnroll/TestFramework/DefaultTestRunSettingsProvider.cs
@@ -2,11 +2,11 @@ using Reqnroll.EnvironmentAccess;
 
 namespace Reqnroll.TestFramework
 {
-    public class DefaultTestRunContext : ITestRunContext
+    public class DefaultTestRunSettingsProvider : ITestRunSettingsProvider
     {
         private readonly IEnvironmentWrapper _environmentWrapper;
 
-        public DefaultTestRunContext(IEnvironmentWrapper environmentWrapper)
+        public DefaultTestRunSettingsProvider(IEnvironmentWrapper environmentWrapper)
         {
             _environmentWrapper = environmentWrapper;
         }

--- a/Reqnroll/TestFramework/ITestRunSettingsProvider.cs
+++ b/Reqnroll/TestFramework/ITestRunSettingsProvider.cs
@@ -1,6 +1,6 @@
 namespace Reqnroll.TestFramework
 {
-    public interface ITestRunContext
+    public interface ITestRunSettingsProvider
     {
         string GetTestDirectory();
     }

--- a/Reqnroll/TestRunContext.cs
+++ b/Reqnroll/TestRunContext.cs
@@ -1,0 +1,25 @@
+﻿using BoDi;
+using Reqnroll.TestFramework;
+
+namespace Reqnroll;
+
+public interface ITestRunContext : IReqnrollContext
+{
+    IObjectContainer TestRunContainer { get; }
+    string TestDirectory { get; }
+}
+
+public class TestRunContext : ReqnrollContext, ITestRunContext
+{
+    private readonly ITestRunSettingsProvider _testRunSettingsProvider;
+
+    public IObjectContainer TestRunContainer { get; }
+
+    public string TestDirectory => _testRunSettingsProvider.GetTestDirectory();
+
+    public TestRunContext(IObjectContainer testRunContainer, ITestRunSettingsProvider testRunSettingsProvider)
+    {
+        _testRunSettingsProvider = testRunSettingsProvider;
+        TestRunContainer = testRunContainer;
+    }
+}

--- a/Tests/Reqnroll.RuntimeTests/Infrastructure/TestExecutionEngineTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/Infrastructure/TestExecutionEngineTests.cs
@@ -43,7 +43,7 @@ namespace Reqnroll.RuntimeTests.Infrastructure
         private ObjectContainer testThreadContainer;
         private ObjectContainer featureContainer;
         private ObjectContainer scenarioContainer;
-        private TestRunContext testRunContext;
+        private DefaultTestRunContext testRunContext;
         private TestObjectResolver defaultTestObjectResolver = new TestObjectResolver();
         private ITestPendingMessageFactory _testPendingMessageFactory;
         private ITestUndefinedMessageFactory _testUndefinedMessageFactory;
@@ -87,7 +87,7 @@ namespace Reqnroll.RuntimeTests.Infrastructure
             testThreadContainer = new ObjectContainer(globalContainer);
             featureContainer = new ObjectContainer(testThreadContainer);
             scenarioContainer = new ObjectContainer(scenarioContainer);
-            testRunContext = new TestRunContext(globalContainer, new Mock<ITestRunSettingsProvider>().Object);
+            testRunContext = new DefaultTestRunContext(globalContainer, new Mock<ITestRunSettingsProvider>().Object);
 
             beforeScenarioEvents = new List<IHookBinding>();
             afterScenarioEvents = new List<IHookBinding>();

--- a/Tests/Reqnroll.RuntimeTests/Infrastructure/TestExecutionEngineTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/Infrastructure/TestExecutionEngineTests.cs
@@ -19,6 +19,7 @@ using FluentAssertions;
 using Reqnroll.Analytics;
 using Reqnroll.Events;
 using Reqnroll.Plugins;
+using Reqnroll.TestFramework;
 
 namespace Reqnroll.RuntimeTests.Infrastructure
 {
@@ -38,9 +39,11 @@ namespace Reqnroll.RuntimeTests.Infrastructure
         private Mock<IObsoleteStepHandler> obsoleteTestHandlerMock;
         private FeatureInfo featureInfo;
         private ScenarioInfo scenarioInfo;
+        private ObjectContainer globalContainer;
         private ObjectContainer testThreadContainer;
         private ObjectContainer featureContainer;
         private ObjectContainer scenarioContainer;
+        private TestRunContext testRunContext;
         private TestObjectResolver defaultTestObjectResolver = new TestObjectResolver();
         private ITestPendingMessageFactory _testPendingMessageFactory;
         private ITestUndefinedMessageFactory _testUndefinedMessageFactory;
@@ -80,9 +83,11 @@ namespace Reqnroll.RuntimeTests.Infrastructure
         {
             reqnrollConfiguration = ConfigurationLoader.GetDefault();
 
-            testThreadContainer = new ObjectContainer();
-            featureContainer = new ObjectContainer();
-            scenarioContainer = new ObjectContainer();
+            globalContainer = new ObjectContainer();
+            testThreadContainer = new ObjectContainer(globalContainer);
+            featureContainer = new ObjectContainer(testThreadContainer);
+            scenarioContainer = new ObjectContainer(scenarioContainer);
+            testRunContext = new TestRunContext(globalContainer, new Mock<ITestRunSettingsProvider>().Object);
 
             beforeScenarioEvents = new List<IHookBinding>();
             afterScenarioEvents = new List<IHookBinding>();
@@ -176,7 +181,7 @@ namespace Reqnroll.RuntimeTests.Infrastructure
                 _testPendingMessageFactory,
                 _testUndefinedMessageFactory,
                 testObjectResolverMock.Object,
-                testThreadContainer);
+                testRunContext);
         }
 
 
@@ -464,7 +469,7 @@ namespace Reqnroll.RuntimeTests.Infrastructure
 
             await testExecutionEngine.OnTestRunStartAsync();
 
-            AssertHooksWasCalledWithParam(hookMock, testThreadContainer);
+            AssertHooksWasCalledWithParam(hookMock, globalContainer);
         }
 
         [Fact]
@@ -494,7 +499,7 @@ namespace Reqnroll.RuntimeTests.Infrastructure
 
             AssertHooksWasCalledWithParam(beforeHook, DummyClass.LastInstance);
             AssertHooksWasCalledWithParam(afterHook, DummyClass.LastInstance);
-            testObjectResolverMock.Verify(bir => bir.ResolveBindingInstance(typeof(DummyClass), testThreadContainer),
+            testObjectResolverMock.Verify(bir => bir.ResolveBindingInstance(typeof(DummyClass), globalContainer),
                 Times.Exactly(2));
         }
 

--- a/Tests/Reqnroll.Specs/Features/Hooks/HookParameterInjection.feature
+++ b/Tests/Reqnroll.Specs/Features/Hooks/HookParameterInjection.feature
@@ -52,33 +52,26 @@ Note: the parameters of the BeforeFeature/AfterFeature hook are resolved from th
         | 1         |
     
 Scenario: Should be able to access thread level and global services in BeforeTestRun/AfterTestRun hooks as parameter
-Note: the parameters of the BeforeFeature/AfterFeature hook are resolved from the test thread container
+Note: the parameters of the BeforeFeature/AfterFeature hook are resolved from the test run (global) container
     Given there is a Reqnroll project
     And there is a scenario	
     And all steps are bound and pass
     And the following hooks
         """
         [BeforeTestRun]
-        public static void BeforeTestRun(ITestRunnerManager testRunnerManager, ITestRunner testRunner)
+        public static void BeforeTestRun(ITestRunnerManager testRunnerManager)
         {
-            //All parameters are resolved from the test thread container automatically. ITestRunnerManager and ITestRunner are just some examples here.
-            //Since the global container is the base container of the test thread container, globally registered services can be also injected.
+            //All parameters are resolved from the test run container automatically. ITestRunnerManager is just an example here.
         
             //ITestRunManager from global container
             if (testRunnerManager == null) throw new Exception("ITestRunManager wasn't passed correctly as parameter to BeforeTestRun");
-            
-            //ITestRunner from test thread container
-            if (testRunner == null) throw new Exception("ITestRunner wasn't passed correctly as parameter to BeforeTestRun");
         }
             
         [AfterTestRun]
-        public static void AfterTestRun(ITestRunnerManager testRunnerManager, ITestRunner testRunner)
+        public static void AfterTestRun(ITestRunnerManager testRunnerManager)
         {
             //ITestRunManager from global container
             if (testRunnerManager == null) throw new Exception("ITestRunManager wasn't passed correctly as parameter to AfterTestRun");
-            
-            //ITestRunner from test thread container
-            if (testRunner == null) throw new Exception("ITestRunner wasn't passed correctly as parameter to AfterTestRun");
         }
         """
     When I execute the tests

--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -203,32 +203,19 @@ In the BeforeTestRun hook you can resolve test thread specific or global service
 ```{code-block} csharp
 :caption: Hook File
 [BeforeTestRun]
-public static void BeforeTestRunInjection(ITestRunnerManager testRunnerManager, ITestRunner testRunner)
+public static void BeforeTestRunInjection(ITestRunnerManager testRunnerManager)
 {
-    //All parameters are resolved from the test thread container automatically.
-    //Since the global container is the base container of the test thread container, globally registered services can be also injected.
-
-    //ITestRunManager from global container
+    //All parameters are resolved from the test run (global) container automatically.
     var location = testRunnerManager.TestAssembly.Location;
-    
-    //ITestRunner from test thread container
-    var threadId = testRunner.ThreadId;
 }
 ```
 
 ```{code-block} csharp
 :caption: Hook File with async method
 [BeforeTestRun]
-public static async Task BeforeTestRunInjectionAsync(ITestRunnerManager testRunnerManager, ITestRunner testRunner)
+public static async Task BeforeTestRunInjectionAsync(ITestRunnerManager testRunnerManager)
 {
-    //All parameters are resolved from the test thread container automatically.
-    //Since the global container is the base container of the test thread container, globally registered services can be also injected.
-
-    //ITestRunManager from global container
     var location = testRunnerManager.TestAssembly.Location;
-    
-    //ITestRunner from test thread container
-    var threadId = testRunner.ThreadId;
 
     // Example async operation
     await Task.Delay(1000);
@@ -239,7 +226,7 @@ Depending on the type of the hook the parameters are resolved from a container w
 
 | Attribute | Container |
 |-----------|-----------|
-| `[BeforeTestRun]`<br/>`[AfterTestRun]` | TestThreadContainer |
+| `[BeforeTestRun]`<br/>`[AfterTestRun]` | TestRunContainer ("global" container) |
 | `[BeforeFeature]`<br/>`[AfterFeature]` | FeatureContainer    |
 | `[BeforeScenario]`<br/>`[AfterScenario]`<br/>`[BeforeScenarioBlock]`<br/>`[AfterScenarioBlock]`<br/>`[BeforeStep]`<br/>`[AfterStep]`| ScenarioContainer |
 


### PR DESCRIPTION
<!-- If this is your first PR, please have a look at the Contribution Guidelines (https://github.com/reqnroll/Reqnroll/blob/main/CONTRIBUTING.md) -->

Fixing #58. 

So far the `[BeforeTestRun]` / `[AfterTestRun]` hooks were resolved from the "first" test run context. This is pretty arbitrary and misleading. They should have been resolved from the test run ("global") context. 

This normally should not matter for single-threaded tests, but it seems that the way how SpecFlow v4 (and Reqnroll) invokes these hooks is different and they are not necessarily invoked from the same test thread that is used for test execution (this depends on the test execution framework probably, but with NUnit there seem to be a different thread), so anything that you register in  `[BeforeTestRun]` to the injected container might not be visible for the step definitions or scenario hooks.

This PR changes this and resolves the `[BeforeTestRun]` / `[AfterTestRun]` hooks from the test run ("global") context. This means that some services that were available so far for these hooks are not available anymore (e.g. "IReqnrollOutputHelper"), let's see the impact of this.

<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Performance improvement
- [ ] Refactoring (so no functional change)
- [ ] Other (docs, build config, etc)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- This checklist is here for you that you didn't forget anything -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I've added tests for my code. (most of the time mandatory)
- [x] I have added an entry to the changelog. (mandatory)
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
