### PR TITLE
Fixing failing Reqnroll build by using TaskHostFactory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,16 +153,16 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: | 
-          8.0.x
+          6.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
       run: dotnet build --no-restore ${{ needs.build.outputs.build_params }}
-    - name: Set .NET 8 SDK
-      run: dotnet new globaljson --sdk-version 8.0.201
+    - name: Set .NET 6 SDK
+      run: dotnet new globaljson --sdk-version 6.0.418
     - name: xUnit Specs
       shell: pwsh
-      run: dotnet test ./Tests/Reqnroll.Specs/Reqnroll.Specs.csproj ${{ needs.build.outputs.test_params }} -f net8.0 --filter "Category=xUnit&Category=Net60&Category!=requiresMsBuild${{ needs.build.outputs.specs_filter }}" --logger "trx;LogFileName=specs-xunit-results.trx"
+      run: dotnet test ./Tests/Reqnroll.Specs/Reqnroll.Specs.csproj ${{ needs.build.outputs.test_params }} -f net6.0 --filter "Category=xUnit&Category=Net60&Category!=requiresMsBuild${{ needs.build.outputs.specs_filter }}" --logger "trx;LogFileName=specs-xunit-results.trx"
     - name: Publish xUnit Test Results
       uses: EnricoMi/publish-unit-test-result-action@v2
       if: always()
@@ -189,16 +189,16 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: | 
-          8.0.x
+          6.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
       run: dotnet build --no-restore ${{ needs.build.outputs.build_params }}
-    - name: Set .NET 8 SDK
-      run: dotnet new globaljson --sdk-version 8.0.201
+    - name: Set .NET 6 SDK
+      run: dotnet new globaljson --sdk-version 6.0.418
     - name: NUnit Specs
       shell: pwsh
-      run: dotnet test ./Tests/Reqnroll.Specs/Reqnroll.Specs.csproj ${{ needs.build.outputs.test_params }} -f net8.0 --filter "Category=NUnit3&Category=Net60&Category!=requiresMsBuild${{ needs.build.outputs.specs_filter }}" --logger "trx;LogFileName=specs-nunit-results.trx"
+      run: dotnet test ./Tests/Reqnroll.Specs/Reqnroll.Specs.csproj ${{ needs.build.outputs.test_params }} -f net6.0 --filter "Category=NUnit3&Category=Net60&Category!=requiresMsBuild${{ needs.build.outputs.specs_filter }}" --logger "trx;LogFileName=specs-nunit-results.trx"
     - name: Publish NUnit Test Results
       uses: EnricoMi/publish-unit-test-result-action@v2
       if: always()
@@ -225,16 +225,16 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: | 
-          8.0.x
+          6.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
       run: dotnet build --no-restore ${{ needs.build.outputs.build_params }}
-    - name: Set .NET 8 SDK
-      run: dotnet new globaljson --sdk-version 8.0.201
+    - name: Set .NET 6 SDK
+      run: dotnet new globaljson --sdk-version 6.0.418
     - name: MsTest Specs
       shell: pwsh
-      run: dotnet test ./Tests/Reqnroll.Specs/Reqnroll.Specs.csproj ${{ needs.build.outputs.test_params }} -f net8.0 --filter "Category=MsTest&Category=Net60&Category!=requiresMsBuild${{ needs.build.outputs.specs_filter }}" --logger "trx;LogFileName=specs-mstest-results.trx"
+      run: dotnet test ./Tests/Reqnroll.Specs/Reqnroll.Specs.csproj ${{ needs.build.outputs.test_params }} -f net6.0 --filter "Category=MsTest&Category=Net60&Category!=requiresMsBuild${{ needs.build.outputs.specs_filter }}" --logger "trx;LogFileName=specs-mstest-results.trx"
     - name: Publish MSTest Test Results
       uses: EnricoMi/publish-unit-test-result-action@v2
       if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,16 +153,16 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: | 
-          6.0.x
+          8.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
       run: dotnet build --no-restore ${{ needs.build.outputs.build_params }}
-    - name: Set .NET 6 SDK
-      run: dotnet new globaljson --sdk-version 6.0.418
+    - name: Set .NET 8 SDK
+      run: dotnet new globaljson --sdk-version 8.0.201
     - name: xUnit Specs
       shell: pwsh
-      run: dotnet test ./Tests/Reqnroll.Specs/Reqnroll.Specs.csproj ${{ needs.build.outputs.test_params }} -f net6.0 --filter "Category=xUnit&Category=Net60&Category!=requiresMsBuild${{ needs.build.outputs.specs_filter }}" --logger "trx;LogFileName=specs-xunit-results.trx"
+      run: dotnet test ./Tests/Reqnroll.Specs/Reqnroll.Specs.csproj ${{ needs.build.outputs.test_params }} -f net8.0 --filter "Category=xUnit&Category=Net60&Category!=requiresMsBuild${{ needs.build.outputs.specs_filter }}" --logger "trx;LogFileName=specs-xunit-results.trx"
     - name: Publish xUnit Test Results
       uses: EnricoMi/publish-unit-test-result-action@v2
       if: always()
