### PR TITLE
Add a reqnroll config option to not consider cucumber expressions

### DIFF
--- a/Reqnroll/Configuration/ConfigDefaults.cs
+++ b/Reqnroll/Configuration/ConfigDefaults.cs
@@ -14,6 +14,7 @@ namespace Reqnroll.Configuration
         public const bool DetectAmbiguousMatches = true;
         public const bool StopAtFirstError = false;
         public const MissingOrPendingStepsOutcome MissingOrPendingStepsOutcome = Reqnroll.Configuration.MissingOrPendingStepsOutcome.Pending;
+        public const bool EnableCucumberStepDefinitionBindings = true;
 
         public const bool TraceSuccessfulSteps = true;
         public const bool TraceTimings = false;

--- a/Reqnroll/Configuration/ConfigurationLoader.cs
+++ b/Reqnroll/Configuration/ConfigurationLoader.cs
@@ -47,6 +47,7 @@ namespace Reqnroll.Configuration
         public static string[] DefaultAddNonParallelizableMarkerForTags => ConfigDefaults.AddNonParallelizableMarkerForTags;
 
         public static ObsoleteBehavior DefaultObsoleteBehavior => ConfigDefaults.ObsoleteBehavior;
+        public static bool DefaultEnableCucumberStepDefinitionBindings => ConfigDefaults.EnableCucumberStepDefinitionBindings;
 
         public static bool DefaultColoredOutput => ConfigDefaults.ColoredOutput;
 
@@ -131,6 +132,7 @@ namespace Reqnroll.Configuration
                 DefaultAllowRowTests,
                 DefaultAddNonParallelizableMarkerForTags,
                 DefaultObsoleteBehavior,
+                DefaultEnableCucumberStepDefinitionBindings,
                 DefaultColoredOutput
                 );
         }

--- a/Reqnroll/Configuration/JsonConfig/JsonConfigurationLoader.cs
+++ b/Reqnroll/Configuration/JsonConfig/JsonConfigurationLoader.cs
@@ -31,6 +31,7 @@ namespace Reqnroll.Configuration.JsonConfig
             bool allowDebugGeneratedFiles = reqnrollConfiguration.AllowDebugGeneratedFiles;
             var addNonParallelizableMarkerForTags = reqnrollConfiguration.AddNonParallelizableMarkerForTags;
             var obsoleteBehavior = reqnrollConfiguration.ObsoleteBehavior;
