### PR TITLE
MsTest: Replace DelayedFixtureTearDown special case with ClassCleanupBehavior.EndOfClass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Fix: #111 @ignore attribute is not inherited to the scenarios from Rule
 * Support for JSON files added to SpecFlow.ExternalData
 * Fix: #120 Capture ExecutionContext after every binding invoke
+* MsTest: Use ClassCleanupBehavior.EndOfClass instead of custom implementation (preparation for MsTest v4.0)
 
 # v1.0.1 - 2024-02-16
 

--- a/Plugins/Reqnroll.MSTest.Generator.ReqnrollPlugin/Reqnroll.MSTest.nuspec
+++ b/Plugins/Reqnroll.MSTest.Generator.ReqnrollPlugin/Reqnroll.MSTest.nuspec
@@ -19,17 +19,17 @@
       <group targetFramework=".NETFramework4.6.2">
         <dependency id="Reqnroll" version="[$version$]" />
         <dependency id="Reqnroll.Tools.MsBuild.Generation" version="[$version$]" />
-        <dependency id="MSTest.TestFramework" version="2.1.2" />
+        <dependency id="MSTest.TestFramework" version="2.2.8" />
       </group>
       <group targetFramework=".NETStandard2.0">
         <dependency id="Reqnroll" version="[$version$]" />
         <dependency id="Reqnroll.Tools.MsBuild.Generation" version="[$version$]" />
-        <dependency id="MSTest.TestFramework" version="2.1.2" />
+        <dependency id="MSTest.TestFramework" version="2.2.8" />
       </group>
       <group targetFramework="net6.0">
         <dependency id="Reqnroll" version="[$version$]" />
         <dependency id="Reqnroll.Tools.MsBuild.Generation" version="[$version$]" />
-        <dependency id="MSTest.TestFramework" version="2.1.2" />
+        <dependency id="MSTest.TestFramework" version="2.2.8" />
       </group>
     </dependencies>
   </metadata>

--- a/Plugins/Reqnroll.MSTest.ReqnrollPlugin/MsTestRuntimeProvider.cs
+++ b/Plugins/Reqnroll.MSTest.ReqnrollPlugin/MsTestRuntimeProvider.cs
@@ -19,7 +19,5 @@ namespace Reqnroll.MSTest.ReqnrollPlugin
         {
             TestInconclusive(message); // there is no dynamic "Ignore" in mstest
         }
-
-        public bool DelayedFixtureTearDown => true;
     }
 }

--- a/Plugins/Reqnroll.NUnit.ReqnrollPlugin/NUnitRuntimeProvider.cs
+++ b/Plugins/Reqnroll.NUnit.ReqnrollPlugin/NUnitRuntimeProvider.cs
@@ -19,7 +19,5 @@ namespace Reqnroll.NUnit.ReqnrollPlugin
         {
             Assert.Ignore(message);
         }
-
-        public bool DelayedFixtureTearDown => false;
     }
 }

--- a/Plugins/Reqnroll.xUnit.ReqnrollPlugin/XUnitRuntimeProvider.cs
+++ b/Plugins/Reqnroll.xUnit.ReqnrollPlugin/XUnitRuntimeProvider.cs
@@ -19,7 +19,5 @@ namespace Reqnroll.xUnit.ReqnrollPlugin
         {
             Skip.If(true, message);
         }
-
-        public bool DelayedFixtureTearDown => false;
     }
 }

--- a/Reqnroll.Generator/UnitTestProvider/MsTestGeneratorProvider.cs
+++ b/Reqnroll.Generator/UnitTestProvider/MsTestGeneratorProvider.cs
@@ -13,6 +13,8 @@ namespace Reqnroll.Generator.UnitTestProvider
         protected internal const string PROPERTY_ATTR = "Microsoft.VisualStudio.TestTools.UnitTesting.TestPropertyAttribute";
         protected internal const string TESTFIXTURESETUP_ATTR = "Microsoft.VisualStudio.TestTools.UnitTesting.ClassInitializeAttribute";
         protected internal const string TESTFIXTURETEARDOWN_ATTR = "Microsoft.VisualStudio.TestTools.UnitTesting.ClassCleanupAttribute";
+        protected internal const string CLASSCLEANUPBEHAVIOR_ENUM = "Microsoft.VisualStudio.TestTools.UnitTesting.ClassCleanupBehavior";
+        protected internal const string CLASSCLEANUPBEHAVIOR_ENDOFCLASS = "EndOfClass";
         protected internal const string TESTSETUP_ATTR = "Microsoft.VisualStudio.TestTools.UnitTesting.TestInitializeAttribute";
         protected internal const string TESTTEARDOWN_ATTR = "Microsoft.VisualStudio.TestTools.UnitTesting.TestCleanupAttribute";
         protected internal const string IGNORE_ATTR = "Microsoft.VisualStudio.TestTools.UnitTesting.IgnoreAttribute";
