### PR TITLE
Fix project template binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Update [versioning policy for plugins](https://docs.reqnroll.net/latest/installation/compatibility.html#versioning-policy) and set plugin dependencies accordingly (#160)
 * Generate symbol packages, use deterministic build and update package metadata (#161)
+* Add binding attribute to example class `CalculatorStepDefinitions`
 
 # v2.0.2 - 2024-05-31
 

--- a/Templates/Reqnroll.Templates.DotNet/templates/reqnroll-project/StepDefinitions/CalculatorStepDefinitions.cs
+++ b/Templates/Reqnroll.Templates.DotNet/templates/reqnroll-project/StepDefinitions/CalculatorStepDefinitions.cs
@@ -2,6 +2,7 @@ using Reqnroll;
 
 namespace Template.StepDefinitions;
 
+[Binding]
 public sealed class CalculatorStepDefinitions
 {
     // For additional details on Reqnroll step definitions see https://go.reqnroll.net/doc-stepdef


### PR DESCRIPTION
<!-- If this is your first PR, please have a look at the Contribution Guidelines (https://github.com/reqnroll/Reqnroll/blob/main/CONTRIBUTING.md) -->


<!--- Describe your changes in detail -->

Following the documentation and creating a new test project with `dotnet new reqnroll-project` then running `dotnet test` ends up with `No matching step definition found for the step. Use the following code to create one: ...`
This change adds the missing binding so following the steps in the documentation won't result in confusion anymore.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Performance improvement
- [ ] Refactoring (so no functional change)
- [ ] Other (docs, build config, etc)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- This checklist is here for you that you didn't forget anything -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->



- [ ] I've added tests for my code. (most of the time mandatory)
- [x] I have added an entry to the changelog. (mandatory)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