+            var enableCucumberStepDefinitionBindings = reqnrollConfiguration.EnableCucumberStepDefinitionBindings;
 
             if (jsonConfig.Language != null)
             {
@@ -58,6 +59,7 @@ namespace Reqnroll.Configuration.JsonConfig
                 missingOrPendingStepsOutcome = jsonConfig.Runtime.MissingOrPendingStepsOutcome;
                 stopAtFirstError = jsonConfig.Runtime.StopAtFirstError;
                 obsoleteBehavior = jsonConfig.Runtime.ObsoleteBehavior;
+                enableCucumberStepDefinitionBindings = jsonConfig.Runtime.EnableCucumberStepDefinitionBindings;
 
                 if (jsonConfig.Runtime.Dependencies != null)
                 {
@@ -121,6 +123,7 @@ namespace Reqnroll.Configuration.JsonConfig
                 allowRowTests,
                 addNonParallelizableMarkerForTags,
                 obsoleteBehavior,
+                enableCucumberStepDefinitionBindings,
                 coloredOutput
             )
             {

--- a/Reqnroll/Configuration/JsonConfig/RuntimeElement.cs
+++ b/Reqnroll/Configuration/JsonConfig/RuntimeElement.cs
@@ -8,20 +8,21 @@ namespace Reqnroll.Configuration.JsonConfig
 {
     public class RuntimeElement
     {
-        //[JsonProperty("stopAtFirstError", DefaultValueHandling = DefaultValueHandling.Populate, NullValueHandling = NullValueHandling.Ignore)]
         [DataMember(Name = "stopAtFirstError")]
         [DefaultValue(ConfigDefaults.StopAtFirstError)]
         public bool StopAtFirstError { get; set; }
 
-        //[JsonProperty("missingOrPendingStepsOutcome", DefaultValueHandling = DefaultValueHandling.Populate, NullValueHandling = NullValueHandling.Ignore)]
         [DataMember(Name = "missingOrPendingStepsOutcome")]
         [DefaultValue(ConfigDefaults.MissingOrPendingStepsOutcome)]
         public MissingOrPendingStepsOutcome MissingOrPendingStepsOutcome { get; set; }
 
-        //[JsonProperty("obsoleteBehavior", DefaultValueHandling = DefaultValueHandling.Populate, NullValueHandling = NullValueHandling.Ignore)]
         [DataMember(Name = "obsoleteBehavior")]
         [DefaultValue(ConfigDefaults.ObsoleteBehavior)]
         public ObsoleteBehavior ObsoleteBehavior { get; set; }
+
+        [DataMember(Name = "enableCucumberStepDefinitionBindings")]
+        [DefaultValue(ConfigDefaults.EnableCucumberStepDefinitionBindings)]
+        public bool EnableCucumberStepDefinitionBindings { get; set; }
 
         [DataMember(Name = "dependencies")]
         public List<Dependency> Dependencies { get; set; }

--- a/Reqnroll/Configuration/ReqnrollConfiguration.cs
+++ b/Reqnroll/Configuration/ReqnrollConfiguration.cs
@@ -32,6 +32,7 @@ namespace Reqnroll.Configuration
             bool allowRowTests,
             string[] addNonParallelizableMarkerForTags,
             ObsoleteBehavior obsoleteBehavior,
+            bool enableCucumberStepDefinitionBindings,
             bool coloredOutput
         )
         {
@@ -51,6 +52,7 @@ namespace Reqnroll.Configuration
             AllowRowTests = allowRowTests;
             AddNonParallelizableMarkerForTags = addNonParallelizableMarkerForTags;
             ObsoleteBehavior = obsoleteBehavior;
+            EnableCucumberStepDefinitionBindings = enableCucumberStepDefinitionBindings;
             ColoredOutput = coloredOutput;
         }
 
@@ -68,6 +70,7 @@ namespace Reqnroll.Configuration
         public bool StopAtFirstError { get; set; }
         public MissingOrPendingStepsOutcome MissingOrPendingStepsOutcome { get; set; }
         public ObsoleteBehavior ObsoleteBehavior { get; set; }
+        public bool EnableCucumberStepDefinitionBindings { get; set; }
 
         //generator settings
         public bool AllowDebugGeneratedFiles { get; set; }
@@ -93,6 +96,7 @@ namespace Reqnroll.Configuration
                                                               && AllowDebugGeneratedFiles == other.AllowDebugGeneratedFiles
                                                               && AllowRowTests == other.AllowRowTests
                                                               && ObsoleteBehavior == other.ObsoleteBehavior
+                                                              && EnableCucumberStepDefinitionBindings == other.EnableCucumberStepDefinitionBindings
                                                               && TraceSuccessfulSteps == other.TraceSuccessfulSteps
                                                               && TraceTimings == other.TraceTimings
                                                               && MinTracedDuration.Equals(other.MinTracedDuration)
@@ -134,6 +138,7 @@ namespace Reqnroll.Configuration
                 hashCode = (hashCode * 397) ^ AllowDebugGeneratedFiles.GetHashCode();
                 hashCode = (hashCode * 397) ^ AllowRowTests.GetHashCode();
                 hashCode = (hashCode * 397) ^ (int)ObsoleteBehavior;
+                hashCode = (hashCode * 397) ^ EnableCucumberStepDefinitionBindings.GetHashCode();
                 hashCode = (hashCode * 397) ^ TraceSuccessfulSteps.GetHashCode();
                 hashCode = (hashCode * 397) ^ TraceTimings.GetHashCode();
                 hashCode = (hashCode * 397) ^ MinTracedDuration.GetHashCode();

--- a/Tests/Reqnroll.RuntimeTests/BindingSourceProcessorStub.cs
+++ b/Tests/Reqnroll.RuntimeTests/BindingSourceProcessorStub.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using Reqnroll.Bindings;
 using Reqnroll.Bindings.CucumberExpressions;
@@ -17,7 +18,12 @@ namespace Reqnroll.RuntimeTests
 
         public IEnumerable<string> ValidationErrors => GeneralErrorMessages.Concat(BindingSpecificErrorMessages);
 
-        public BindingSourceProcessorStub() : base(new BindingFactory(new StepDefinitionRegexCalculator(ConfigurationLoader.GetDefault()), new CucumberExpressionStepDefinitionBindingBuilderFactory(new CucumberExpressionParameterTypeRegistry(new BindingRegistry()))))
+        public BindingSourceProcessorStub() 
+            : base(
+                new BindingFactory(
+                    new StepDefinitionRegexCalculator(ConfigurationLoader.GetDefault()),
+                    new CucumberExpressionStepDefinitionBindingBuilderFactory(new CucumberExpressionParameterTypeRegistry(new BindingRegistry())),
+                    ConfigurationLoader.GetDefault()))
         {
         }
 

--- a/Tests/Reqnroll.RuntimeTests/Bindings/BindingFactoryTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/Bindings/BindingFactoryTests.cs
@@ -1,0 +1,80 @@
+using System;
+using Moq;
+using Reqnroll.Bindings;
+using Reqnroll.Bindings.CucumberExpressions;
+using Reqnroll.Bindings.Reflection;
+using Reqnroll.Configuration;
+using Xunit;
+
+namespace Reqnroll.RuntimeTests.Bindings;
+
+public class BindingFactoryTests
+{
+    private readonly IBindingMethod _bindingMethod = new Mock<IBindingMethod>().Object;
+    private readonly BindingScope _bindingScope = new BindingScope("testTag", "testTitle", "TestScenario");
+
+    private static BindingFactory CreateSut() => new(
+        new Mock<IStepDefinitionRegexCalculator>().Object,
+        new Mock<ICucumberExpressionStepDefinitionBindingBuilderFactory>().Object,
+        ConfigurationLoader.GetDefault());
+
+    [Fact]
+    public void CreateHookBinding_Passes_Arguments()
+    {
+        var sut = CreateSut();
+
+        const int hookOrder = 0;
+        const HookType hookType = HookType.AfterFeature;
+
+        var hookBinding = sut.CreateHookBinding(_bindingMethod, hookType, _bindingScope, hookOrder);
+
+        Assert.Equal(_bindingMethod, hookBinding.Method);
+        Assert.Equal(hookType, hookBinding.HookType);
+        Assert.Equal(_bindingScope, hookBinding.BindingScope);
+        Assert.Equal(hookOrder, hookBinding.HookOrder);
+    }
+
+    [Fact]
+    public void CreateStepArgumentTransformation_Passes_Arguments()
+    {
+        var sut = CreateSut();
+
+        const string regexString = "^testRegexString$";
+        const string parameterTypeName = "testParameterTypeName";
+
+        var stepArgumentTransformation = sut.CreateStepArgumentTransformation(regexString, _bindingMethod, parameterTypeName);
+
+        Assert.Equal(_bindingMethod, stepArgumentTransformation.Method);
+        Assert.Equal(regexString, stepArgumentTransformation.Regex.ToString());
+        Assert.Equal(parameterTypeName, stepArgumentTransformation.Name);
+    }
+
+    [Theory]
+    [InlineData(null, typeof(MethodNameStepDefinitionBindingBuilder), true)]
+    [InlineData(null, typeof(MethodNameStepDefinitionBindingBuilder), false)]
+    [InlineData("I have {int} cucumber(s) in my belly/tummy", typeof(CucumberExpressionStepDefinitionBindingBuilder), true)]
+    [InlineData("I have {int} cucumber(s) in my belly/tummy", typeof(RegexStepDefinitionBindingBuilder), false)]
+    [InlineData("I have (\\d+) cucumber(?:s)? in my (?:belly|tummy)", typeof(RegexStepDefinitionBindingBuilder), true)]
+    [InlineData("I have (\\d+) cucumber(?:s)? in my (?:belly|tummy)", typeof(RegexStepDefinitionBindingBuilder), false)]
+    public void CreateStepDefinitionBindingBuilder_ReturnsBindingTypeBuilder_BasedOnInput(string expressionString, Type expectedBindingType, bool enableCucumberStepDefinitionBindings)
+    {
+        var cucumberExpressionStepDefinitionBindingBuilderFactory = new Mock<ICucumberExpressionStepDefinitionBindingBuilderFactory>();
+        var reqnrollConfiguration = ConfigurationLoader.GetDefault();
+
+        var sut = new BindingFactory(
+            new Mock<IStepDefinitionRegexCalculator>().Object,
+            cucumberExpressionStepDefinitionBindingBuilderFactory.Object,
+            reqnrollConfiguration);
+
+        reqnrollConfiguration.EnableCucumberStepDefinitionBindings = enableCucumberStepDefinitionBindings;
+
+        const StepDefinitionType stepDefinitionType = StepDefinitionType.When;
+
+        cucumberExpressionStepDefinitionBindingBuilderFactory.Setup(m => m.Create(stepDefinitionType, _bindingMethod, _bindingScope, expressionString))
+                                                             .Returns(new CucumberExpressionStepDefinitionBindingBuilder(default, default, default, default, default));
+
+        var stepDefinitionBindingBuilder = sut.CreateStepDefinitionBindingBuilder(stepDefinitionType, _bindingMethod, _bindingScope, expressionString);
+
+        Assert.Equal(expectedBindingType, stepDefinitionBindingBuilder.GetType());
+    }
+}

--- a/Tests/Reqnroll.RuntimeTests/Bindings/CultureInfoScopeTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/Bindings/CultureInfoScopeTests.cs
@@ -51,7 +51,7 @@ namespace Reqnroll.RuntimeTests.Bindings
         {
             return new FeatureContext(default,
                                       new FeatureInfo(cultureInfo, default, default, default),
-                                      new ReqnrollConfiguration(default, default, default, default, cultureInfo, default, default, default, default, default, default, default, default, default, default, default, default));
+                                      new ReqnrollConfiguration(default, default, default, default, cultureInfo, default, default, default, default, default, default, default, default, default, default, default, default, default));
         }
     }
 }