@@ -112,7 +114,9 @@ namespace Reqnroll.Generator.UnitTestProvider
         public void SetTestClassCleanupMethod(TestClassGenerationContext generationContext)
         {
             generationContext.TestClassCleanupMethod.Attributes |= MemberAttributes.Static;
-            CodeDomHelper.AddAttribute(generationContext.TestClassCleanupMethod, TESTFIXTURETEARDOWN_ATTR);
+            // [Microsoft.VisualStudio.TestTools.UnitTesting.ClassCleanupAttribute(Microsoft.VisualStudio.TestTools.UnitTesting.ClassCleanupBehavior.EndOfClass)]
+            var attribute = CodeDomHelper.AddAttribute(generationContext.TestClassCleanupMethod, TESTFIXTURETEARDOWN_ATTR);
+            attribute.Arguments.Add(new CodeAttributeArgument(new CodeFieldReferenceExpression(new CodeTypeReferenceExpression(CLASSCLEANUPBEHAVIOR_ENUM), CLASSCLEANUPBEHAVIOR_ENDOFCLASS)));
         }
 
 

--- a/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator/ProjectBuilder.cs
+++ b/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator/ProjectBuilder.cs
@@ -16,7 +16,7 @@ namespace Reqnroll.TestProjectGenerator
         public const string NUnit3TestAdapterPackageName = "NUnit3TestAdapter";
         public const string NUnit3TestAdapterPackageVersion = "3.17.0";
         private const string XUnitPackageVersion = "2.4.2";
-        private const string MSTestPackageVersion = "2.1.2";
+        private const string MSTestPackageVersion = "2.2.8";
         private const string InternalJsonPackageName = "SpecFlow.Internal.Json";
         private const string InternalJsonVersion = "1.0.8";
         private readonly BindingsGeneratorFactory _bindingsGeneratorFactory;

--- a/Reqnroll/Infrastructure/TestExecutionEngine.cs
+++ b/Reqnroll/Infrastructure/TestExecutionEngine.cs
@@ -141,15 +141,6 @@ namespace Reqnroll.Infrastructure
 
         public virtual async Task OnFeatureStartAsync(FeatureInfo featureInfo)
         {
-            // if the unit test provider would execute the fixture teardown code
-            // only delayed (at the end of the execution), we automatically close
-            // the current feature if necessary
-            if (_unitTestRuntimeProvider.DelayedFixtureTearDown && FeatureContext != null)
-            {
-                await OnFeatureEndAsync();
-            }
-
-
             _contextManager.InitializeFeatureContext(featureInfo);
 
             _testThreadExecutionEventPublisher.PublishEvent(new FeatureStartedEvent(FeatureContext));
@@ -159,13 +150,6 @@ namespace Reqnroll.Infrastructure
 
         public virtual async Task OnFeatureEndAsync()
         {
-            // if the unit test provider would execute the fixture teardown code
-            // only delayed (at the end of the execution), we ignore the
-            // feature-end call, if the feature has been closed already
-            if (_unitTestRuntimeProvider.DelayedFixtureTearDown &&
-                FeatureContext == null)
-                return;
-
             await FireEventsAsync(HookType.AfterFeature);
 
             if (_reqnrollConfiguration.TraceTimings)

--- a/Reqnroll/UnitTestProvider/IUnitTestRuntimeProvider.cs
+++ b/Reqnroll/UnitTestProvider/IUnitTestRuntimeProvider.cs
@@ -5,6 +5,5 @@ namespace Reqnroll.UnitTestProvider
         void TestPending(string message);
         void TestInconclusive(string message);
         void TestIgnore(string message);
-        bool DelayedFixtureTearDown { get; }
     }
 }

--- a/Tests/Reqnroll.RuntimeTests/Infrastructure/TestRunContainerBuilderTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/Infrastructure/TestRunContainerBuilderTests.cs
@@ -111,11 +111,6 @@ namespace Reqnroll.RuntimeTests.Infrastructure
             {
                 throw new NotImplementedException();
             }
-
-            public bool DelayedFixtureTearDown
-            {
-                get { throw new NotImplementedException(); }
-            }
         }
 
         public void Dispose()

--- a/docs/integrations/mstest.md
+++ b/docs/integrations/mstest.md
@@ -1,6 +1,6 @@
 # MSTest
 
-Reqnroll supports MsTest V2.
+Reqnroll supports MsTest V2 (NuGet Version 2.2.8 or higher).
 
 Documentation for MSTest can be found [here](https://docs.microsoft.com/en-us/visualstudio/test/unit-test-your-code?view=vs-2019).
 


### PR DESCRIPTION
This PR removes the special `DelayedFixtureTearDown` for MsTest. The workaround was used to ensure that `AfterFeature` was called after all scenarios of a feature had been called.

This is now replaced by [`ClassCleanupBehavior.EndOfClass`](https://github.com/microsoft/testfx/pull/968). This required a MsTest version of at least 2.2.8 (released end of 2021).

Rationale:
- This will allow us to move forward with [MsTest Parallelization](#119), as the current workaround doesn't properly support multiple running scenarios.
- The current workaround uses internal information from MsTest that is likely to change. It relies on the fact that all tests and the `ClassInitialize` hook running on the same thread (same `ManagedThreadId`). But this is not guaranteed by the framework and is likely to change with MsTest [V4.0](https://github.com/microsoft/testfx/milestone/29) (switch to [async pattern](https://github.com/microsoft/testfx/issues/1284) internally).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Performance improvement
- [x] Refactoring (so no functional change)
- [ ] Other (docs, build config, etc)

## Checklist:

- [ ] I've added tests for my code. (most of the time mandatory)
- [x] I have added an entry to the changelog. (mandatory)
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
