### PR TITLE
Fix for 81 - Cucumber Expression using Enums errors when two enums exist with the same short name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   test run (global) context instead of the test thread context.
 * Support for PriorityAttribute in MsTest adapter
 * Support for Scenario Outline / DataRowAttribute in MsTest adapter
+* Fix for #81 in which Cucumber Expressions fail when two enums with the same short name (differing namespaces) are used as parameters
 
 # v1.0.1 - 2024-02-16
 

--- a/Reqnroll/Bindings/CucumberExpressions/CucumberExpressionParameterTypeRegistry.cs
+++ b/Reqnroll/Bindings/CucumberExpressions/CucumberExpressionParameterTypeRegistry.cs
@@ -130,12 +130,12 @@ public class CucumberExpressionParameterTypeRegistry : IParameterTypeRegistry
         if (_parameterTypesByName.Value.TryGetValue(name, out var parameterType))
             return parameterType;
         //enum keys contain the Fullname of the type, try matching on the short name:
-        var matchingEnums = _parameterTypesByName.Value.Where(kvp => kvp.Key.EndsWith("." + name) && kvp.Value.ParameterType.IsEnum).ToArray();
+        var matchingEnums = _parameterTypesByName.Value.Where(kvp => kvp.Value.ParameterType.IsEnum && (kvp.Key.EndsWith("." + name) || kvp.Key.EndsWith("+" + name))).ToArray();
         if (matchingEnums.Length == 0) { return null; }
         if (matchingEnums.Length == 1) { return matchingEnums[0].Value; }
         if (matchingEnums.Length > 1)
         {
-            throw new ReqnrollException($"Ambiguous Enum Parameters share the same short name '{name}'. Use the Enum's FullName in the Cucumber Expression or define a [StepArgumentTransformation] with the chosen type and the short name.");
+            throw new ReqnrollException($"Ambiguous enum in cucumber expression. Multiple enums share the same short name '{name}'. Use the enum's full name in the cucumber expression or define a [StepArgumentTransformation] with the chosen type and the short name.");
         }
         return null;
     }

--- a/Reqnroll/Bindings/CucumberExpressions/CucumberExpressionParameterTypeRegistry.cs
+++ b/Reqnroll/Bindings/CucumberExpressions/CucumberExpressionParameterTypeRegistry.cs
@@ -129,6 +129,14 @@ public class CucumberExpressionParameterTypeRegistry : IParameterTypeRegistry
     {
         if (_parameterTypesByName.Value.TryGetValue(name, out var parameterType))
             return parameterType;
+        //enum keys contain the Fullname of the type, try matching on the short name:
+        var matchingEnums = _parameterTypesByName.Value.Where(kvp => kvp.Key.EndsWith(name) && kvp.Value.ParameterType.IsEnum).ToArray();
+        if (matchingEnums.Length == 0) { return null; }
+        if (matchingEnums.Length == 1) { return matchingEnums[0].Value; }
+        if (matchingEnums.Length > 1)
+        {
+            throw new ApplicationException($"Ambigous Enum Parameters share the same short name '{name}'. Use the Enum's FullName in the Cucumber Expression.");
+        }
         return null;
     }
 

--- a/Reqnroll/Bindings/CucumberExpressions/CucumberExpressionParameterTypeRegistry.cs
+++ b/Reqnroll/Bindings/CucumberExpressions/CucumberExpressionParameterTypeRegistry.cs
@@ -130,12 +130,12 @@ public class CucumberExpressionParameterTypeRegistry : IParameterTypeRegistry
         if (_parameterTypesByName.Value.TryGetValue(name, out var parameterType))
             return parameterType;
         //enum keys contain the Fullname of the type, try matching on the short name:
-        var matchingEnums = _parameterTypesByName.Value.Where(kvp => kvp.Key.EndsWith(name) && kvp.Value.ParameterType.IsEnum).ToArray();
+        var matchingEnums = _parameterTypesByName.Value.Where(kvp => kvp.Key.EndsWith("." + name) && kvp.Value.ParameterType.IsEnum).ToArray();
         if (matchingEnums.Length == 0) { return null; }
         if (matchingEnums.Length == 1) { return matchingEnums[0].Value; }
         if (matchingEnums.Length > 1)
         {
-            throw new ApplicationException($"Ambigous Enum Parameters share the same short name '{name}'. Use the Enum's FullName in the Cucumber Expression.");
+            throw new ReqnrollException($"Ambiguous Enum Parameters share the same short name '{name}'. Use the Enum's FullName in the Cucumber Expression or define a [StepArgumentTransformation] with the chosen type and the short name.");
         }
         return null;
     }