@@ -189,16 +189,16 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: | 
-          6.0.x
+          8.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
       run: dotnet build --no-restore ${{ needs.build.outputs.build_params }}
-    - name: Set .NET 6 SDK
-      run: dotnet new globaljson --sdk-version 6.0.418
+    - name: Set .NET 8 SDK
+      run: dotnet new globaljson --sdk-version 8.0.201
     - name: NUnit Specs
       shell: pwsh
-      run: dotnet test ./Tests/Reqnroll.Specs/Reqnroll.Specs.csproj ${{ needs.build.outputs.test_params }} -f net6.0 --filter "Category=NUnit3&Category=Net60&Category!=requiresMsBuild${{ needs.build.outputs.specs_filter }}" --logger "trx;LogFileName=specs-nunit-results.trx"
+      run: dotnet test ./Tests/Reqnroll.Specs/Reqnroll.Specs.csproj ${{ needs.build.outputs.test_params }} -f net8.0 --filter "Category=NUnit3&Category=Net60&Category!=requiresMsBuild${{ needs.build.outputs.specs_filter }}" --logger "trx;LogFileName=specs-nunit-results.trx"
     - name: Publish NUnit Test Results
       uses: EnricoMi/publish-unit-test-result-action@v2
       if: always()
@@ -225,16 +225,16 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: | 
-          6.0.x
+          8.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
       run: dotnet build --no-restore ${{ needs.build.outputs.build_params }}
-    - name: Set .NET 6 SDK
-      run: dotnet new globaljson --sdk-version 6.0.418
+    - name: Set .NET 8 SDK
+      run: dotnet new globaljson --sdk-version 8.0.201
     - name: MsTest Specs
       shell: pwsh
-      run: dotnet test ./Tests/Reqnroll.Specs/Reqnroll.Specs.csproj ${{ needs.build.outputs.test_params }} -f net6.0 --filter "Category=MsTest&Category=Net60&Category!=requiresMsBuild${{ needs.build.outputs.specs_filter }}" --logger "trx;LogFileName=specs-mstest-results.trx"
+      run: dotnet test ./Tests/Reqnroll.Specs/Reqnroll.Specs.csproj ${{ needs.build.outputs.test_params }} -f net8.0 --filter "Category=MsTest&Category=Net60&Category!=requiresMsBuild${{ needs.build.outputs.specs_filter }}" --logger "trx;LogFileName=specs-mstest-results.trx"
     - name: Publish MSTest Test Results
       uses: EnricoMi/publish-unit-test-result-action@v2
       if: always()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,7 +142,6 @@ Hints to speed up tests:
 * Always select a unit test framework and a platform category to run tests.
 * Add the `%TEMP%\SF` folder to the Microsoft Defender Antivirus exclusion list.
 * Add the following processes to the Microsoft Defender Antivirus exclusion list: dotnet.exe, MSBuild.exe, vstest.console.exe, VBCSCompiler.exe, testhost.exe, testhost.x86.exe
-* Set the `MSBUILDDISABLENODEREUSE` environment variable to `1`
 
 Other notes:
 * The Specs tests use an interim version of Reqnroll that you have just built locally. The version number of this package is calculated automatically by the git commits, so after every commit there will be a new version. You might need to do a rebuild to pick it up if you see failures related to not found Reqnroll package versions.

--- a/Directory.Build.rsp
+++ b/Directory.Build.rsp
@@ -1,1 +1,0 @@
--nodeReuse:false

--- a/Reqnroll.Tools.MsBuild.Generation/Reqnroll.Tools.MsBuild.Generation.nuspec
+++ b/Reqnroll.Tools.MsBuild.Generation/Reqnroll.Tools.MsBuild.Generation.nuspec
@@ -25,8 +25,12 @@
     <file src="bin\$config$\net462\*.dll" target="tasks\$Reqnroll_FullFramework_Generator_TFM$" />
     <file src="bin\$config$\netcoreapp3.1\*.dll" target="tasks\$Reqnroll_Core_Tools_TFM$" />
     <file src="bin\$config$\netcoreapp3.1\*.deps.json" target="tasks\$Reqnroll_Core_Tools_TFM$" />
