### PR TITLE
Support Scenario-Level Parallelization for MsTest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fix for #81 in which Cucumber Expressions fail when two enums or two custom types with the same short name (differing namespaces) are used as parameters
 * Fix: Adding @ignore to an Examples block generates invalid code for NUnit v3+ (#103)
 * Fix: #111 @ignore attribute is not inherited to the scenarios from Rule
+* Support Scenario-Level Parallelization for MsTest (`ExecutionScope.MethodLevel`)
 
 # v1.0.1 - 2024-02-16
 

--- a/Reqnroll.Generator/Generation/GeneratorConstants.cs
+++ b/Reqnroll.Generator/Generation/GeneratorConstants.cs
@@ -13,6 +13,7 @@ namespace Reqnroll.Generator.Generation
         public const string TESTCLASS_CLEANUP_NAME = "FeatureTearDownAsync";
         public const string BACKGROUND_NAME = "FeatureBackgroundAsync";
         public const string TESTRUNNER_FIELD = "testRunner";
+        public const string FEATURETESTRUNNER_FIELD = "featureTestRunner";
         public const string REQNROLL_NAMESPACE = "Reqnroll";
         public const string SCENARIO_OUTLINE_EXAMPLE_TAGS_PARAMETER = "exampleTags";
         public const string SCENARIO_TAGS_VARIABLE_NAME = "tagsOfScenario";

--- a/Reqnroll.Generator/Generation/ScenarioPartHelper.cs
+++ b/Reqnroll.Generator/Generation/ScenarioPartHelper.cs
@@ -173,6 +173,11 @@ namespace Reqnroll.Generator.Generation
             return new CodeVariableReferenceExpression(GeneratorConstants.TESTRUNNER_FIELD);
         }
 
+        public CodeExpression GetTestFeatureRunnerExpression()
+        {
+            return new CodeVariableReferenceExpression(GeneratorConstants.FEATURETESTRUNNER_FIELD);
+        }
+
         private CodeExpression GetStringArrayExpression(IEnumerable<string> items, ParameterSubstitution paramToIdentifier)
         {
             return new CodeArrayCreateExpression(typeof(string[]), items.Select(item => GetSubstitutedString(item, paramToIdentifier)).ToArray());

--- a/Reqnroll.Generator/Generation/UnitTestFeatureGenerator.cs
+++ b/Reqnroll.Generator/Generation/UnitTestFeatureGenerator.cs
@@ -176,7 +176,7 @@ namespace Reqnroll.Generator.Generation
             _testGeneratorProvider.SetTestClassInitializeMethod(generationContext);
 
             //testRunner = TestRunnerManager.GetTestRunnerForAssembly(null, [test_worker_id]);
-            var testRunnerField = _scenarioPartHelper.GetTestRunnerExpression();
+            var testRunnerField = generationContext.FeatureRunnerField == null ? _scenarioPartHelper.GetTestRunnerExpression() : _scenarioPartHelper.GetTestFeatureRunnerExpression();
 
             var testRunnerParameters = new[]
             {
@@ -229,7 +229,7 @@ namespace Reqnroll.Generator.Generation
             
             _testGeneratorProvider.SetTestClassCleanupMethod(generationContext);
 
-            var testRunnerField = _scenarioPartHelper.GetTestRunnerExpression();
+            var testRunnerField = generationContext.FeatureRunnerField == null ? _scenarioPartHelper.GetTestRunnerExpression() : _scenarioPartHelper.GetTestFeatureRunnerExpression();
 
             // await testRunner.OnFeatureEndAsync();
             var expression = new CodeMethodInvokeExpression(

--- a/Reqnroll.Generator/TestClassGenerationContext.cs
+++ b/Reqnroll.Generator/TestClassGenerationContext.cs
@@ -23,6 +23,7 @@ namespace Reqnroll.Generator
         public CodeMemberMethod ScenarioCleanupMethod { get; private set; }
         public CodeMemberMethod FeatureBackgroundMethod { get; private set; }
         public CodeMemberField TestRunnerField { get; private set; }
+        public CodeMemberField FeatureRunnerField { get; internal set; }
 
         public bool GenerateRowTests { get; private set; }
 

--- a/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator/ProjectBuilder.cs
+++ b/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator/ProjectBuilder.cs
@@ -377,7 +377,7 @@ namespace Reqnroll.TestProjectGenerator
                     break;
                 case UnitTestProvider.MSTest when _parallelTestExecution:
                     _project.AddFile(
-                        new ProjectFile("MsTestConfiguration.cs", "Compile", "using Microsoft.VisualStudio.TestTools.UnitTesting; [assembly: Parallelize(Workers = 4, Scope = ExecutionScope.ClassLevel)]"));
+                        new ProjectFile("MsTestConfiguration.cs", "Compile", "using Microsoft.VisualStudio.TestTools.UnitTesting; [assembly: Parallelize(Workers = 4, Scope = ExecutionScope.MethodLevel)]"));
                     break;
                 case UnitTestProvider.MSTest when !_parallelTestExecution:
                     _project.AddFile(new ProjectFile("MsTestConfiguration.cs", "Compile", "using Microsoft.VisualStudio.TestTools.UnitTesting; [assembly: DoNotParallelize]"));

--- a/Reqnroll/Bindings/IStepArgumentTypeConverter.cs
+++ b/Reqnroll/Bindings/IStepArgumentTypeConverter.cs
@@ -1,12 +1,13 @@
 using System.Globalization;
 using System.Threading.Tasks;
 using Reqnroll.Bindings.Reflection;
+using Reqnroll.Infrastructure;
 
 namespace Reqnroll.Bindings
 {
     public interface IStepArgumentTypeConverter
     {
-        Task<object> ConvertAsync(object value, IBindingType typeToConvertTo, CultureInfo cultureInfo);
+        Task<object> ConvertAsync(object value, IBindingType typeToConvertTo, IContextManager contextManager, CultureInfo cultureInfo);
         bool CanConvert(object value, IBindingType typeToConvertTo, CultureInfo cultureInfo);
     }
 }

--- a/Reqnroll/ITestRunner.cs
+++ b/Reqnroll/ITestRunner.cs
@@ -34,5 +34,7 @@ namespace Reqnroll
         Task ButAsync(string text, string multilineTextArg, Table tableArg, string keyword = null);
 
         void Pending();
+
+        ITestRunner GetScenarioTestRunner();
     }
 }

