### PR TITLE
Fix 81 - modified CucumberExpressionParameterTypeRegistry to handle m…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
   test run (global) context instead of the test thread context.
 * Support for PriorityAttribute in MsTest adapter
 * Support for Scenario Outline / DataRowAttribute in MsTest adapter
-* Fix for #81 in which Cucumber Expressions fail when two enums with the same short name (differing namespaces) are used as parameters
+* Fix for #81 in which Cucumber Expressions fail when two enums or two custom types with the same short name (differing namespaces) are used as parameters
 * Fix: Adding @ignore to an Examples block generates invalid code for NUnit v3+ (#103)
 
 # v1.0.1 - 2024-02-16

--- a/Tests/Reqnroll.RuntimeTests/Bindings/CucumberExpressions/CucumberExpressionParameterTypeRegistryTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/Bindings/CucumberExpressions/CucumberExpressionParameterTypeRegistryTests.cs
@@ -9,7 +9,8 @@ using Reqnroll.Bindings.Reflection;
 using Reqnroll.Infrastructure;
 using Xunit;
 
-namespace Reqnroll.RuntimeTests.Bindings.CucumberExpressions {
+namespace Reqnroll.RuntimeTests.Bindings.CucumberExpressions
+{
 
     public class CucumberExpressionParameterTypeRegistryTests
     {
@@ -47,15 +48,15 @@ namespace Reqnroll.RuntimeTests.Bindings.CucumberExpressions {
             var sut = CreateSut();
             IBindingMethod enumUsingBindingMethod1 = new RuntimeBindingMethod(typeof(SampleEnumUsingClass).GetMethod(nameof(SampleEnumUsingClass.MethodUsingSampleColorEnum1)));
             sut.OnBindingMethodProcessed(enumUsingBindingMethod1);
-            IBindingMethod enumUsingBindingMethod2 = new RuntimeBindingMethod(typeof(CucumberAddtionalExpressions.EnumCucumberExpressions).GetMethod(nameof(CucumberAddtionalExpressions.EnumCucumberExpressions.MethodUsingSampleColorEnum2)));
+            IBindingMethod enumUsingBindingMethod2 = new RuntimeBindingMethod(typeof(CucumberAddtionalExpressions.KlasWithCucumberExpressions).GetMethod(nameof(CucumberAddtionalExpressions.KlasWithCucumberExpressions.MethodUsingSampleColorEnum2)));
             sut.OnBindingMethodProcessed(enumUsingBindingMethod2);
             var paramTypes = sut.GetParameterTypes().Where(pt => pt.ParameterType.IsEnum).ToList();
-                
+
             paramTypes.Should().HaveCount(2);
         }
 
         [Fact]
-        public void ParameterTypeRegistry_should_identify_error_when_given_multiple_bindings_with_an_ambiguous_enum_as_a_parameter() 
+        public void ParameterTypeRegistry_should_identify_error_when_given_multiple_bindings_with_an_ambiguous_enum_as_a_parameter()
         {
             var expression = "I have {SampleColorEnum} cucumbers in my belly";
             var containerBuilder = new ContainerBuilder(new CucumberExpressionIntegrationTests.TestDependencyProvider());
@@ -66,9 +67,66 @@ namespace Reqnroll.RuntimeTests.Bindings.CucumberExpressions {
             var bindingRegistry = globalContainer.Resolve<IBindingRegistry>();
 
             // set up first method binding that uses an ambiguous enum parameter
+            SetupBoundMethod(expression, bindingRegistry, bindingSourceProcessor, typeof(SampleEnumUsingClass), nameof(SampleEnumUsingClass.MethodUsingSampleColorEnum1));
+
+            // set up second method binding that uses an ambiguous enum parameter
+            SetupBoundMethod(expression, bindingRegistry, bindingSourceProcessor, typeof(CucumberAddtionalExpressions.KlasWithCucumberExpressions), nameof(CucumberAddtionalExpressions.KlasWithCucumberExpressions.MethodUsingSampleColorEnum2));
+
+            bindingSourceProcessor.BuildingCompleted();
+
+            bindingRegistry.IsValid.Should().BeFalse();
+            var stepDefs = bindingRegistry.GetStepDefinitions().ToArray();
+            stepDefs.Count().Should().Be(2);
+            stepDefs.All(sd => sd.SourceExpression == expression).Should().BeTrue();
+            stepDefs.All(sd => sd.IsValid == false).Should().BeTrue();
+            stepDefs.All(sd => sd.ErrorMessage.StartsWith("Ambiguous enum")).Should().BeTrue();
+        }
+
+        [Fact]
+        public void ParameterTypeRegistry_should_identify_error_when_given_multiple_bindings_with_an_ambiguous_type_as_a_parameter()
+        {
+            var expression = "a user {SampleUser} is registered";
+            var containerBuilder = new ContainerBuilder(new CucumberExpressionIntegrationTests.TestDependencyProvider());
+            var globalContainer = containerBuilder.CreateGlobalContainer(GetType().Assembly);
+
+            var bindingSourceProcessor = globalContainer.Resolve<IRuntimeBindingSourceProcessor>();
+
+            var bindingRegistry = globalContainer.Resolve<IBindingRegistry>();
+
+            IStepArgumentTransformationBinding transformation1 = new StepArgumentTransformationBinding(
+                "user ([A-Z][a-z]+)",
+                new RuntimeBindingMethod(typeof(Reqnroll.RuntimeTests.Bindings.CucumberExpressions.SampleUser).GetMethod(nameof(Reqnroll.RuntimeTests.Bindings.CucumberExpressions.SampleUser.Create))));
+
+            // set up first method binding that uses an ambiguous enum parameter
+            SetupBoundMethod(expression, bindingRegistry, bindingSourceProcessor, typeof(CucumberExpressionIntegrationTests.SampleBindings), nameof(CucumberExpressionIntegrationTests.SampleBindings.StepDefWithCustomClassParam), transformation1);
+
+            IStepArgumentTransformationBinding transformation2 = new StepArgumentTransformationBinding(
+                "user ([A-Z][a-z]+)",
+                new RuntimeBindingMethod(typeof(Reqnroll.RuntimeTests.Bindings.CucumberAddtionalExpressions.SampleUser).GetMethod(nameof(Reqnroll.RuntimeTests.Bindings.CucumberAddtionalExpressions.SampleUser.Create))));
+
+            // set up second method binding that uses an ambiguous enum parameter
+            SetupBoundMethod(expression, bindingRegistry, bindingSourceProcessor, typeof(CucumberAddtionalExpressions.KlasWithCucumberExpressions), nameof(CucumberAddtionalExpressions.KlasWithCucumberExpressions.MethodUsingSampleUser), transformation2);
+
+            bindingSourceProcessor.BuildingCompleted();
+
+            bindingRegistry.IsValid.Should().BeFalse();
+            var stepDefs = bindingRegistry.GetStepDefinitions().ToArray();
+            stepDefs.Count().Should().Be(2);
+            stepDefs.All(sd => sd.SourceExpression == expression).Should().BeTrue();
+            stepDefs.All(sd => sd.IsValid == false).Should().BeTrue();
+            stepDefs.All(sd => sd.ErrorMessage.StartsWith("Ambiguous type used in cucumber expressions")).Should().BeTrue();
+        }
+
+
+        private static void SetupBoundMethod(string expression, IBindingRegistry bindingRegistry, IRuntimeBindingSourceProcessor bindingSourceProcessor, Type testType, string methodName, IStepArgumentTransformationBinding transformation = null)
+        {
+            if (transformation != null)
+            {
+                bindingRegistry.RegisterStepArgumentTransformationBinding(transformation);
+            }
             var bindingSourceMethod = new BindingSourceMethod
             {
-                BindingMethod = new RuntimeBindingMethod(typeof(CucumberExpressionIntegrationTests.SampleBindings).GetMethod(nameof(CucumberExpressionIntegrationTests.SampleBindings.StepDefWithEnumParam))),
+                BindingMethod = new RuntimeBindingMethod(testType.GetMethod(methodName)),
                 IsPublic = true,
                 Attributes = new[]
                 {
@@ -97,58 +155,28 @@ namespace Reqnroll.RuntimeTests.Bindings.CucumberExpressions {
                     IsClass = true
                 });
             bindingSourceProcessor.ProcessMethod(bindingSourceMethod);
-
-            // set up second method binding that uses an ambiguous enum parameter
-            var second_bindingSourceMethod = new BindingSourceMethod
-            {
-                BindingMethod = new RuntimeBindingMethod(typeof(CucumberAddtionalExpressions.EnumCucumberExpressions).GetMethod(nameof(CucumberAddtionalExpressions.EnumCucumberExpressions.MethodUsingSampleColorEnum2))),
-                IsPublic = true,
-                Attributes = new[]
-                {
-                new BindingSourceAttribute
-                {
-                    AttributeType = new RuntimeBindingType(typeof(GivenAttribute)),
-                    AttributeValues = new IBindingSourceAttributeValueProvider[]
-                    {
-                        new BindingSourceAttributeValueProvider(expression)
-                    }
-                }
-            }
-            };
-            bindingSourceProcessor.ProcessType(
-                new BindingSourceType
-                {
-                    BindingType = new RuntimeBindingType(typeof(CucumberAddtionalExpressions.EnumCucumberExpressions)),
-                    Attributes = new[]
-                    {
-                    new BindingSourceAttribute
-                    {
-                        AttributeType = new RuntimeBindingType(typeof(BindingAttribute))
-                    }
-                    },
-                    IsPublic = true,
-                    IsClass = true
-                });
-            bindingSourceProcessor.ProcessMethod(second_bindingSourceMethod);
-
-
-            bindingSourceProcessor.BuildingCompleted();
-
-            bindingRegistry.IsValid.Should().BeFalse();
-            var stepDefs = bindingRegistry.GetStepDefinitions().ToArray();
-            stepDefs.Count().Should().Be(2);
-            stepDefs.All(sd => sd.SourceExpression == expression).Should().BeTrue();
-            stepDefs.All(sd => sd.IsValid == false).Should().BeTrue();
-            stepDefs.All(sd => sd.ErrorMessage.StartsWith("Ambiguous enum")).Should().BeTrue();
         }
     }
 }
 namespace Reqnroll.RuntimeTests.Bindings.CucumberAddtionalExpressions
 {
-    public class EnumCucumberExpressions
+    public class KlasWithCucumberExpressions
     {
         public enum SampleColorEnum { Yellow, Brown };
- 
+
         public void MethodUsingSampleColorEnum2(SampleColorEnum color) { }
+
+        public void MethodUsingSampleUser(SampleUser user) { }
+    }
+
+    public class SampleUser
+    {
+        public string UserName { get; }
+
+        public SampleUser(string userName)
+        {
+            UserName = userName;
+        }
+        public static SampleUser Create(string userName) => new(userName);
     }
 }


### PR DESCRIPTION
…ultiple custom types used as cucumber expressions when those types share the same short name.

Modified CucumberExpressionParameterTypeRegistry to identify when multiple cucumber expressions, using custom object types as expression parameters, share the same short name.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Performance improvement
- [ ] Refactoring (so no functional change)
- [ ] Other (docs, build config, etc)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- This checklist is here for you that you didn't forget anything -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->



- [X] I've added tests for my code. (most of the time mandatory)
- [X] I have added an entry to the changelog. (mandatory)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