--- a/Reqnroll/Bindings/CucumberExpressions/CucumberExpressionParameterTypeRegistry.cs
+++ b/Reqnroll/Bindings/CucumberExpressions/CucumberExpressionParameterTypeRegistry.cs
@@ -120,7 +120,8 @@ public class CucumberExpressionParameterTypeRegistry : IParameterTypeRegistry
         {
             yield return new BuiltInCucumberExpressionParameterTypeTransformation(
                 CucumberExpressionParameterType.MatchAllRegex,
-                enumParameterType);
+                enumParameterType,
+                enumParameterType.Type.FullName);
         }
     }
 

--- a/Tests/Reqnroll.RuntimeTests/Bindings/CucumberExpressions/CucumberExpressionParameterTypeRegistryTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/Bindings/CucumberExpressions/CucumberExpressionParameterTypeRegistryTests.cs
@@ -1,34 +1,64 @@
 using System;
+using System.Linq;
 using FluentAssertions;
 using Reqnroll.Bindings;
 using Reqnroll.Bindings.CucumberExpressions;
+using Reqnroll.Bindings.Reflection;
 using Xunit;
 
-namespace Reqnroll.RuntimeTests.Bindings.CucumberExpressions;
+namespace Reqnroll.RuntimeTests.Bindings.CucumberExpressions {
 
-public class CucumberExpressionParameterTypeRegistryTests
-{
-    // Most of the logic in CucumberExpressionParameterTypeRegistry can only be tested in integration of a cucumber expression match,
-    // so those are tested in the CucumberExpressionIntegrationTests class.
-
-    private BindingRegistry _bindingRegistry;
-    private CucumberExpressionParameterTypeRegistry CreateSut()
+    public class CucumberExpressionParameterTypeRegistryTests
     {
-        _bindingRegistry = new BindingRegistry();
-        return new CucumberExpressionParameterTypeRegistry(_bindingRegistry);
+        // Most of the logic in CucumberExpressionParameterTypeRegistry can only be tested in integration of a cucumber expression match,
+        // so those are tested in the CucumberExpressionIntegrationTests class.
+
+        private BindingRegistry _bindingRegistry;
+        private CucumberExpressionParameterTypeRegistry CreateSut()
+        {
+            _bindingRegistry = new BindingRegistry();
+            return new CucumberExpressionParameterTypeRegistry(_bindingRegistry);
+        }
+
+        [Fact]
+        public void Should_provide_string_type()
+        {
+            var sut = CreateSut();
+            var paramType = sut.LookupByTypeName("string");
+
+            // The regex '.*' provided by the CucumberExpressionParameterTypeRegistry is fake and
+            // will be ignored because of the special string type handling implemented in ReqnrollCucumberExpression.
+            // See ReqnrollCucumberExpression.HandleStringType for detailed explanation.
+            paramType.Should().NotBeNull();
+            paramType.RegexStrings.Should().HaveCount(1);
+            paramType.RegexStrings[0].Should().Be(".*");
+        }
+
+        public class SampleEnumUsingClass
+        {
+            public void MethodUsingSampleColorEnum1(SampleColorEnum color) { }
+        }
+        [Fact]
+        public void Should_not_error_on_multiple_enums_of_the_same_name()
+        {
+            var sut = CreateSut();
+            Reqnroll.Bindings.Reflection.IBindingMethod enumUsingBindingMethod1 = new RuntimeBindingMethod(typeof(SampleEnumUsingClass).GetMethod("MethodUsingSampleColorEnum1"));
+            sut.OnBindingMethodProcessed(enumUsingBindingMethod1);
+            Reqnroll.Bindings.Reflection.IBindingMethod enumUsingBindingMethod2 = new RuntimeBindingMethod(typeof(CucumberAddtionalExpressions.EnumCucumberExpressions).GetMethod("MethodUsingSampleColorEnum2"));
+            sut.OnBindingMethodProcessed(enumUsingBindingMethod2);
+            var paramTypes = sut.GetParameterTypes().Where(pt => pt.ParameterType.IsEnum).ToList();
+                
+            paramTypes.Should().HaveCount(2);
+        }
+
     }
-
-    [Fact]
-    public void Should_provide_string_type()
+}
+namespace Reqnroll.RuntimeTests.Bindings.CucumberAddtionalExpressions
+{
+    public class EnumCucumberExpressions
     {
-        var sut = CreateSut();
-        var paramType = sut.LookupByTypeName("string");
-
-        // The regex '.*' provided by the CucumberExpressionParameterTypeRegistry is fake and
-        // will be ignored because of the special string type handling implemented in ReqnrollCucumberExpression.
-        // See ReqnrollCucumberExpression.HandleStringType for detailed explanation.
-        paramType.Should().NotBeNull();
-        paramType.RegexStrings.Should().HaveCount(1);
-        paramType.RegexStrings[0].Should().Be(".*");
+        public enum SampleColorEnum { Yellow, Brown };
+ 
+        public void MethodUsingSampleColorEnum2(SampleColorEnum color) { }
     }
 }

--- a/Tests/Reqnroll.RuntimeTests/Bindings/CucumberExpressions/CucumberExpressionParameterTypeRegistryTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/Bindings/CucumberExpressions/CucumberExpressionParameterTypeRegistryTests.cs
@@ -42,9 +42,9 @@ namespace Reqnroll.RuntimeTests.Bindings.CucumberExpressions {
         public void Should_not_error_on_multiple_enums_of_the_same_name()
         {
             var sut = CreateSut();
-            Reqnroll.Bindings.Reflection.IBindingMethod enumUsingBindingMethod1 = new RuntimeBindingMethod(typeof(SampleEnumUsingClass).GetMethod("MethodUsingSampleColorEnum1"));
+            Reqnroll.Bindings.Reflection.IBindingMethod enumUsingBindingMethod1 = new RuntimeBindingMethod(typeof(SampleEnumUsingClass).GetMethod(nameof(SampleEnumUsingClass.MethodUsingSampleColorEnum1)));
             sut.OnBindingMethodProcessed(enumUsingBindingMethod1);
-            Reqnroll.Bindings.Reflection.IBindingMethod enumUsingBindingMethod2 = new RuntimeBindingMethod(typeof(CucumberAddtionalExpressions.EnumCucumberExpressions).GetMethod("MethodUsingSampleColorEnum2"));
+            Reqnroll.Bindings.Reflection.IBindingMethod enumUsingBindingMethod2 = new RuntimeBindingMethod(typeof(CucumberAddtionalExpressions.EnumCucumberExpressions).GetMethod(nameof(CucumberAddtionalExpressions.EnumCucumberExpressions.MethodUsingSampleColorEnum2)));
             sut.OnBindingMethodProcessed(enumUsingBindingMethod2);
             var paramTypes = sut.GetParameterTypes().Where(pt => pt.ParameterType.IsEnum).ToList();
                 

--- a/Tests/Reqnroll.RuntimeTests/Bindings/CucumberExpressions/CucumberExpressionParameterTypeRegistryTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/Bindings/CucumberExpressions/CucumberExpressionParameterTypeRegistryTests.cs
@@ -1,9 +1,12 @@
 using System;
 using System.Linq;
+using System.Xml.Linq;
 using FluentAssertions;
 using Reqnroll.Bindings;
 using Reqnroll.Bindings.CucumberExpressions;
+using Reqnroll.Bindings.Discovery;
 using Reqnroll.Bindings.Reflection;
+using Reqnroll.Infrastructure;
 using Xunit;
 
 namespace Reqnroll.RuntimeTests.Bindings.CucumberExpressions {
@@ -42,15 +45,102 @@ namespace Reqnroll.RuntimeTests.Bindings.CucumberExpressions {
         public void Should_not_error_on_multiple_enums_of_the_same_name()
         {
             var sut = CreateSut();
-            Reqnroll.Bindings.Reflection.IBindingMethod enumUsingBindingMethod1 = new RuntimeBindingMethod(typeof(SampleEnumUsingClass).GetMethod(nameof(SampleEnumUsingClass.MethodUsingSampleColorEnum1)));
+            IBindingMethod enumUsingBindingMethod1 = new RuntimeBindingMethod(typeof(SampleEnumUsingClass).GetMethod(nameof(SampleEnumUsingClass.MethodUsingSampleColorEnum1)));
             sut.OnBindingMethodProcessed(enumUsingBindingMethod1);
-            Reqnroll.Bindings.Reflection.IBindingMethod enumUsingBindingMethod2 = new RuntimeBindingMethod(typeof(CucumberAddtionalExpressions.EnumCucumberExpressions).GetMethod(nameof(CucumberAddtionalExpressions.EnumCucumberExpressions.MethodUsingSampleColorEnum2)));
+            IBindingMethod enumUsingBindingMethod2 = new RuntimeBindingMethod(typeof(CucumberAddtionalExpressions.EnumCucumberExpressions).GetMethod(nameof(CucumberAddtionalExpressions.EnumCucumberExpressions.MethodUsingSampleColorEnum2)));
             sut.OnBindingMethodProcessed(enumUsingBindingMethod2);
             var paramTypes = sut.GetParameterTypes().Where(pt => pt.ParameterType.IsEnum).ToList();
                 
             paramTypes.Should().HaveCount(2);
         }
 
+        [Fact]
+        public void ParameterTypeRegistry_should_identify_error_when_given_multiple_bindings_with_an_ambiguous_enum_as_a_parameter() 
+        {
+            var expression = "I have {SampleColorEnum} cucumbers in my belly";
+            var containerBuilder = new ContainerBuilder(new CucumberExpressionIntegrationTests.TestDependencyProvider());
+            var globalContainer = containerBuilder.CreateGlobalContainer(GetType().Assembly);
+
+            var bindingSourceProcessor = globalContainer.Resolve<IRuntimeBindingSourceProcessor>();
+
+            var bindingRegistry = globalContainer.Resolve<IBindingRegistry>();
+
+            // set up first method binding that uses an ambiguous enum parameter
+            var bindingSourceMethod = new BindingSourceMethod
+            {
+                BindingMethod = new RuntimeBindingMethod(typeof(CucumberExpressionIntegrationTests.SampleBindings).GetMethod(nameof(CucumberExpressionIntegrationTests.SampleBindings.StepDefWithEnumParam))),
+                IsPublic = true,
+                Attributes = new[]
+                {
+                new BindingSourceAttribute
+                {
+                    AttributeType = new RuntimeBindingType(typeof(GivenAttribute)),
+                    AttributeValues = new IBindingSourceAttributeValueProvider[]
+                    {
+                        new BindingSourceAttributeValueProvider(expression)
+                    }
+                }
+            }
+            };
+            bindingSourceProcessor.ProcessType(
+                new BindingSourceType
+                {
+                    BindingType = new RuntimeBindingType(typeof(CucumberExpressionIntegrationTests.SampleBindings)),
+                    Attributes = new[]
+                    {
+                    new BindingSourceAttribute
+                    {
+                        AttributeType = new RuntimeBindingType(typeof(BindingAttribute))
+                    }
+                    },
+                    IsPublic = true,
+                    IsClass = true
+                });
+            bindingSourceProcessor.ProcessMethod(bindingSourceMethod);
+
+            // set up second method binding that uses an ambiguous enum parameter
+            var second_bindingSourceMethod = new BindingSourceMethod
+            {
+                BindingMethod = new RuntimeBindingMethod(typeof(CucumberAddtionalExpressions.EnumCucumberExpressions).GetMethod(nameof(CucumberAddtionalExpressions.EnumCucumberExpressions.MethodUsingSampleColorEnum2))),
+                IsPublic = true,
+                Attributes = new[]
+                {
+                new BindingSourceAttribute
+                {
+                    AttributeType = new RuntimeBindingType(typeof(GivenAttribute)),
+                    AttributeValues = new IBindingSourceAttributeValueProvider[]
+                    {
+                        new BindingSourceAttributeValueProvider(expression)
+                    }
+                }
+            }
+            };
+            bindingSourceProcessor.ProcessType(
+                new BindingSourceType
+                {
+                    BindingType = new RuntimeBindingType(typeof(CucumberAddtionalExpressions.EnumCucumberExpressions)),
+                    Attributes = new[]
+                    {
+                    new BindingSourceAttribute
+                    {
+                        AttributeType = new RuntimeBindingType(typeof(BindingAttribute))
+                    }
+                    },
+                    IsPublic = true,
+                    IsClass = true
+                });
+            bindingSourceProcessor.ProcessMethod(second_bindingSourceMethod);
+
+
+            bindingSourceProcessor.BuildingCompleted();
+
+            bindingRegistry.IsValid.Should().BeFalse();
+            var stepDefs = bindingRegistry.GetStepDefinitions().ToArray();
+            stepDefs.Count().Should().Be(2);
+            stepDefs.All(sd => sd.SourceExpression == expression).Should().BeTrue();
+            stepDefs.All(sd => sd.IsValid == false).Should().BeTrue();
+            stepDefs.All(sd => sd.ErrorMessage.StartsWith("Ambiguous enum")).Should().BeTrue();
+        }
     }
 }
 namespace Reqnroll.RuntimeTests.Bindings.CucumberAddtionalExpressions


### PR DESCRIPTION
This fix causes the CucumberExpressionParameterTypeRegistry to use the FQN of the enum Types used as Cucumber Expression parameters.

<!-- If this is your first PR, please have a look at the Contribution Guidelines (https://github.com/reqnroll/Reqnroll/blob/main/CONTRIBUTING.md) -->


<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Performance improvement
- [ ] Refactoring (so no functional change)
- [ ] Other (docs, build config, etc)



- [X ] I've added tests for my code. (most of the time mandatory)
- [X ] I have added an entry to the changelog. (mandatory)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