-    
-    <file src="bin\$config$\net6.0\*.dll" target="tasks\$Reqnroll_Net6_TFM$" />
+
+    <file src="bin\$config$\net6.0\BoDi.dll" target="tasks\$Reqnroll_Net6_TFM$" />
+    <file src="bin\$config$\net6.0\CucumberExpressions.dll" target="tasks\$Reqnroll_Net6_TFM$" />
+    <file src="bin\$config$\net6.0\Gherkin.dll" target="tasks\$Reqnroll_Net6_TFM$" />
+    <file src="bin\$config$\net6.0\SpecFlow.Internal.Json.dll" target="tasks\$Reqnroll_Net6_TFM$" />
+    <file src="bin\$config$\net6.0\Reqnroll*.dll" target="tasks\$Reqnroll_Net6_TFM$" />
     <file src="bin\$config$\net6.0\*.deps.json" target="tasks\$Reqnroll_Net6_TFM$" />
     
     <file src="$SolutionDir$\Licenses\**\*" target="licenses" />

--- a/Reqnroll.Tools.MsBuild.Generation/Reqnroll.Tools.MsBuild.Generation.nuspec
+++ b/Reqnroll.Tools.MsBuild.Generation/Reqnroll.Tools.MsBuild.Generation.nuspec
@@ -23,11 +23,7 @@
     <file src="build\**\*" target="build" />
     <file src="buildMultiTargeting\**\*" target="buildMultiTargeting" />
     <file src="bin\$config$\net462\*.dll" target="tasks\$Reqnroll_FullFramework_Generator_TFM$" />
-    <file src="bin\$config$\netcoreapp3.1\BoDi.dll" target="tasks\$Reqnroll_Core_Tools_TFM$" />
-    <file src="bin\$config$\netcoreapp3.1\CucumberExpressions.dll" target="tasks\$Reqnroll_Core_Tools_TFM$" />
-    <file src="bin\$config$\netcoreapp3.1\Gherkin.dll" target="tasks\$Reqnroll_Core_Tools_TFM$" />
-    <file src="bin\$config$\netcoreapp3.1\SpecFlow.Internal.Json.dll" target="tasks\$Reqnroll_Core_Tools_TFM$" />
-    <file src="bin\$config$\netcoreapp3.1\Reqnroll*.dll" target="tasks\$Reqnroll_Core_Tools_TFM$" />
+    <file src="bin\$config$\netcoreapp3.1\*.dll" target="tasks\$Reqnroll_Core_Tools_TFM$" />
     <file src="bin\$config$\netcoreapp3.1\*.deps.json" target="tasks\$Reqnroll_Core_Tools_TFM$" />
 
     <file src="bin\$config$\net6.0\BoDi.dll" target="tasks\$Reqnroll_Net6_TFM$" />

--- a/Reqnroll.Tools.MsBuild.Generation/Reqnroll.Tools.MsBuild.Generation.nuspec
+++ b/Reqnroll.Tools.MsBuild.Generation/Reqnroll.Tools.MsBuild.Generation.nuspec
@@ -23,7 +23,11 @@
     <file src="build\**\*" target="build" />
     <file src="buildMultiTargeting\**\*" target="buildMultiTargeting" />
     <file src="bin\$config$\net462\*.dll" target="tasks\$Reqnroll_FullFramework_Generator_TFM$" />
-    <file src="bin\$config$\netcoreapp3.1\*.dll" target="tasks\$Reqnroll_Core_Tools_TFM$" />
+    <file src="bin\$config$\netcoreapp3.1\BoDi.dll" target="tasks\$Reqnroll_Core_Tools_TFM$" />
+    <file src="bin\$config$\netcoreapp3.1\CucumberExpressions.dll" target="tasks\$Reqnroll_Core_Tools_TFM$" />
+    <file src="bin\$config$\netcoreapp3.1\Gherkin.dll" target="tasks\$Reqnroll_Core_Tools_TFM$" />
+    <file src="bin\$config$\netcoreapp3.1\SpecFlow.Internal.Json.dll" target="tasks\$Reqnroll_Core_Tools_TFM$" />
+    <file src="bin\$config$\netcoreapp3.1\Reqnroll*.dll" target="tasks\$Reqnroll_Core_Tools_TFM$" />
     <file src="bin\$config$\netcoreapp3.1\*.deps.json" target="tasks\$Reqnroll_Core_Tools_TFM$" />
 
     <file src="bin\$config$\net6.0\BoDi.dll" target="tasks\$Reqnroll_Net6_TFM$" />

--- a/Reqnroll.Tools.MsBuild.Generation/Reqnroll.Tools.MsBuild.Generation.nuspec
+++ b/Reqnroll.Tools.MsBuild.Generation/Reqnroll.Tools.MsBuild.Generation.nuspec
@@ -23,18 +23,10 @@
     <file src="build\**\*" target="build" />
     <file src="buildMultiTargeting\**\*" target="buildMultiTargeting" />
     <file src="bin\$config$\net462\*.dll" target="tasks\$Reqnroll_FullFramework_Generator_TFM$" />