--- a/Tests/Reqnroll.RuntimeTests/Configuration/JsonConfigTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/Configuration/JsonConfigTests.cs
@@ -1,13 +1,11 @@
 using System;
 using System.Globalization;
 using System.Linq;
-using Reqnroll.BoDi;
 using FluentAssertions;
 using Xunit;
 using Reqnroll.BindingSkeletons;
 using Reqnroll.Configuration;
 using Reqnroll.Configuration.JsonConfig;
-using Reqnroll.Plugins;
 
 namespace Reqnroll.RuntimeTests.Configuration
 {
@@ -29,7 +27,8 @@ namespace Reqnroll.RuntimeTests.Configuration
             ""generator"": { ""allowDebugGeneratedFiles"": false },
             ""runtime"": {              
               ""stopAtFirstError"": false,
-              ""missingOrPendingStepsOutcome"": ""Inconclusive""
+              ""missingOrPendingStepsOutcome"": ""Inconclusive"",
+              ""enableCucumberStepDefinitionBindings"": false
             },
             ""trace"": {
               ""traceSuccessfulSteps"": true,
@@ -96,6 +95,32 @@ namespace Reqnroll.RuntimeTests.Configuration
             var runtimeConfig = new JsonConfigurationLoader().LoadJson(ConfigurationLoader.GetDefault(), config);
 
             runtimeConfig.StopAtFirstError.Should().BeFalse();
+        }
+
+        [Fact]
+        public void Check_Runtime_enableCucumberStepDefinitionBindings_as_true()
+        {
+            string config = @"{
+                                ""runtime"": { ""enableCucumberStepDefinitionBindings"": true }
+                            }";
+
+            var runtimeConfig = new JsonConfigurationLoader().LoadJson(ConfigurationLoader.GetDefault(), config);
+
+            runtimeConfig.EnableCucumberStepDefinitionBindings.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Check_Runtime_enableCucumberStepDefinitionBindings_as_false()
+        {
+            string config = @"{
+                                ""runtime"": { ""enableCucumberStepDefinitionBindings"": false }
+                            }";
+
+
+
+            var runtimeConfig = new JsonConfigurationLoader().LoadJson(ConfigurationLoader.GetDefault(), config);
+
+            runtimeConfig.EnableCucumberStepDefinitionBindings.Should().BeFalse();
         }
 
         [Fact]