--- a/Reqnroll/Infrastructure/IContextManager.cs
+++ b/Reqnroll/Infrastructure/IContextManager.cs
@@ -10,6 +10,9 @@ namespace Reqnroll.Infrastructure
         ScenarioStepContext StepContext { get; }
         StepDefinitionType? CurrentTopLevelStepDefinitionType { get; }
 
+        void InitScenarioExecutionEngine(ITestExecutionEngine testExecutionEngine);
+        void InitScenarioRunner(ITestRunner testRunner);
+
         void InitializeFeatureContext(FeatureInfo featureInfo);
         void CleanupFeatureContext();
 
@@ -18,5 +21,7 @@ namespace Reqnroll.Infrastructure
 
         void InitializeStepContext(StepInfo stepInfo);
         void CleanupStepContext();
+
+        IContextManager GetScenarioContextManager();
     }
 }

--- a/Reqnroll/Infrastructure/ITestExecutionEngine.cs
+++ b/Reqnroll/Infrastructure/ITestExecutionEngine.cs
@@ -24,5 +24,8 @@ namespace Reqnroll.Infrastructure
         Task StepAsync(StepDefinitionKeyword stepDefinitionKeyword, string keyword, string text, string multilineTextArg, Table tableArg);
 
         void Pending();
+
+        ITestExecutionEngine GetScenarioExecutionEngine();
+        void InitScenarioRunner(ITestRunner testRunner);
     }
 }

--- a/Reqnroll/Infrastructure/TestExecutionEngine.cs
+++ b/Reqnroll/Infrastructure/TestExecutionEngine.cs
@@ -611,18 +611,18 @@ namespace Reqnroll.Infrastructure
 
             for (var i = 0; i < match.Arguments.Length; i++)
             {
-                arguments[i] = await ConvertArg(match.Arguments[i], bindingParameters[i].Type);
+                arguments[i] = await ConvertArg(match.Arguments[i], _contextManager, bindingParameters[i].Type);
             }
 
             return arguments;
         }
 
