### PR TITLE
Fix 111 ignore attr not inherited from rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Support for Scenario Outline / DataRowAttribute in MsTest adapter
 * Fix for #81 in which Cucumber Expressions fail when two enums or two custom types with the same short name (differing namespaces) are used as parameters
 * Fix: Adding @ignore to an Examples block generates invalid code for NUnit v3+ (#103)
+* Fix: #111 @ignore attribute is not inherited to the scenarios from Rule
 
 # v1.0.1 - 2024-02-16
 

--- a/Reqnroll.Generator/Generation/UnitTestMethodGenerator.cs
+++ b/Reqnroll.Generator/Generation/UnitTestMethodGenerator.cs
@@ -277,8 +277,10 @@ namespace Reqnroll.Generator.Generation
             var tagsOfScenarioVariableReferenceExpression = new CodeVariableReferenceExpression(GeneratorConstants.SCENARIO_TAGS_VARIABLE_NAME);
             var featureFileTagFieldReferenceExpression = new CodeFieldReferenceExpression(null, GeneratorConstants.FEATURE_TAGS_VARIABLE_NAME);
 
+            var scenarioCombinedTagsPropertyExpression = new CodePropertyReferenceExpression(new CodeVariableReferenceExpression("scenarioInfo"), "CombinedTags");
+
             var tagHelperReference = new CodeTypeReferenceExpression(_codeDomHelper.GetGlobalizedTypeName(typeof(TagHelper)));
-            var scenarioTagIgnoredCheckStatement = new CodeMethodInvokeExpression(tagHelperReference, nameof(TagHelper.ContainsIgnoreTag), tagsOfScenarioVariableReferenceExpression);
+            var scenarioTagIgnoredCheckStatement = new CodeMethodInvokeExpression(tagHelperReference, nameof(TagHelper.ContainsIgnoreTag), scenarioCombinedTagsPropertyExpression);
             var featureTagIgnoredCheckStatement = new CodeMethodInvokeExpression(tagHelperReference, nameof(TagHelper.ContainsIgnoreTag), featureFileTagFieldReferenceExpression);
 
             var ifIsIgnoredStatement = new CodeConditionStatement(

--- a/Tests/Reqnroll.SystemTests/Generation/GenerationTestBase.cs
+++ b/Tests/Reqnroll.SystemTests/Generation/GenerationTestBase.cs
@@ -84,6 +84,11 @@ public abstract class GenerationTestBase : SystemTestBase
             Examples:
                 | result |
                 | fails  |
+
+            @ignore
+            Rule: Scenario in this Rule should be Ignored
+             Scenario: Rule ignored scenario
+             When the step passes
             """);
         _projectsDriver.AddPassingStepBinding(stepRegex: "the step passes");
         _projectsDriver.AddFailingStepBinding(stepRegex: "the step fails");
@@ -133,6 +138,9 @@ public abstract class GenerationTestBase : SystemTestBase
                               .Which.Outcome.Should().Be(expectedIgnoredOutcome);
         _vsTestExecutionDriver.LastTestExecutionResult.LeafTestResults
                               .Should().ContainSingle(tr => tr.TestName.StartsWith("ExampleIgnored"))
+                              .Which.Outcome.Should().Be(expectedIgnoredOutcome);
+        _vsTestExecutionDriver.LastTestExecutionResult.LeafTestResults
+                              .Should().ContainSingle(tr => tr.TestName.StartsWith("Rule ignored")) 
                               .Which.Outcome.Should().Be(expectedIgnoredOutcome);
         AssertIgnoredScenarioOutlineExampleHandled();
     }

--- a/Tests/Reqnroll.SystemTests/Generation/GenerationTestBase.cs
+++ b/Tests/Reqnroll.SystemTests/Generation/GenerationTestBase.cs
@@ -87,7 +87,7 @@ public abstract class GenerationTestBase : SystemTestBase
 
             @ignore
             Rule: Scenario in this Rule should be Ignored
-             Scenario: Rule ignored scenario
+             Scenario: Ruleignored scenario
              When the step passes
             """);
         _projectsDriver.AddPassingStepBinding(stepRegex: "the step passes");
@@ -140,7 +140,7 @@ public abstract class GenerationTestBase : SystemTestBase
                               .Should().ContainSingle(tr => tr.TestName.StartsWith("ExampleIgnored"))
                               .Which.Outcome.Should().Be(expectedIgnoredOutcome);
         _vsTestExecutionDriver.LastTestExecutionResult.LeafTestResults
-                              .Should().ContainSingle(tr => tr.TestName.StartsWith("Rule ignored")) 
+                              .Should().ContainSingle(tr => tr.TestName.StartsWith("Ruleignored")) 
                               .Which.Outcome.Should().Be(expectedIgnoredOutcome);
         AssertIgnoredScenarioOutlineExampleHandled();
     }


### PR DESCRIPTION
This fix addresses Issue #111 by modifying the generated test method code to look for the ignore tag in the ScenarioInfo.CombinedTags property at test run-time.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Performance improvement
- [ ] Refactoring (so no functional change)
- [ ] Other (docs, build config, etc)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- This checklist is here for you that you didn't forget anything -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->



- [X ] I've added tests for my code. (most of the time mandatory)
- [x] I have added an entry to the changelog. (mandatory)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