@@ -486,6 +511,7 @@ namespace Reqnroll.RuntimeTests.Configuration
             config.StopAtFirstError.Should().Be(ConfigDefaults.StopAtFirstError);
             config.MissingOrPendingStepsOutcome.Should().Be(ConfigDefaults.MissingOrPendingStepsOutcome);
             config.ObsoleteBehavior.Should().Be(ConfigDefaults.ObsoleteBehavior);
+            config.EnableCucumberStepDefinitionBindings.Should().Be(ConfigDefaults.EnableCucumberStepDefinitionBindings);
             config.CustomDependencies.Should().NotBeNull();
             config.CustomDependencies.Count.Should().Be(0);
 

--- a/reqnroll-config.json
+++ b/reqnroll-config.json
@@ -4,6 +4,9 @@
   /*
 
   Changelog:
+  
+  1.1
+  - Add properties.runtime.enableCucumberStepDefinitionBindings
 
   1.0
   - Initial Reqnroll configuration schema
@@ -76,6 +79,11 @@
           "description": "Determines whether the execution should stop when encountering the first error, or whether it should attempt to try and match subsequent steps (in order to detect missing steps).",
           "type": "boolean",
           "default": false
+        },
+        "enableCucumberStepDefinitionBindings": {
+          "description": "Determines whether the step definition binding should consider cucumber expressions",
+          "type": "boolean",
+          "default": true
         }
       }
     },


### PR DESCRIPTION
Currently regex expressions incorrectly determined as cucumber expressions can be fixed by appending `^` and `$` to the start and the end of the expression. This extra configuration aims to make it easier to only use regex expressions without having to append `^` and `$`.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Performance improvement
- [ ] Refactoring (so no functional change)
- [ ] Other (docs, build config, etc)

## Checklist:

- [x] I've added tests for my code. (most of the time mandatory)
- [ ] I have added an entry to the changelog. (mandatory)
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly. --> The website has not yet been updated https://docs.reqnroll.net/latest/automation/cucumber-expressions.html 
