### PR TITLE
Add release contributors to CHANGELOG

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,6 +22,6 @@
 
 
 - [ ] I've added tests for my code. (most of the time mandatory)
-- [ ] I have added an entry to the changelog. (mandatory)
+- [ ] I have added an entry to the changelog & included my GitHub handle to the release contributors list. (mandatory)
 - [ ] My change requires a change to the documentation.
 - [ ] I have updated the documentation accordingly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 * Fix: Project created with `dotnet new reqnroll-project` contains an invalid binding class (`[Binding]` attribute missing) (#169)
 
+*Contributors of this release (in alphabetical order):* @gasparnagy, @mcraa
+
 # v2.0.2 - 2024-05-31
 
 ## Bug fixes:


### PR DESCRIPTION
In order to give more credit to the people who contribute to the open-source project, I recommend listing all contributors of a particular release in the change log (with GitHub handle & in alphabetical order).

My goal is to make this as an ongoing thing (everyone should add their own name as part of PR), but of course we can fix the changelog backwards as well. 

What do you think?