-        private async Task<object> ConvertArg(object value, IBindingType typeToConvertTo)
+        private async Task<object> ConvertArg(object value, IContextManager contextManager, IBindingType typeToConvertTo)
         {
             Debug.Assert(value != null);
             Debug.Assert(typeToConvertTo != null);
 
-            return await _stepArgumentTypeConverter.ConvertAsync(value, typeToConvertTo, FeatureContext.BindingCulture);
+            return await _stepArgumentTypeConverter.ConvertAsync(value, typeToConvertTo, _contextManager, FeatureContext.BindingCulture);
         }
 
         #endregion

--- a/Reqnroll/Infrastructure/TestExecutionEngine.cs
+++ b/Reqnroll/Infrastructure/TestExecutionEngine.cs
@@ -270,6 +270,24 @@ namespace Reqnroll.Infrastructure
             throw _errorProvider.GetPendingStepDefinitionError();
         }
 
+        public virtual ITestExecutionEngine GetScenarioExecutionEngine()
+        {
+            var scenarioContextManager = _contextManager.GetScenarioContextManager();
+
+            var scenarioEngine = new TestExecutionEngine(_stepFormatter, _testTracer, _errorProvider, _stepArgumentTypeConverter, _reqnrollConfiguration, _bindingRegistry, _unitTestRuntimeProvider, scenarioContextManager,
+                _stepDefinitionMatchService, _bindingInvoker, _obsoleteStepHandler, _analyticsEventProvider, _analyticsTransmitter, _testRunnerManager,
+                _runtimePluginTestExecutionLifecycleEventEmitter, _testThreadExecutionEventPublisher, _testPendingMessageFactory, _testUndefinedMessageFactory, _testObjectResolver, _testRunContext);
+
+            scenarioContextManager.InitScenarioExecutionEngine(scenarioEngine);
+
+            return scenarioEngine;
+        }
+
+        public virtual void InitScenarioRunner(ITestRunner testRunner)
+        {
+            _contextManager.InitScenarioRunner(testRunner);
+        }
+
         protected virtual async Task OnBlockStartAsync(ScenarioBlock block)
         {
             if (block == ScenarioBlock.None)

--- a/Reqnroll/TestRunner.cs
+++ b/Reqnroll/TestRunner.cs
@@ -104,5 +104,12 @@ namespace Reqnroll
         {
             _executionEngine.Pending();
         }
+
+        public ITestRunner GetScenarioTestRunner()
+        {
+            var testRunner = new TestRunner(_executionEngine.GetScenarioExecutionEngine());
+            testRunner._executionEngine.InitScenarioRunner(testRunner);
+            return testRunner;
+        }
     }
 }

--- a/Tests/Reqnroll.RuntimeTests/Infrastructure/TestExecutionEngineTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/Infrastructure/TestExecutionEngineTests.cs
@@ -349,7 +349,7 @@ namespace Reqnroll.RuntimeTests.Infrastructure
 
             await testExecutionEngine.StepAsync(StepDefinitionKeyword.Given, null, "user bar", null, null);
 
-            _stepArgumentTypeConverterMock.Verify(i => i.ConvertAsync(It.IsAny<object>(), It.IsAny<IBindingType>(), It.IsAny<CultureInfo>()), Times.Never);
+            _stepArgumentTypeConverterMock.Verify(i => i.ConvertAsync(It.IsAny<object>(), It.IsAny<IBindingType>(), contextManagerStub.Object, It.IsAny<CultureInfo>()), Times.Never);
         }
 
         [Fact]

--- a/Tests/Reqnroll.RuntimeTests/StepArgumentTypeConverterTest.cs
+++ b/Tests/Reqnroll.RuntimeTests/StepArgumentTypeConverterTest.cs
@@ -26,7 +26,7 @@ namespace Reqnroll.RuntimeTests
             List<IStepArgumentTransformationBinding> stepTransformations = new List<IStepArgumentTransformationBinding>();
             bindingRegistryStub.Setup(br => br.GetStepTransformations()).Returns(stepTransformations);
 
-            _stepArgumentTypeConverter = new StepArgumentTypeConverter(new Mock<ITestTracer>().Object, bindingRegistryStub.Object, new Mock<IContextManager>().Object, methodBindingInvokerStub.Object);
+            _stepArgumentTypeConverter = new StepArgumentTypeConverter(new Mock<ITestTracer>().Object, bindingRegistryStub.Object, methodBindingInvokerStub.Object);
             _enUSCulture = new CultureInfo("en-US", false);
         }
 

