### PR TITLE
Capture ExecutionContext after every binding invoke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Fix: Adding @ignore to an Examples block generates invalid code for NUnit v3+ (#103)
 * Fix: #111 @ignore attribute is not inherited to the scenarios from Rule
 * Support for JSON files added to SpecFlow.ExternalData
+* Fix: #120 Capture ExecutionContext after every binding invoke
 
 # v1.0.1 - 2024-02-16
 

--- a/Reqnroll/Bindings/BindingDelegateInvoker.cs
+++ b/Reqnroll/Bindings/BindingDelegateInvoker.cs
@@ -22,16 +22,18 @@ namespace Reqnroll.Bindings
             // The ExecutionContext only flows down, so async binding methods cannot directly change it, but even if all binding method
             // is async the constructor of the binding classes are run in sync, so they should be able to change the ExecutionContext. 
             // (The binding classes are created as part of the 'bindingDelegate' this method receives.
-
-            try
+            return await InvokeInExecutionContext(executionContext?.Value, () =>
             {
-                return await InvokeInExecutionContext(executionContext?.Value, () => CreateDelegateInvocationTask(bindingDelegate, invokeArgs));
-            }
-            finally
-            {
-                if (executionContext != null)
-                    executionContext.Value = ExecutionContext.Capture();
-            }
+                try
+                {
+                    return CreateDelegateInvocationTask(bindingDelegate, invokeArgs);
+                }
+                finally
+                {
+                    if (executionContext != null)
+                        executionContext.Value = ExecutionContext.Capture();
+                }
+            });
         }
 
         private Task<object> InvokeInExecutionContext(ExecutionContext executionContext, Func<Task<object>> callback)

--- a/Tests/Reqnroll.RuntimeTests/Bindings/BindingInvokerTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/Bindings/BindingInvokerTests.cs
@@ -283,35 +283,35 @@ public class BindingInvokerTests
         public string LoadedValue { get; set; }
 
         // ReSharper disable once UnusedMember.Local
-        public void SetAsyncLocal_Sync(AsyncLocalType asyncLocalType)
+        public void SetAsyncLocal_Sync(AsyncLocalType asyncLocalType, string content)
         {
             switch (asyncLocalType)
             {
                 case AsyncLocalType.Uninitialized:
-                    _uninitializedAsyncLocal.Value = "42";
+                    _uninitializedAsyncLocal.Value = content;
                     break;
                 case AsyncLocalType.CtorInitialized:
-                    _ctorInitializedAsyncLocal.Value = "42";
+                    _ctorInitializedAsyncLocal.Value = content;
                     break;
                 case AsyncLocalType.Boxed:
-                    _boxedAsyncLocal.Value!.Value = "42";
+                    _boxedAsyncLocal.Value!.Value = content;
                     break;
             }
         }
 
         // ReSharper disable once UnusedMember.Local
-        public async Task SetAsyncLocal_Async(AsyncLocalType asyncLocalType)
+        public async Task SetAsyncLocal_Async(AsyncLocalType asyncLocalType, string content)
         {
             switch (asyncLocalType)
             {
                 case AsyncLocalType.Uninitialized:
-                    _uninitializedAsyncLocal.Value = "42";
+                    _uninitializedAsyncLocal.Value = content;
                     break;
                 case AsyncLocalType.CtorInitialized:
-                    _ctorInitializedAsyncLocal.Value = "42";
+                    _ctorInitializedAsyncLocal.Value = content;
                     break;
                 case AsyncLocalType.Boxed:
-                    _boxedAsyncLocal.Value!.Value = "42";
+                    _boxedAsyncLocal.Value!.Value = content;
                     break;
             }
             await Task.Delay(1);
@@ -352,11 +352,24 @@ public class BindingInvokerTests
         var contextManager = CreateContextManagerWith();
 
         if (setAs != null)
-            await InvokeBindingAsync(sut, contextManager, typeof(StepDefClassWithAsyncLocal), "SetAsyncLocal_" + setAs, asyncLocalType);
+            await InvokeBindingAsync(sut, contextManager, typeof(StepDefClassWithAsyncLocal), "SetAsyncLocal_" + setAs, asyncLocalType, "42");
         await InvokeBindingAsync(sut, contextManager, typeof(StepDefClassWithAsyncLocal), nameof(StepDefClassWithAsyncLocal.GetAsyncLocal_Async), asyncLocalType, expectedResult);
 
         var stepDefClass = contextManager.ScenarioContext.ScenarioContainer.Resolve<StepDefClassWithAsyncLocal>();
         stepDefClass.LoadedValue.Should().Be(expectedResult, $"Error was not propagated for {description}");
+    }
+
+    [Fact]
+    public async Task ExecutionContext_can_be_changed_multiple_times()
+    {
+        var sut = CreateSut();
+        var contextManager = CreateContextManagerWith();
+
+        await InvokeBindingAsync(sut, contextManager, typeof(StepDefClassWithAsyncLocal), "SetAsyncLocal_Sync", AsyncLocalType.Uninitialized, "14");
+        await InvokeBindingAsync(sut, contextManager, typeof(StepDefClassWithAsyncLocal), "SetAsyncLocal_Sync", AsyncLocalType.Uninitialized, "42");
+        await InvokeBindingAsync(sut, contextManager, typeof(StepDefClassWithAsyncLocal), nameof(StepDefClassWithAsyncLocal.GetAsyncLocal_Async), AsyncLocalType.Uninitialized, "42");
+        var stepDefClass = contextManager.ScenarioContext.ScenarioContainer.Resolve<StepDefClassWithAsyncLocal>();
+        stepDefClass.LoadedValue.Should().Be("42", $"Error was not propagated");
     }
 
     #endregion   


### PR DESCRIPTION
Fixes #120

Reqnroll (and Specflow v4,x) uses Async internally (only one code path).
To ensure the user sees no difference between the old (synchronous) implementation and the new ones the `ExecutionContext` (including `AsyncLocal`) are handled manually by Reqnroll.
This is done using `ExecutionContext.Capture()` in `BindingDelegateInvoker,InvokeInExecutionContext`.

The problem is that this only works once.
Background:
- In the first call
  - `ExecutionContextHolder.Value` is null. 
  - This means that `ExecutionContext.Run` is not called.
  - The Binding-Method is called with the current `ExecutionContext` and modifies the `AsyncLocal`. 
  - Current `ExecutionContext` is captured
  -  => everything is fine.
- In the second call
  - `ExecutionContextHolder.Value` is not null.
  - `ExecutionContext.Run` is called.
    - `ExecutionContext.Run` captures the current `ExecutionContext`
    - In `ExecutionContext.Run` the Binding-Method is called and modifies the `AsyncLocal`.
    - The `ExecutionContext.Run` restores the captured "old current" `ExecutionContext` with the old values
  - The current (restored) `ExecutionContext` is captured
  -  => Information is lost.

Bufix: Capture `ExecutionContext` explicitly in `ExecutionContext.Run` after every binding invoke.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Performance improvement
- [ ] Refactoring (so no functional change)
- [ ] Other (docs, build config, etc)

## Checklist:

- [x] I've added tests for my code. (most of the time mandatory)
- [x] I have added an entry to the changelog. (mandatory)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