-    <file src="bin\$config$\netcoreapp3.1\BoDi.dll" target="tasks\$Reqnroll_Core_Tools_TFM$" />
-    <file src="bin\$config$\netcoreapp3.1\CucumberExpressions.dll" target="tasks\$Reqnroll_Core_Tools_TFM$" />
-    <file src="bin\$config$\netcoreapp3.1\Gherkin.dll" target="tasks\$Reqnroll_Core_Tools_TFM$" />
-    <file src="bin\$config$\netcoreapp3.1\SpecFlow.Internal.Json.dll" target="tasks\$Reqnroll_Core_Tools_TFM$" />
-    <file src="bin\$config$\netcoreapp3.1\Reqnroll*.dll" target="tasks\$Reqnroll_Core_Tools_TFM$" />
+    <file src="bin\$config$\netcoreapp3.1\*.dll" exclude="bin\$config$\netcoreapp3.1\System.*;bin\$config$\netcoreapp3.1\Microsoft.*" target="tasks\$Reqnroll_Core_Tools_TFM$" />
     <file src="bin\$config$\netcoreapp3.1\*.deps.json" target="tasks\$Reqnroll_Core_Tools_TFM$" />
 
-    <file src="bin\$config$\net6.0\BoDi.dll" target="tasks\$Reqnroll_Net6_TFM$" />
-    <file src="bin\$config$\net6.0\CucumberExpressions.dll" target="tasks\$Reqnroll_Net6_TFM$" />
-    <file src="bin\$config$\net6.0\Gherkin.dll" target="tasks\$Reqnroll_Net6_TFM$" />
-    <file src="bin\$config$\net6.0\SpecFlow.Internal.Json.dll" target="tasks\$Reqnroll_Net6_TFM$" />
-    <file src="bin\$config$\net6.0\Reqnroll*.dll" target="tasks\$Reqnroll_Net6_TFM$" />
+    <file src="bin\$config$\net6.0\*.dll" exclude="bin\$config$\net6.0\System.*;bin\$config$\net6.0\Microsoft.*" target="tasks\$Reqnroll_Net6_TFM$" />
     <file src="bin\$config$\net6.0\*.deps.json" target="tasks\$Reqnroll_Net6_TFM$" />
     
     <file src="$SolutionDir$\Licenses\**\*" target="licenses" />

--- a/Reqnroll.Tools.MsBuild.Generation/build/Reqnroll.Tools.MsBuild.Generation.tasks
+++ b/Reqnroll.Tools.MsBuild.Generation/build/Reqnroll.Tools.MsBuild.Generation.tasks
@@ -1,6 +1,13 @@
 <Project>
-  <UsingTask TaskName="Reqnroll.Tools.MsBuild.Generation.GenerateFeatureFileCodeBehindTask" AssemblyFile="$(_Reqnroll_TaskAssembly)"  />
-  <UsingTask TaskName="Reqnroll.Tools.MsBuild.Generation.ReplaceTokenInFileTask" AssemblyFile="$(_Reqnroll_TaskAssembly)"  />
+  <!-- Using `TaskHostFactory` ensures that the task assembly will not be locked
+       at the end of the build. If it's omitted, that can cause build failures
+       in subsequent builds because the task assembly can't be written by the
+       next build.
+
+       Reference: https://learn.microsoft.com/en-us/visualstudio/msbuild/how-to-configure-targets-and-tasks?view=vs-2022#task-factories
+  -->
+  <UsingTask TaskName="Reqnroll.Tools.MsBuild.Generation.GenerateFeatureFileCodeBehindTask" AssemblyFile="$(_Reqnroll_TaskAssembly)" TaskFactory="TaskHostFactory" />
+  <UsingTask TaskName="Reqnroll.Tools.MsBuild.Generation.ReplaceTokenInFileTask" AssemblyFile="$(_Reqnroll_TaskAssembly)" TaskFactory="TaskHostFactory" />
 
   <PropertyGroup>
     <_ReqnrollTasksImported>true</_ReqnrollTasksImported>


### PR DESCRIPTION
This seems to fix the problem described in this discussion:
https://github.com/orgs/reqnroll/discussions/38

It should prevent developers from setting the `MSBUILDDISABLENODEREUSE` environment variable and speed up builds slightly as the msbuild nodes will be re-used.

More details on the fix here:
https://learn.microsoft.com/en-us/visualstudio/msbuild/how-to-configure-targets-and-tasks?view=vs-2022#task-factories



## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Performance improvement
- [ ] Refactoring (so no functional change)
- [x] Other (docs, build config, etc)
