### PR TITLE
Fix: Reqnroll.Autofac: Objects registered in the global container cannot be relsolved in BeforeTestRun/AfterTestRun hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@
 
 ## Bug fixes:
 
-*Contributors of this release (in alphabetical order):* @ajeckmans, @cimnine, @obligaron
+* Fix: Reqnroll.Autofac: Objects registered in the global container cannot be relsolved in BeforeTestRun/AfterTestRun hooks (#183)
+
+*Contributors of this release (in alphabetical order):* @ajeckmans, @cimnine, @gasparnagy, @obligaron
 
 # v2.0.3 - 2024-06-10
 

--- a/Plugins/Reqnroll.Autofac.ReqnrollPlugin/AutofacTestObjectResolver.cs
+++ b/Plugins/Reqnroll.Autofac.ReqnrollPlugin/AutofacTestObjectResolver.cs
@@ -21,6 +21,12 @@ namespace Reqnroll.Autofac
                 return lifeTimeScope.Resolve(bindingType);
             }
 
+            if (container.IsRegistered<IContainer>())
+            {
+                var lifeTimeScope = container.Resolve<IContainer>();
+                return lifeTimeScope.Resolve(bindingType);
+            }
+
             return container.Resolve(bindingType);
         }
     }

--- a/Tests/Reqnroll.PluginTests/Autofac/AutofacPluginTests.cs
+++ b/Tests/Reqnroll.PluginTests/Autofac/AutofacPluginTests.cs
@@ -159,6 +159,22 @@ private readonly RuntimePluginEvents _runtimePluginEvents;
         globalDep1.Should().NotBeNull();
     }
 
+    [Fact] public void Should_allow_global_registrations_to_GlobalContainer()
+    {
+        // Arrange
+        var sut = new TestableAutofacPlugin(typeof(ContainerSetup1), nameof(ContainerSetup1.SetupGlobalContainer));
+        
+        // Act
+        sut.Initialize(_runtimePluginEvents, new RuntimePluginParameters(), new UnitTestProviderConfiguration());
+        var reqnrollConfiguration = ConfigurationLoader.GetDefault();
+        _runtimePluginEvents.RaiseCustomizeGlobalDependencies(_testRunContainer, reqnrollConfiguration);
+
+        // Assert
+        var resolver = _testRunContainer.Resolve<ITestObjectResolver>();
+        var globalDep1 = resolver.ResolveBindingInstance(typeof(IGlobalDependency1), _testRunContainer);
+        globalDep1.Should().NotBeNull();
+    }
+
     private ObjectContainer InitializeToScenarioContainer(TestableAutofacPlugin sut)
     {
         sut.Initialize(_runtimePluginEvents, new RuntimePluginParameters(), new UnitTestProviderConfiguration());


### PR DESCRIPTION
### 🤔 What's changed?

Fixes #183 

### ⚡️ What's your motivation? 

<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] Users should know about my change
  - [x] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
