### PR TITLE
Improve E2E test stability

### DIFF
--- a/.ncrunch/Reqnroll.TestProjectGenerator.Cli.v3.ncrunchproject
+++ b/.ncrunch/Reqnroll.TestProjectGenerator.Cli.v3.ncrunchproject
@@ -3,6 +3,5 @@
     <CustomBuildProperties>
       <Value>TargetFrameworks = net6.0</Value>
     </CustomBuildProperties>
-    <IgnoreThisComponentCompletely>True</IgnoreThisComponentCompletely>
   </Settings>
 </ProjectConfiguration>

--- a/.ncrunch/Reqnroll.TestProjectGenerator.Tests.v3.ncrunchproject
+++ b/.ncrunch/Reqnroll.TestProjectGenerator.Tests.v3.ncrunchproject
@@ -1,8 +1,3 @@
 ﻿<ProjectConfiguration>
-  <Settings>
-    <CustomBuildProperties>
-      <Value>TargetFrameworks = net6.0</Value>
-    </CustomBuildProperties>
-    <IgnoreThisComponentCompletely>True</IgnoreThisComponentCompletely>
-  </Settings>
+  <Settings />
 </ProjectConfiguration>

--- a/.ncrunch/Reqnroll.TestProjectGenerator.v3.ncrunchproject
+++ b/.ncrunch/Reqnroll.TestProjectGenerator.v3.ncrunchproject
@@ -1,5 +1,3 @@
 ﻿<ProjectConfiguration>
-  <Settings>
-    <IgnoreThisComponentCompletely>False</IgnoreThisComponentCompletely>
-  </Settings>
+  <Settings />
 </ProjectConfiguration>