--- a/Tests/Reqnroll.RuntimeTests/StepExecutionTestsWithConversions.cs
+++ b/Tests/Reqnroll.RuntimeTests/StepExecutionTestsWithConversions.cs
@@ -16,7 +16,7 @@ namespace Reqnroll.RuntimeTests
     {
         public static async Task<object> ConvertAsync(this IStepArgumentTypeConverter converter, object value, Type typeToConvertTo, CultureInfo cultureInfo)
         {
-            return await converter.ConvertAsync(value, new RuntimeBindingType(typeToConvertTo), cultureInfo);
+            return await converter.ConvertAsync(value, new RuntimeBindingType(typeToConvertTo), It.IsAny<IContextManager>(), cultureInfo);
         }
 
         public static Expression<Func<IStepArgumentTypeConverter, bool>> GetCanConvertMethodFilter(object argument, Type type)
@@ -26,7 +26,7 @@ namespace Reqnroll.RuntimeTests
 
         public static Expression<Func<IStepArgumentTypeConverter, Task<object>>> GetConvertAsyncMethodFilter(object argument, Type type)
         {
-            return c => c.ConvertAsync(It.Is<object>(s => s.Equals(argument)), It.Is<IBindingType>(bt => bt.TypeEquals(type)), It.IsAny<CultureInfo>());
+            return c => c.ConvertAsync(It.Is<object>(s => s.Equals(argument)), It.Is<IBindingType>(bt => bt.TypeEquals(type)), It.IsAny<IContextManager>(), It.IsAny<CultureInfo>());
                 //Arg<string>.Is.Equal(argument),
                 //Arg<IBindingType>.Matches(bt => bt.TypeEquals(type)), 
                 //Arg<CultureInfo>.Is.Anything);

--- a/Tests/Reqnroll.RuntimeTests/StepTransformationTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/StepTransformationTests.cs
@@ -222,7 +222,7 @@ namespace Reqnroll.RuntimeTests
 
         private StepArgumentTypeConverter CreateStepArgumentTypeConverter()
         {
-            return new StepArgumentTypeConverter(new Mock<ITestTracer>().Object, bindingRegistryStub.Object, contextManagerStub.Object, methodBindingInvokerStub.Object);
+            return new StepArgumentTypeConverter(new Mock<ITestTracer>().Object, bindingRegistryStub.Object, methodBindingInvokerStub.Object);
         }
 
         [Fact]

--- a/Tests/Reqnroll.Specs/Features/UnitTestProviderSpecific/MsTest/MethodLevelParallelisation.feature
+++ b/Tests/Reqnroll.Specs/Features/UnitTestProviderSpecific/MsTest/MethodLevelParallelisation.feature
@@ -1,0 +1,154 @@
+@xUnit @NUnit3 @MSTest
+Feature: MethodLevel Parallelisation
+
+Background:
+    Given there is a Reqnroll project
+    And parallel execution is enabled
+    And the following binding class 
+        """
+using Reqnroll;
+using Reqnroll.Tracing;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using FluentAssertions;
+
+[Binding]
+public class TraceSteps
+{
+    sealed class FeatureData
+    {
+        public Stopwatch Duration { get; } = Stopwatch.StartNew();
+        public volatile int StepCount;
+        public ConcurrentDictionary<ITestRunner, byte> TestRunners { get; } = new ConcurrentDictionary<ITestRunner, byte>();
+        public ConcurrentDictionary<FeatureContext, byte> FeatureContexts { get; } = new ConcurrentDictionary<FeatureContext, byte>();
+        public ConcurrentDictionary<ScenarioContext, byte> ScenarioContexts { get; } = new ConcurrentDictionary<ScenarioContext, byte>();
+        public ConcurrentDictionary<TraceSteps, byte> BindingInstances { get; } = new ConcurrentDictionary<TraceSteps, byte>();
+    }
+
+    private readonly ITraceListener _traceListener;
+    private readonly ITestRunner _testRunner;
+    private volatile int _ScenarioLocalCounter;
+
+    public TraceSteps(ITraceListener traceListener, ITestRunner testRunner)
+    {
+        _traceListener = traceListener;
+        _testRunner = testRunner;
+
+        Interlocked.Increment(ref _ScenarioLocalCounter);
+    }
+
+    [BeforeFeature]
+    static void BeforeFeature(FeatureContext featureContext, ITestRunner testRunner)
+    {
+        testRunner.ScenarioContext.Should().BeNull();
+
+        var featureData = new FeatureData();
+        featureData.TestRunners.TryAdd(testRunner, 1);
+        featureData.FeatureContexts.TryAdd(featureContext, 1);
+        featureContext.Set(featureData);
+    }
+
+    static FeatureData GetFeatureData(FeatureContext featureContext) => featureContext.Get<FeatureData>();
+    const int WaitTimeInMS = 1_000;
+
+    [AfterFeature]
+    static void AfterFeature(FeatureContext featureContext, ITestRunner testRunner)
+    {
+        testRunner.ScenarioContext.Should().BeNull();
+
+        var featureData = GetFeatureData(featureContext);
+        featureData.TestRunners.TryAdd(testRunner, 1).Should().BeFalse();
+        featureData.Duration.Stop();
+        featureData.TestRunners.Count.Should().Be(11, because: "One TestRunner for before/after hooks and one for each test is created");
+        featureData.FeatureContexts.Count.Should().Be(1, because: "Only one FeatureContext should be created");
+        featureData.ScenarioContexts.Count.Should().Be(10, because: "One ScenarioContext for each test is created");
+        featureData.BindingInstances.Count.Should().Be(10, because: "One binding instance for each test is created");
+        featureData.Duration.ElapsedMilliseconds.Should().BeLessThan(9 * WaitTimeInMS, because: "Test should be processed (parallel) in time");
+    }
+
+    [When(@"I do something in Scenario '(.*)'")]
+    void WhenIDoSomething(string scenario)
+    {
+        _testRunner.ScenarioContext.Should().NotBeNull();
+        _testRunner.ScenarioContext.ScenarioInfo.Title.Should().Be(scenario);
+
+        Interlocked.Increment(ref _ScenarioLocalCounter);
+        _ScenarioLocalCounter.Should().Be(2);
+
+        var featureData = GetFeatureData(_testRunner.FeatureContext);
+        featureData.TestRunners.TryAdd(_testRunner, 1);
+        featureData.FeatureContexts.TryAdd(_testRunner.FeatureContext, 1);
+        featureData.ScenarioContexts.TryAdd(_testRunner.ScenarioContext, 1);
+        featureData.BindingInstances.TryAdd(this, 1);
+        var currentStartIndex = Interlocked.Increment(ref featureData.StepCount);
+        _traceListener.WriteTestOutput($"Start index: {currentStartIndex}, Worker: {_testRunner.TestWorkerId}");
+        Thread.Sleep(WaitTimeInMS);
+        var afterStartIndex = featureData.StepCount;
+        if (afterStartIndex == currentStartIndex)
+        {
+            _traceListener.WriteTestOutput("Was not parallel");
+        }
+        else
+        {
+            _traceListener.WriteTestOutput("Was parallel");
+        }
+    }
+}
+        """
+
+    And there is a feature file in the project as
+        """
+Feature: Feature 1
+Scenario Outline: Simple Scenario Outline 1
+	When I do something in Scenario 'Simple Scenario Outline 1'
+
+Examples:
+	| Count |
+	| 1     |
+    | 2     |
+    | 3     |
+
+Scenario Outline: Simple Scenario Outline 2
+	When I do something in Scenario 'Simple Scenario Outline 2'
+
+Examples:
+	| Count |
+	| 1     |
+	| 2     |
+    | 3     |
+
+Scenario Outline: Simple Scenario Outline 3
+	When I do something in Scenario 'Simple Scenario Outline 3'
+
+Scenario Outline: Simple Scenario Outline 4
+	When I do something in Scenario 'Simple Scenario Outline 4'
+
+Scenario Outline: Simple Scenario Outline 5
+	When I do something in Scenario 'Simple Scenario Outline 5'
+
+Scenario Outline: Simple Scenario Outline 6
+	When I do something in Scenario 'Simple Scenario Outline 6'
+        """
+
+Scenario: Precondition: Tests run parallel 
+    When I execute the tests
+    Then the execution log should contain text 'Was parallel'
+
+Scenario: Tests should be processed parallel without failure
+    When I execute the tests
+    Then the execution log should contain text 'Was parallel'
+    And the execution summary should contain
+        | Total | Succeeded |
+        | 10    | 10        |
+
+Scenario Outline: Before/After TestRun hook should only be executed once
+    Given a hook 'HookFor<event>' for '<event>'
+    When I execute the tests
+    Then the execution log should contain text 'Was parallel'
+    And the hook 'HookFor<event>' is executed once
+
+Examples:
+    | event               |
+    | BeforeTestRun       |
+    | AfterTestRun        |
+

--- a/docs/execution/parallel-execution.md
+++ b/docs/execution/parallel-execution.md
@@ -19,7 +19,7 @@ When using Reqnroll we can consider the parallel scheduling on the level of scen
 
 | Scheduling unit  | Description          | Runner support       |
 | ---------------- | -------------------- | -------------------- |
-| Scenario         | Scenarios can run in parallel with each other (also from different features) | N/A     |
+| Scenario         | Scenarios can run in parallel with each other (also from different features) | MsTest |
 | Feature          | Features can run in parallel with each other. Scenarios from the same feature are running on the same test thread. | NUnit, MsTest, xUnit |
 | Test assembly    | Different test assemblies can run in parallel with each other | e.g. VSTest |
 
@@ -74,10 +74,6 @@ Parallelisation must be configured by setting an assembly-level attribute in the
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 [assembly: Parallelize(Scope = ExecutionScope.ClassLevel)]
-```
-
-```{note}
-Reqnroll does not support scenario level parallelization with MsTest (when scenarios from the same feature execute in parallel). If you configure a higher level MsTest parallelization than "ClassLevel" your tests will fail with runtime errors.
 ```
 
 ### xUnit Configuration


### PR DESCRIPTION
## Behaviour changes
* Support Scenario-Level Parallelization for MsTest (`ExecutionScope.MethodLevel`)
* MsTest: Each Scenario has it's own/new `ITestRunner`, `ITestExecutionEngine` and `IContextManager` instance (before one instance was reused)
* `ITestRunner`, `ITestExecutionEngine` and `IContextManager` have new methods

## Implementation notes
* `BeforeFeature`/`AfterFeature` is only called once. This is done with a static `ITestRunner` (same behaviour as before). The  `ITestRunner` needs to be created, because it can be injected as an (optional) parameter into the `BeforeFeature`/`AfterFeature` methods.
* To ensure that no state is shared between Scenarios a new `ITestRunner`/`ITestExecutionEngine`/`IContextManager` is created for each Scenario.
* The new objects are registered in the BoDi-`IObjectContainer` at scenario-level. So hopefully they should not share state and the DI-Logic will still work for them. They override the feature-level objects.
* Pass `IContextManager` to `IStepArgumentTypeConverter` to make it independent from DI (needed now there are multiple instances of IContextManager in DI)

## Open questions
* Currently the per Scenario objects are created with `new` instead of the BoDi-Logic. Can a new instance be registered in a child-`IObjectContainer` when a instance already exists in the parent-`IObjectContainer`?
* Should the per-scenario `ITestRunner` be registered in the `ITestRunnerManager`?
* How should `TestWorkerId` be handled in the per-scenario `ITestRunner`? (Currently null)
* Could this be used as a basis for `NUnit` support?
* I wasn't sure if this should be classified as bug fix or new feature.
* I wasn't sure if the behaviour change (new instance of `ITestRunner`, `ITestExecutionEngine` and `IContextManager` per scenario) should be classified as a breaking change. They should work the same as before (they have the same information etc.) but technically they are not the same instance. So if someone puts them  in a static field, they might see some differences in the behaviour.
* I tried to push a branch to the main repro, but got the following error:
  > Pushing parallel
Remote: Permission to reqnroll/Reqnroll.git denied to obligaron.
Error encountered while pushing to the remote repository: Git failed with a fatal error.
Git failed with a fatal error.
unable to access 'https://github.com/reqnroll/Reqnroll/': The requested URL returned error: 403
    I checked "Allow edits by maintainers", so collaboration should still be possible.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Performance improvement
- [ ] Refactoring (so no functional change)
- [x] Other (docs, build config, etc)

## Checklist:

- [x] I've added tests for my code. (most of the time mandatory)
- [x] I have added an entry to the changelog. (mandatory)
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

I'm glad that Reqnroll exists and that there is a future for BDD/Cucumber in the .NET ecosystem. This is my first major change for the project. I hope you like it and I'm looking forward to your feedback. 🙂 