--- a/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator.Cli/ArtifactNamingConventionOverride.cs
+++ b/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator.Cli/ArtifactNamingConventionOverride.cs
@@ -3,11 +3,11 @@ using Reqnroll.TestProjectGenerator.Conventions;
 
 namespace Reqnroll.TestProjectGenerator.Cli
 {
-    public class SolutionNamingConventionOverride : SolutionNamingConvention
+    public class ArtifactNamingConventionOverride : ArtifactNamingConvention
     {
         private readonly SolutionConfiguration _solutionConfiguration;
 
-        public SolutionNamingConventionOverride(SolutionConfiguration solutionConfiguration)
+        public ArtifactNamingConventionOverride(SolutionConfiguration solutionConfiguration)
         {
             _solutionConfiguration = solutionConfiguration;
         }

--- a/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator.Cli/FoldersOverride.cs
+++ b/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator.Cli/FoldersOverride.cs
@@ -1,12 +1,13 @@
 using System.IO;
 using Reqnroll.TestProjectGenerator;
+using Reqnroll.TestProjectGenerator.Conventions;
 
 namespace Reqnroll.TestProjectGenerator.Cli
 {
     public class FoldersOverride : Folders
     {
         private readonly SolutionConfiguration _solutionConfiguration;
-        public FoldersOverride(SolutionConfiguration solutionConfiguration) : base(null)
+        public FoldersOverride(SolutionConfiguration solutionConfiguration, ArtifactNamingConvention artifactNamingConvention) : base(null, artifactNamingConvention)
         {
             _solutionConfiguration = solutionConfiguration;
         }

--- a/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator.Cli/Program.cs
+++ b/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator.Cli/Program.cs
@@ -135,7 +135,7 @@ namespace Reqnroll.TestProjectGenerator.Cli
 
             services.AddSingleton<IOutputWriter, OutputWriter>();
             services.AddSingleton<Folders, FoldersOverride>();
-            services.AddSingleton<SolutionNamingConvention, SolutionNamingConventionOverride>();
+            services.AddSingleton<ArtifactNamingConvention, ArtifactNamingConventionOverride>();
 
             services.AddSingleton<IProjectContentGenerator, ComplexProjectContentGenerator>();
 

--- a/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator.Cli/Reqnroll.TestProjectGenerator.Cli.csproj
+++ b/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator.Cli/Reqnroll.TestProjectGenerator.Cli.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>reqnroll-tpg</ToolCommandName>

--- a/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator.Tests/Reqnroll.TestProjectGenerator.Tests.csproj
+++ b/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator.Tests/Reqnroll.TestProjectGenerator.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net60;net48</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator/CompileResult.cs
+++ b/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator/CompileResult.cs
@@ -1,16 +1,20 @@
-namespace Reqnroll.TestProjectGenerator
-{
-    public class CompileResult
-    {
-        public CompileResult(int exitCode, string output)
-        {
-            ExitCode = exitCode;
-            IsSuccessful = exitCode == 0;
-            Output = output;
-        }
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
 
-        public int ExitCode { get; }
-        public bool IsSuccessful { get; }
-        public string Output { get; }
-    }
+namespace Reqnroll.TestProjectGenerator;
+
+public class CompileResult(int exitCode, string output)
+{
+    public int ExitCode { get; } = exitCode;
+
+    public bool IsSuccessful { get; } = exitCode == 0;
+
+    public string Output { get; } = output;
+
+    public string ErrorLines =>
+        string.Join(
+            Environment.NewLine,
+            Regex.Split(Output, @"\r?\n").Where(l => l.Contains("error")));
 }

--- a/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator/Compiler.cs
+++ b/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator/Compiler.cs
@@ -65,7 +65,7 @@ namespace Reqnroll.TestProjectGenerator
 
             var processHelper = new ProcessHelper();
 
-            string argumentsFormat = $"build {GetWarningAsErrorParameter(treatWarningsAsErrors)} --no-cache -binaryLogger:;ProjectImports=None -nodeReuse:false -nologo -v:m \"{_testProjectFolders.PathToSolutionFile}\"";
+            string argumentsFormat = $"build {GetWarningAsErrorParameter(treatWarningsAsErrors)} -nologo -v:m \"{_testProjectFolders.PathToSolutionFile}\"";
             var dotnetBuildProcessResult = processHelper.RunProcess(_outputWriter, _testProjectFolders.PathToSolutionDirectory, "dotnet", argumentsFormat);
 
             return new CompileResult(dotnetBuildProcessResult.ExitCode, dotnetBuildProcessResult.CombinedOutput);

--- a/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator/Conventions/ArtifactNamingConvention.cs
+++ b/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator/Conventions/ArtifactNamingConvention.cs
@@ -2,8 +2,10 @@ using System;
 
 namespace Reqnroll.TestProjectGenerator.Conventions
 {
-    public class SolutionNamingConvention
+    public class ArtifactNamingConvention
     {
         public virtual string GetSolutionName(Guid guid) => $"S{guid.ToString("N").Substring(24)}";
+
+        public string GetRunName(Guid guid) => $"R{guid.ToString("N").Substring(24)}";
     }
 }

--- a/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator/Data/NuGetConfigGenerator.cs
+++ b/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator/Data/NuGetConfigGenerator.cs
@@ -8,9 +8,9 @@ namespace Reqnroll.TestProjectGenerator.Data
 {
     public class NuGetConfigGenerator : XmlFileGeneratorBase
     {
-        private readonly ProjectFileFactory _projectFileFactory = new ProjectFileFactory();
+        private readonly ProjectFileFactory _projectFileFactory = new();
 
-        public ProjectFile Generate(NuGetSource[] nuGetSources = null)
+        public ProjectFile Generate(NuGetSource[] nuGetSources = null, string globalPackagesFolder = null)
         {
             using (var ms = new MemoryStream())
             {
@@ -18,7 +18,7 @@ namespace Reqnroll.TestProjectGenerator.Data
                 {
                     writer.WriteStartElement("configuration");
 
-                    WriteConfig(writer);
+                    WriteConfig(writer, globalPackagesFolder);
 
                     WritePackageSources(nuGetSources, writer);
                     WriteAPIKeys(writer, nuGetSources);
@@ -31,7 +31,7 @@ namespace Reqnroll.TestProjectGenerator.Data
             }
         }
 
-        private void WriteConfig(XmlWriter writer)
+        private void WriteConfig(XmlWriter writer, string globalPackagesFolder)
         {
             writer.WriteStartElement("config");
 
@@ -39,6 +39,14 @@ namespace Reqnroll.TestProjectGenerator.Data
             writer.WriteAttributeString("key", "dependencyversion");
             writer.WriteAttributeString("value", "Highest");
             writer.WriteEndElement();
+
+            if (globalPackagesFolder != null)
+            {
+                writer.WriteStartElement("add");
+                writer.WriteAttributeString("key", "globalPackagesFolder");
+                writer.WriteAttributeString("value", globalPackagesFolder);
+                writer.WriteEndElement();
+            }
 
             writer.WriteEndElement();
         }

--- a/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator/Driver/CompilationDriver.cs
+++ b/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator/Driver/CompilationDriver.cs
@@ -1,3 +1,6 @@
+using System;
+using FluentAssertions;
+
 namespace Reqnroll.TestProjectGenerator.Driver
 {
     public class CompilationDriver
@@ -18,12 +21,12 @@ namespace Reqnroll.TestProjectGenerator.Driver
 
         public bool HasTriedToCompile { get; private set; }
 
-        public void CompileSolution(BuildTool buildTool = DefaultBuildTool, bool? treatWarningsAsErrors = null)
+        public void CompileSolution(BuildTool buildTool = DefaultBuildTool, bool? treatWarningsAsErrors = null, bool failOnError = true)
         {
-            CompileSolutionTimes(1, buildTool, treatWarningsAsErrors);
+            CompileSolutionTimes(1, buildTool, treatWarningsAsErrors, failOnError);
         }
 
-        public void CompileSolutionTimes(uint times, BuildTool buildTool = DefaultBuildTool, bool? treatWarningsAsErrors = null)
+        public void CompileSolutionTimes(uint times, BuildTool buildTool = DefaultBuildTool, bool? treatWarningsAsErrors = null, bool failOnError = true)
         {
             HasTriedToCompile = true;
             _solutionWriteToDiskDriver.WriteSolutionToDisk(treatWarningsAsErrors);
@@ -33,6 +36,8 @@ namespace Reqnroll.TestProjectGenerator.Driver
             for (uint time = 0; time < times; time++)
             {
                 _compilationResultDriver.CompileResult = _compiler.Run(usedBuildTool, treatWarningsAsErrors);
+                if (failOnError)
+                    _compilationResultDriver.CompileResult.IsSuccessful.Should().BeTrue($"Compilation should succeed. Build errors: {Environment.NewLine}{_compilationResultDriver.CompileResult.ErrorLines}");
             }
         }
 

--- a/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator/Driver/ProjectsDriver.cs
+++ b/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator/Driver/ProjectsDriver.cs
@@ -84,6 +84,16 @@ namespace Reqnroll.TestProjectGenerator.Driver
             _solutionDriver.DefaultProject.AddFeatureFile(featureFileContent);
         }
 
+        public void AddScenario(string scenarioContent)
+        {
+            AddFeatureFile(
+                $$"""
+                  Feature: Sample Feature
+                  
+                  {{scenarioContent}}
+                  """);
+        }
+
         public void AddStepBinding(string attributeName, string regex, string csharpcode, string vbnetcode)
         {
             _solutionDriver.DefaultProject.AddStepBinding(attributeName, regex, csharpcode, vbnetcode);
@@ -150,6 +160,11 @@ namespace Reqnroll.TestProjectGenerator.Driver
         public void AddFailingStepBinding(string scenarioBlock, string stepRegex)
         {
             AddStepBinding(scenarioBlock, stepRegex, @"throw new System.Exception(""simulated failure"");", @"Throw New System.Exception(""simulated failure"")");
+        }
+
+        public void AddPassingStepBinding(string scenarioBlock = "StepDefinition", string stepRegex = ".*")
+        {
+            AddStepBinding(scenarioBlock, stepRegex, "//pass", "'pass");
         }
     }
 }

--- a/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator/Driver/SolutionDriver.cs
+++ b/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator/Driver/SolutionDriver.cs
@@ -16,7 +16,7 @@ namespace Reqnroll.TestProjectGenerator.Driver
         private readonly TestRunConfiguration _testRunConfiguration;
         private readonly ProjectBuilderFactory _projectBuilderFactory;
         private readonly Folders _folders;
-        private readonly SolutionNamingConvention _solutionNamingConvention;
+        private readonly ArtifactNamingConvention _artifactNamingConvention;
         private readonly Solution _solution;
         private readonly Dictionary<string, ProjectBuilder> _projects = new Dictionary<string, ProjectBuilder>();
         private ProjectBuilder _defaultProject;
@@ -27,13 +27,13 @@ namespace Reqnroll.TestProjectGenerator.Driver
             ProjectBuilderFactory projectBuilderFactory,
             Folders folders,
             TestProjectFolders testProjectFolders,
-            SolutionNamingConvention solutionNamingConvention)
+            ArtifactNamingConvention artifactNamingConvention)
         {
             _nuGetConfigGenerator = nuGetConfigGenerator;
             _testRunConfiguration = testRunConfiguration;
             _projectBuilderFactory = projectBuilderFactory;
             _folders = folders;
-            _solutionNamingConvention = solutionNamingConvention;
+            _artifactNamingConvention = artifactNamingConvention;
             NuGetSources = new List<NuGetSource>
             {
                 new NuGetSource("LocalReqnrollDevPackages", _folders.NuGetFolder),
@@ -53,14 +53,14 @@ namespace Reqnroll.TestProjectGenerator.Driver
             }
 
             _solution = new Solution(SolutionName);
-            testProjectFolders.PathToSolutionFile = Path.Combine(_folders.FolderToSaveGeneratedSolutions, SolutionName, $"{SolutionName}.sln");
+            testProjectFolders.PathToSolutionFile = Path.Combine(_folders.RunUniqueFolderToSaveGeneratedSolutions, SolutionName, $"{SolutionName}.sln");
         }
 
         public Guid SolutionGuid { get; } = Guid.NewGuid();
 
         public IList<NuGetSource> NuGetSources { get; }
 
-        public string SolutionName => _solutionNamingConvention.GetSolutionName(SolutionGuid);
+        public string SolutionName => _artifactNamingConvention.GetSolutionName(SolutionGuid);
 
         public IReadOnlyDictionary<string, ProjectBuilder> Projects => _projects;
 
@@ -86,7 +86,7 @@ namespace Reqnroll.TestProjectGenerator.Driver
                 _solution.AddProject(project);
             }
 
-            _solution.NugetConfig = _nuGetConfigGenerator?.Generate(NuGetSources.ToArray());
+            _solution.NugetConfig = _nuGetConfigGenerator?.Generate(NuGetSources.ToArray(), _folders.RunUniqueGlobalPackages);
             return _solution;
         }
 

--- a/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator/Factories/BindingsGenerator/CSharp10BindingsGenerator.cs
+++ b/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator/Factories/BindingsGenerator/CSharp10BindingsGenerator.cs
@@ -6,54 +6,55 @@ public class CSharp10BindingsGenerator : CSharpBindingsGenerator
 {
     public override ProjectFile GenerateLoggerClass(string pathToLogFile)
     {
-        string fileContent = $@"
-using System;
-using System.IO;
-using System.Runtime.CompilerServices;
-using System.Threading;
+        string fileContent = $$"""
+                               using System;
+                               using System.IO;
+                               using System.Runtime.CompilerServices;
+                               using System.Threading;
 
-internal static class Log
-{{
-    private const string LogFileLocation = @""{pathToLogFile}"";
-
-    private static void Retry(int number, Action action)
-    {{
-        try
-        {{
-            action();
-        }}
-        catch (Exception)
-        {{
-            var i = number - 1;
-
-            if (i == 0)
-                throw;
-
-            Thread.Sleep(500);
-            Retry(i, action);
-        }}
-    }}
-
-    internal static void LogStep([CallerMemberName] string stepName = null!)
-    {{
-        Retry(5, () => WriteToFile($@""-> step: {{stepName}}{{Environment.NewLine}}""));
-    }}
-
-    internal static void LogHook([CallerMemberName] string stepName = null!)
-    {{
-        Retry(5, () => WriteToFile($@""-> hook: {{stepName}}{{Environment.NewLine}}""));
-    }}
-
-    static void WriteToFile(string line)
-    {{
-        using (FileStream fs = File.Open(LogFileLocation, FileMode.Append, FileAccess.Write, FileShare.None))
-        {{
-            byte[] bytes = System.Text.Encoding.UTF8.GetBytes(line);
-            fs.Write(bytes, 0, bytes.Length);
-            fs.Close();
-        }}
-    }}
-}}";
+                               internal static class Log
+                               {
+                                   private const string LogFileLocation = @"{{pathToLogFile}}";
+                               
+                                   private static void Retry(int number, Action action)
+                                   {
+                                       try
+                                       {
+                                           action();
+                                       }
+                                       catch (Exception)
+                                       {
+                                           var i = number - 1;
+                               
+                                           if (i == 0)
+                                               throw;
+                               
+                                           Thread.Sleep(500);
+                                           Retry(i, action);
+                                       }
+                                   }
+                               
+                                   internal static void LogStep([CallerMemberName] string stepName = null!)
+                                   {
+                                       Retry(5, () => WriteToFile($@"-> step: {stepName}{Environment.NewLine}"));
+                                   }
+                               
+                                   internal static void LogHook([CallerMemberName] string stepName = null!)
+                                   {
+                                       Retry(5, () => WriteToFile($@"-> hook: {stepName}{Environment.NewLine}"));
+                                   }
+                               
+                                   static void WriteToFile(string line)
+                                   {
+                                       using (FileStream fs = File.Open(LogFileLocation, FileMode.Append, FileAccess.Write, FileShare.None))
+                                       {
+                                           byte[] bytes = System.Text.Encoding.UTF8.GetBytes(line);
+                                           fs.Write(bytes, 0, bytes.Length);
+                                           fs.Close();
+                                       }
+                                   }
+                               }
+                               """;
         return new ProjectFile("Log.cs", "Compile", fileContent);
     }
 

--- a/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator/Factories/BindingsGenerator/CSharpBindingsGenerator.cs
+++ b/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator/Factories/BindingsGenerator/CSharpBindingsGenerator.cs
@@ -63,86 +63,88 @@ public class {0}
 
         public override ProjectFile GenerateLoggerClass(string pathToLogFile)
         {
-            string fileContent = $@"
-using System;
-using System.IO;
-using System.Runtime.CompilerServices;
-using System.Threading;
-using System.Threading.Tasks;
+            string fileContent = $$"""
+                                   #nullable disable
+                                   using System;
+                                   using System.IO;
+                                   using System.Runtime.CompilerServices;
+                                   using System.Threading;
+                                   using System.Threading.Tasks;
 
-internal static class Log
-{{
-    private const string LogFileLocation = @""{pathToLogFile}"";
-
-    private static void Retry(int number, Action action)
-    {{
-        try
-        {{
-            action();
-        }}
-        catch (Exception)
-        {{
-            var i = number - 1;
-
-            if (i == 0)
-                throw;
-
-            Thread.Sleep(500);
-            Retry(i, action);
-        }}
-    }}
-
-    internal static void LogStep([CallerMemberName] string stepName = null)
-    {{
-        Retry(5, () => WriteToFile($@""-> step: {{stepName}}{{Environment.NewLine}}""));
-    }}
-
-    internal static void LogHook([CallerMemberName] string stepName = null)
-    {{
-        Retry(5, () => WriteToFile($@""-> hook: {{stepName}}{{Environment.NewLine}}""));
-    }}
-
-    internal static async Task LogHookIncludingLockingAsync([CallerMemberName] string stepName = null)
-    {{
-        WriteToFile($@""-> waiting for hook lock: {{stepName}}{{Environment.NewLine}}"");
-        await WaitForLockAsync();
-        WriteToFile($@""-> hook: {{stepName}}{{Environment.NewLine}}"");
-    }}
-
-    static void WriteToFile(string line)
-    {{
-        using (FileStream fs = File.Open(LogFileLocation, FileMode.Append, FileAccess.Write, FileShare.None))
-        {{
-            byte[] bytes = System.Text.Encoding.UTF8.GetBytes(line);
-            fs.Write(bytes, 0, bytes.Length);
-            fs.Close();
-        }}
-    }}
-
-    static async Task WaitForLockAsync()
-    {{
-        var lockFile = LogFileLocation + "".lock"";
-
-        while (true)
-        {{
-            try
-            {{
-                using (File.Open(lockFile, FileMode.CreateNew))
-                {{
-                }}
-
-                break;
-            }}
-            catch (IOException)
-            {{
-                //wait and retry
-                await Task.Delay(1000);
-            }}
-        }}
-
-        File.Delete(lockFile);
-    }}
-}}";
+                                   internal static class Log
+                                   {
+                                       private const string LogFileLocation = @"{{pathToLogFile}}";
+                                   
+                                       private static void Retry(int number, Action action)
+                                       {
+                                           try
+                                           {
+                                               action();
+                                           }
+                                           catch (Exception)
+                                           {
+                                               var i = number - 1;
+                                   
+                                               if (i == 0)
+                                                   throw;
+                                   
+                                               Thread.Sleep(500);
+                                               Retry(i, action);
+                                           }
+                                       }
+                                   
+                                       internal static void LogStep([CallerMemberName] string stepName = null)
+                                       {
+                                           Retry(5, () => WriteToFile($@"-> step: {stepName}{Environment.NewLine}"));
+                                       }
+                                   
+                                       internal static void LogHook([CallerMemberName] string stepName = null)
+                                       {
+                                           Retry(5, () => WriteToFile($@"-> hook: {stepName}{Environment.NewLine}"));
+                                       }
+                                   
+                                       internal static async Task LogHookIncludingLockingAsync([CallerMemberName] string stepName = null)
+                                       {
+                                           WriteToFile($@"-> waiting for hook lock: {stepName}{Environment.NewLine}");
+                                           await WaitForLockAsync();
+                                           WriteToFile($@"-> hook: {stepName}{Environment.NewLine}");
+                                       }
+                                   
+                                       static void WriteToFile(string line)
+                                       {
+                                           using (FileStream fs = File.Open(LogFileLocation, FileMode.Append, FileAccess.Write, FileShare.None))
+                                           {
+                                               byte[] bytes = System.Text.Encoding.UTF8.GetBytes(line);
+                                               fs.Write(bytes, 0, bytes.Length);
+                                               fs.Close();
+                                           }
+                                       }
+                                   
+                                       static async Task WaitForLockAsync()
+                                       {
+                                           var lockFile = LogFileLocation + ".lock";
+                                   
+                                           while (true)
+                                           {
+                                               try
+                                               {
+                                                   using (File.Open(lockFile, FileMode.CreateNew))
+                                                   {
+                                                   }
+                                   
+                                                   break;
+                                               }
+                                               catch (IOException)
+                                               {
+                                                   //wait and retry
+                                                   await Task.Delay(1000);
+                                               }
+                                           }
+                                   
+                                           File.Delete(lockFile);
+                                       }
+                                   }
+                                   """;
             return new ProjectFile("Log.cs", "Compile", fileContent);
         }
 

--- a/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator/Folders.cs
+++ b/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator/Folders.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Reflection;
+using Reqnroll.TestProjectGenerator.Conventions;
 using Reqnroll.TestProjectGenerator.Helpers;
 
 namespace Reqnroll.TestProjectGenerator
@@ -8,6 +9,8 @@ namespace Reqnroll.TestProjectGenerator
     public class Folders
     {
         private readonly AppConfigDriver _appConfigDriver;
+        private readonly ArtifactNamingConvention _artifactNamingConvention;
+        private static readonly Guid UniqueRunId = Guid.NewGuid();
         protected string _nugetFolder;
         protected string _packageFolder;
         protected string _sourceRoot;
@@ -19,9 +22,10 @@ namespace Reqnroll.TestProjectGenerator
 
         public string TestFolder => Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().Location).LocalPath);
 
-        public Folders(AppConfigDriver appConfigDriver)
+        public Folders(AppConfigDriver appConfigDriver, ArtifactNamingConvention artifactNamingConvention)
         {
             _appConfigDriver = appConfigDriver;
+            _artifactNamingConvention = artifactNamingConvention;
         }
 
         public virtual string SourceRoot
@@ -32,10 +36,7 @@ namespace Reqnroll.TestProjectGenerator
 
         public string VSAdapterFolder
         {
-            get
-            {
-                return !string.IsNullOrWhiteSpace(_vsAdapterFolder) ? _vsAdapterFolder : VsAdapterFolderProjectBinaries;
-            }
+            get => !string.IsNullOrWhiteSpace(_vsAdapterFolder) ? _vsAdapterFolder : VsAdapterFolderProjectBinaries;
             set
             {
                 _vsAdapterFolder = value;
@@ -60,7 +61,7 @@ namespace Reqnroll.TestProjectGenerator
         }
 
         public virtual string ExternalNuGetFolder
-            => _externalNuGetFolder = _externalNuGetFolder ?? Path.GetFullPath(Path.Combine(SourceRoot, "NuGet", "feed"));
+            => _externalNuGetFolder ??= Path.GetFullPath(Path.Combine(SourceRoot, "NuGet", "feed"));
 
         public string PackageFolder
         {
@@ -77,5 +78,8 @@ namespace Reqnroll.TestProjectGenerator
         }
 
         public virtual string FolderToSaveGeneratedSolutions => Path.Combine(Path.GetTempPath(), _appConfigDriver.TestProjectFolderName);
+
+        public virtual string RunUniqueFolderToSaveGeneratedSolutions => Path.Combine(FolderToSaveGeneratedSolutions, _artifactNamingConvention.GetRunName(UniqueRunId));
+        public virtual string RunUniqueGlobalPackages => Path.Combine(RunUniqueFolderToSaveGeneratedSolutions, ".nuget");
     }
 }

--- a/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator/Helpers/FolderCleaner.cs
+++ b/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator/Helpers/FolderCleaner.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.IO;
+using System.Threading;
+
+namespace Reqnroll.TestProjectGenerator.Helpers;
+public class FolderCleaner
+{
+    private const int MaxTestRunAgeMinutes = 60;
+    private const int MaxTestRunsToKeep = 4;
+
+    private static int _oldFoldersCleaned = 0;
+    private readonly Folders _folders;
+    private readonly TestProjectFolders _testProjectFolders;
+    private readonly IOutputWriter _outputWriter;
+
+    public FolderCleaner(Folders folders, TestProjectFolders testProjectFolders, IOutputWriter outputWriter)
+    {
+        _folders = folders;
+        _testProjectFolders = testProjectFolders;
+        _outputWriter = outputWriter;
+    }
+
+    public void EnsureOldRunFoldersCleaned()
+    {
+        if (Interlocked.CompareExchange(ref _oldFoldersCleaned, 1, 0) != 0 ||
+            !Directory.Exists(_folders.FolderToSaveGeneratedSolutions))
+            return;
+
+        CleanOldRunFolders();
+    }
+
+    private void CleanOldRunFolders()
+    {
+        int counter = 0;
+        var deleteBefore = DateTime.UtcNow.Subtract(TimeSpan.FromMinutes(MaxTestRunAgeMinutes));
+        var deletedCount = FileSystemHelper.DeleteFolderContent(
+            _folders.FolderToSaveGeneratedSolutions, 
+            f => f.LastWriteTimeUtc < deleteBefore || (++counter > MaxTestRunsToKeep),
+            ignoreErrors: true);
+        if (deletedCount > 0)
+            _outputWriter.WriteLine($"{deletedCount} old run folder cleaned up");
+    }
+
+    public void CleanSolutionFolder()
+    {
+        FileSystemHelper.DeleteFolder(_testProjectFolders.PathToSolutionDirectory);
+    }
+}

--- a/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator/ProcessHelper.cs
+++ b/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator/ProcessHelper.cs
@@ -74,11 +74,7 @@ namespace Reqnroll.TestProjectGenerator
 
             if (!processResult)
             {
-#if NETCOREAPP3_1_OR_GREATER
-                process.Kill(true);
-#else
                 process.Kill();
-#endif
             }
 
             var waitForOutputs = Timeout-sw.Elapsed;
@@ -121,11 +117,7 @@ namespace Reqnroll.TestProjectGenerator
 
             cancellationTokenSource.Token.Register(() =>
             {
-#if NETCOREAPP3_1_OR_GREATER
-                process.Kill(true);
-#else
                 process.Kill();
-#endif
                 var waitForOutputs = Timeout - sw.Elapsed;
                 if (waitForOutputs <= TimeSpan.Zero || waitForOutputs > TimeSpan.FromMinutes(1)) waitForOutputs = TimeSpan.FromMinutes(1);
                 outputWaiter.Wait(waitForOutputs);

--- a/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator/ProjectBuilder.cs
+++ b/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator/ProjectBuilder.cs
@@ -214,7 +214,11 @@ namespace Reqnroll.TestProjectGenerator
 
             _project = new Project(ProjectName, ProjectGuid, Language, TargetFramework, Format, ProjectType);
 
-            _testProjectFolders.PathToNuGetPackages = _project.ProjectFormat == ProjectFormat.Old ? Path.Combine(_testProjectFolders.PathToSolutionDirectory, "packages") : _folders.GlobalPackages;
+            _testProjectFolders.PathToNuGetPackages = _project.ProjectFormat == ProjectFormat.Old ? Path.Combine(_testProjectFolders.PathToSolutionDirectory, "packages") : _folders.RunUniqueGlobalPackages;
+            if (!Directory.Exists(_testProjectFolders.PathToNuGetPackages))
+            {
+                Directory.CreateDirectory(_testProjectFolders.PathToNuGetPackages);
+            }
 
             if (ProjectType == ProjectType.Library)
             {

--- a/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator.csproj
+++ b/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net60;net471</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
 

--- a/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator/VSTestExecutionDriver.cs
+++ b/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator/VSTestExecutionDriver.cs
@@ -204,7 +204,7 @@ namespace Reqnroll.TestProjectGenerator
             {
                 if (_testRunConfiguration.ProjectFormat == ProjectFormat.Old)
                 {
-                    return $" -a \"{_testProjectFolders.PathToNuGetPackages}\"";
+                    return $" --test-adapter-path \"{_testProjectFolders.PathToNuGetPackages}\"";
                 }
             }
 

--- a/Tests/Reqnroll.Specs/StepDefinitions/ExecutionResultSteps.cs
+++ b/Tests/Reqnroll.Specs/StepDefinitions/ExecutionResultSteps.cs
@@ -40,6 +40,14 @@ namespace Reqnroll.Specs.StepDefinitions
         {
             _vsTestExecutionDriver.LastTestExecutionResult.Should().NotBeNull();
             expectedTestExecutionResult.CompareToInstance(_vsTestExecutionDriver.LastTestExecutionResult);
+
+            // if we only assert for total number of tests, we will make an additional assertion for the 
+            // successful tests with the same count, to highlight hidden runtime errors
+            if (expectedTestExecutionResult.Header.Count == 1 && expectedTestExecutionResult.ContainsColumn("Total"))
+            {
+                expectedTestExecutionResult.RenameColumn("Total", "Succeeded");
+                expectedTestExecutionResult.CompareToInstance(_vsTestExecutionDriver.LastTestExecutionResult);
+            }
         }
 
         [Then(@"the binding method '(.*)' is executed")]

--- a/Tests/Reqnroll.Specs/StepDefinitions/ProjectSteps.cs
+++ b/Tests/Reqnroll.Specs/StepDefinitions/ProjectSteps.cs
@@ -44,7 +44,7 @@ namespace Reqnroll.Specs.StepDefinitions
         [When(@"I compile the solution")]
         public void WhenTheProjectIsCompiled()
         {
-            _compilationDriver.CompileSolution();
+            _compilationDriver.CompileSolution(failOnError: false);
         }
 
         [Then(@"no compilation errors are reported")]

--- a/Tests/Reqnroll.Specs/Support/Hooks.cs
+++ b/Tests/Reqnroll.Specs/Support/Hooks.cs
@@ -1,95 +1,44 @@
 using System;
-using System.IO;
-using Reqnroll.Specs.Drivers;
 using Reqnroll.TestProjectGenerator;
 using Reqnroll.TestProjectGenerator.Helpers;
-using Reqnroll.UnitTestProvider;
 
-namespace Reqnroll.Specs.Support
+namespace Reqnroll.Specs.Support;
+
+[Binding]
+public class Hooks
 {
-    [Binding]
-    public class Hooks
+    private readonly ScenarioContext _scenarioContext;
+    private readonly CurrentVersionDriver _currentVersionDriver;
+    private readonly TestProjectFolders _testProjectFolders;
+    private FolderCleaner _folderCleaner;
+
+    public Hooks(ScenarioContext scenarioContext, CurrentVersionDriver currentVersionDriver, TestProjectFolders testProjectFolders)
     {
-        private readonly ScenarioContext _scenarioContext;
-        private readonly CurrentVersionDriver _currentVersionDriver;
-        private readonly RuntimeInformationProvider _runtimeInformationProvider;
-        private readonly IUnitTestRuntimeProvider _unitTestRuntimeProvider;
-        private readonly TestProjectFolders _testProjectFolders;
+        _scenarioContext = scenarioContext;
+        _currentVersionDriver = currentVersionDriver;
+        _testProjectFolders = testProjectFolders;
+    }
 
-        public Hooks(ScenarioContext scenarioContext, CurrentVersionDriver currentVersionDriver, RuntimeInformationProvider runtimeInformationProvider, IUnitTestRuntimeProvider unitTestRuntimeProvider, TestProjectFolders testProjectFolders)
+    [BeforeScenario]
+    public void BeforeScenario()
+    {
+        _currentVersionDriver.NuGetVersion = NuGetPackageVersion.Version;
+        _currentVersionDriver.ReqnrollNuGetVersion = NuGetPackageVersion.Version;
+        _scenarioContext.ScenarioContainer.RegisterTypeAs<OutputConnector, IOutputWriter>();
+
+        _folderCleaner = _scenarioContext.ScenarioContainer.Resolve<FolderCleaner>();
+
+        // deleting old project folders (the actual deletion runs only once per test run)
+        _folderCleaner.EnsureOldRunFoldersCleaned();
+    }
+
+    [AfterScenario]
+    public void AfterScenario()
+    {
+        if (_scenarioContext.TestError == null && _testProjectFolders.IsPathToSolutionFileSet)
         {
-            _scenarioContext = scenarioContext;
-            _currentVersionDriver = currentVersionDriver;
-            _runtimeInformationProvider = runtimeInformationProvider;
-            _unitTestRuntimeProvider = unitTestRuntimeProvider;
-            _testProjectFolders = testProjectFolders;
-        }
-
-        [BeforeScenario]
-        public void BeforeScenario()
-        {
-            _currentVersionDriver.NuGetVersion = NuGetPackageVersion.Version;
-            _currentVersionDriver.ReqnrollNuGetVersion = NuGetPackageVersion.Version;
-            _scenarioContext.ScenarioContainer.RegisterTypeAs<OutputConnector, IOutputWriter>();
-        }
-
-        [AfterScenario]
-        public void AfterScenario()
-        {
-            if (_scenarioContext.TestError == null && _testProjectFolders.IsPathToSolutionFileSet)
-            {
-                try
-                {
-                    FileSystemHelper.DeleteFolder(_testProjectFolders.PathToSolutionDirectory);
-                }
-                catch (Exception)
-                {
-                    // ignored
-                }
-            }
-        }
-
-        [BeforeTestRun]
-        public static void BeforeTestRun()
-        {
-            var appConfigDriver = new AppConfigDriver();
-            var folders = new Folders(appConfigDriver);
-
-            DeletePackageVersionFolders();
-            DeleteOldTestRunData(folders);
-        }
-
-        private static void DeleteOldTestRunData(Folders folders)
-        {
-            try
-            {
-                FileSystemHelper.DeleteFolderContent(folders.FolderToSaveGeneratedSolutions);
-            }
-            catch (Exception)
-            {
-                // ignored
-            }
-        }
-
-        private static void DeletePackageVersionFolders()
-        {
-            if (!HaveRightsToDeletePackages()) return;
-
-            var currentVersionDriver = new CurrentVersionDriver {NuGetVersion = NuGetPackageVersion.Version };
-
-            string[] packageNames = { "Reqnroll", "Reqnroll.CustomPlugin", "Reqnroll.MsTest", "Reqnroll.NUnit", "Reqnroll.NUnit.Runners", "Reqnroll.Tools.MsBuild.Generation", "Reqnroll.xUnit" };
-            
-            foreach (var name in packageNames)
-            {
-                string hooksPath = Path.Combine(Environment.ExpandEnvironmentVariables("%USERPROFILE%"), ".nuget", "packages", name, currentVersionDriver.NuGetVersion);
-                FileSystemHelper.DeleteFolder(hooksPath);
-            }
-        }
-
-        private static bool HaveRightsToDeletePackages()
-        {
-            var azureAgentOs = Environment.GetEnvironmentVariable("AGENT_OS");
-            return azureAgentOs != "Windows_NT";
+            // making sure that the temporary files are deleted if the scenario succeeded anyway
+            _folderCleaner.CleanSolutionFolder();
         }
     }
 }


### PR DESCRIPTION
This PR contains a couple of changes to improve the E2E test stability and robustness. The "specs" tests run the E2E tests currently, but later they will be also used for "system tests" (see #62).

There are a couple of improvements included in this PR, but the most important is that it provides a solution for using cached packages. This issue we have discovered with @livioc on #54: If you modify the generation part (e.g. `MsTestV2GeneratorProvider`) and rerun the related "specs" test, the test will pick up the previously generated nuget package from the package cache and therefore the test will not reflect your changes (you still see the old behavior). 

The reason for this is that these E2E test use the generated NuGet packages for generating the sample projects. Between two compilations these packages have the same version number, therefore if a version has been used, nuget automatically caches that in the local nuget cache (`C:\Users\<your-user>\.nuget\packages`), so the subsequent execution will re-use the cached version. The solution was to manually clean the Reqnroll related packages from the local nuget cache.

There has been tries to avoid this problem: in SpecFlow we tried to generate commit specific nuget versions (this caused other problems and did not solve the changes within commits) and also there was a code that tried to delete the packages from the local nuget cache (most of the cases did not work because of file locking issues).

This PR uses a different approach: it reconfigures nuget for the test projects to use an alternative local nuget cache folder somewhere in $TEMP, so that the execution always starts with an empty nuget cache. (There is a [related issue](https://github.com/NuGet/Home/issues/5619) in nuget where this idea was mentioned.) The nuget cache has several megabytes, so instead of making a local nuget cache for every sample project, we introduce a "Test Run" folder, that contains all sample project folders and the local nuget cache. Each time a new test run folder is created in $TEMP, but we have a cleanup mechanism that removes old test run folders. 

I have tested that by replaying the changes of #54 and it works fine, all changes of the code are immediately reflected in tests.

Other improvements in this PR:

- For those tests that only assert for the total number of tests we also verify that those were passing (in #54 many problems were hidden because of that).
- The TestProjectGenerator related projects are now target netstandard2.0 and net6.0 only.
- The obsolete `-a` argument of nuget has been replaced
- Improve "specs" to assert for a successful compilation except otherwise stated (in #54 we also had this) and provide better error message
- Added some additional helper methods to TestProjectGenerator that will be needed for "system tests"
- Get rid of the warnings in the generated Log.cs files 


## Types of changes

- [x] Refactoring (so no functional change)
