### PR TITLE
Added order parameter to stepArgumentTransformation to prioritize execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Reqnroll.Verify: Support for Verify v24 (Verify.Xunit v24.2.0) for .NET 4.7.2+ and .NET 6.0+. For earlier versions of Verify or for .NET 4.6.2, use the latest 2.0.3 version of the plugin that is compatible with Reqnroll v2.*. (#151)
 * Optimize creation of test-thread context using test framework independent resource pooling (#144)
 * Support DateTimeOffset in value comparer (#180)
+* Support 'Order' parameter for `StepArgumentTransformationAttribute` to prioritize execution
 
 ## Bug fixes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@
 * Reqnroll.Verify: Support for Verify v24 (Verify.Xunit v24.2.0) for .NET 4.7.2+ and .NET 6.0+. For earlier versions of Verify or for .NET 4.6.2, use the latest 2.0.3 version of the plugin that is compatible with Reqnroll v2.*. (#151)
 * Optimize creation of test-thread context using test framework independent resource pooling (#144)
 * Support DateTimeOffset in value comparer (#180)
-* Support 'Order' parameter for `StepArgumentTransformationAttribute` to prioritize execution
+* Support 'Order' parameter for `StepArgumentTransformationAttribute` to prioritize execution (#185)
 
 ## Bug fixes:
 
-*Contributors of this release (in alphabetical order):* @ajeckmans, @cimnine, @obligaron
+*Contributors of this release (in alphabetical order):* @ajeckmans, @cimnine, @obligaron, @stbychkov
 
 # v2.0.3 - 2024-06-10
 

--- a/Reqnroll/Bindings/BindingFactory.cs
+++ b/Reqnroll/Bindings/BindingFactory.cs
@@ -25,7 +25,8 @@ public class BindingFactory(
     }
 
     public IStepArgumentTransformationBinding CreateStepArgumentTransformation(string regexString,
-        IBindingMethod bindingMethod, string parameterTypeName = null, int order = default)
+        IBindingMethod bindingMethod, string parameterTypeName = null, 
+        int order = StepArgumentTransformationAttribute.DefaultOrder)
     {
         return new StepArgumentTransformationBinding(regexString, bindingMethod, parameterTypeName, order);
     }

--- a/Reqnroll/Bindings/BindingFactory.cs
+++ b/Reqnroll/Bindings/BindingFactory.cs
@@ -25,8 +25,8 @@ public class BindingFactory(
     }
 
     public IStepArgumentTransformationBinding CreateStepArgumentTransformation(string regexString,
-        IBindingMethod bindingMethod, string parameterTypeName = null)
+        IBindingMethod bindingMethod, string parameterTypeName = null, int order = default)
     {
-        return new StepArgumentTransformationBinding(regexString, bindingMethod, parameterTypeName);
+        return new StepArgumentTransformationBinding(regexString, bindingMethod, parameterTypeName, order);
     }
 }

--- a/Reqnroll/Bindings/BindingRegistry.cs
+++ b/Reqnroll/Bindings/BindingRegistry.cs
@@ -46,7 +46,7 @@ namespace Reqnroll.Bindings
 
         public virtual IEnumerable<IStepArgumentTransformationBinding> GetStepTransformations()
         {
-            return _stepArgumentTransformations;
+            return _stepArgumentTransformations.OrderBy(s => s.Order);
         }
 
         public IEnumerable<BindingError> GetErrorMessages()

--- a/Reqnroll/Bindings/Discovery/BindingSourceProcessor.cs
+++ b/Reqnroll/Bindings/Discovery/BindingSourceProcessor.cs
@@ -199,6 +199,7 @@ namespace Reqnroll.Bindings.Discovery
         {
             string regex = stepArgumentTransformationAttribute.TryGetAttributeValue<string>(0) ?? stepArgumentTransformationAttribute.TryGetAttributeValue<string>(nameof(StepArgumentTransformationAttribute.Regex));
             string name = stepArgumentTransformationAttribute.TryGetAttributeValue<string>(nameof(StepArgumentTransformationAttribute.Name));
+            int order = stepArgumentTransformationAttribute.TryGetAttributeValue<int>(nameof(StepArgumentTransformationAttribute.Order));
 
             var validationResult = ValidateStepArgumentTransformation(bindingSourceMethod, stepArgumentTransformationAttribute);
             if (!validationResult.IsValid)
@@ -207,7 +208,7 @@ namespace Reqnroll.Bindings.Discovery
                 return;
             }
 
-            var stepArgumentTransformationBinding = _bindingFactory.CreateStepArgumentTransformation(regex, bindingSourceMethod.BindingMethod, name);
+            var stepArgumentTransformationBinding = _bindingFactory.CreateStepArgumentTransformation(regex, bindingSourceMethod.BindingMethod, name, order);
 
             ProcessStepArgumentTransformationBinding(stepArgumentTransformationBinding);
         }

--- a/Reqnroll/Bindings/Discovery/BindingSourceProcessor.cs
+++ b/Reqnroll/Bindings/Discovery/BindingSourceProcessor.cs
@@ -199,7 +199,7 @@ namespace Reqnroll.Bindings.Discovery
         {
             string regex = stepArgumentTransformationAttribute.TryGetAttributeValue<string>(0) ?? stepArgumentTransformationAttribute.TryGetAttributeValue<string>(nameof(StepArgumentTransformationAttribute.Regex));
             string name = stepArgumentTransformationAttribute.TryGetAttributeValue<string>(nameof(StepArgumentTransformationAttribute.Name));
-            int order = stepArgumentTransformationAttribute.TryGetAttributeValue<int>(nameof(StepArgumentTransformationAttribute.Order));
+            int order = stepArgumentTransformationAttribute.TryGetAttributeValue(nameof(StepArgumentTransformationAttribute.Order), StepArgumentTransformationAttribute.DefaultOrder);
 
             var validationResult = ValidateStepArgumentTransformation(bindingSourceMethod, stepArgumentTransformationAttribute);
             if (!validationResult.IsValid)

--- a/Reqnroll/Bindings/IBindingFactory.cs
+++ b/Reqnroll/Bindings/IBindingFactory.cs
@@ -11,6 +11,6 @@ namespace Reqnroll.Bindings
             BindingScope bindingScope, string expressionString);
 
         IStepArgumentTransformationBinding CreateStepArgumentTransformation(string regexString,
-            IBindingMethod bindingMethod, string parameterTypeName = null);
+            IBindingMethod bindingMethod, string parameterTypeName = null, int order = default);
     }
 }

--- a/Reqnroll/Bindings/IBindingFactory.cs
+++ b/Reqnroll/Bindings/IBindingFactory.cs
@@ -11,6 +11,7 @@ namespace Reqnroll.Bindings
             BindingScope bindingScope, string expressionString);
 
         IStepArgumentTransformationBinding CreateStepArgumentTransformation(string regexString,
-            IBindingMethod bindingMethod, string parameterTypeName = null, int order = default);
+            IBindingMethod bindingMethod, string parameterTypeName = null,
+            int order = StepArgumentTransformationAttribute.DefaultOrder);
     }
 }

--- a/Reqnroll/Bindings/IStepArgumentTransformationBinding.cs
+++ b/Reqnroll/Bindings/IStepArgumentTransformationBinding.cs
@@ -16,5 +16,10 @@ namespace Reqnroll.Bindings
         /// The regular expression matches the step argument. Optional, if null, the transformation receives the entire argument.
         /// </summary>
         Regex Regex { get; }
+        
+        /// <summary>
+        /// The deterministic order for step argument transformation
+        /// </summary>
+        int Order { get; }
     }
 }

--- a/Reqnroll/Bindings/StepArgumentTransformationBinding.cs
+++ b/Reqnroll/Bindings/StepArgumentTransformationBinding.cs
@@ -8,16 +8,19 @@ namespace Reqnroll.Bindings
         public string Name { get; }
 
         public Regex Regex { get; }
+        
+        public int Order { get; }
 
-        public StepArgumentTransformationBinding(Regex regex, IBindingMethod bindingMethod, string name = null)
+        public StepArgumentTransformationBinding(Regex regex, IBindingMethod bindingMethod, string name = null, int order = default)
             : base(bindingMethod)
         {
             Regex = regex;
             Name = name;
+            Order = order;
         }
 
-        public StepArgumentTransformationBinding(string regexString, IBindingMethod bindingMethod, string name = null)
-            : this(CreateRegexOrNull(regexString), bindingMethod, name)
+        public StepArgumentTransformationBinding(string regexString, IBindingMethod bindingMethod, string name = null, int order = default)
+            : this(CreateRegexOrNull(regexString), bindingMethod, name, order)
         {
         }
 

--- a/Reqnroll/Bindings/StepArgumentTransformationBinding.cs
+++ b/Reqnroll/Bindings/StepArgumentTransformationBinding.cs
@@ -11,7 +11,8 @@ namespace Reqnroll.Bindings
         
         public int Order { get; }
 
-        public StepArgumentTransformationBinding(Regex regex, IBindingMethod bindingMethod, string name = null, int order = default)
+        public StepArgumentTransformationBinding(Regex regex, IBindingMethod bindingMethod, string name = null, 
+            int order = StepArgumentTransformationAttribute.DefaultOrder)
             : base(bindingMethod)
         {
             Regex = regex;
@@ -19,7 +20,8 @@ namespace Reqnroll.Bindings
             Order = order;
         }
 
-        public StepArgumentTransformationBinding(string regexString, IBindingMethod bindingMethod, string name = null, int order = default)
+        public StepArgumentTransformationBinding(string regexString, IBindingMethod bindingMethod, string name = null, 
+            int order = StepArgumentTransformationAttribute.DefaultOrder)
             : this(CreateRegexOrNull(regexString), bindingMethod, name, order)
         {
         }

--- a/Reqnroll/Bindings/StepArgumentTypeConverter.cs
+++ b/Reqnroll/Bindings/StepArgumentTypeConverter.cs
@@ -29,13 +29,18 @@ namespace Reqnroll.Bindings
         protected virtual IStepArgumentTransformationBinding GetMatchingStepTransformation(object value, IBindingType typeToConvertTo, bool traceWarning)
         {
             var stepTransformations = bindingRegistry.GetStepTransformations().Where(t => CanConvert(t, value, typeToConvertTo)).ToArray();
-            if (stepTransformations.Length > 1 && traceWarning)
+            if (traceWarning && HasMultipleTransformationsWithSameOrder(stepTransformations))
             {
                 testTracer.TraceWarning($"Multiple step transformation matches to the input ({value}, target type: {typeToConvertTo}). We use the first.");
             }
 
             return stepTransformations.Length > 0 ? stepTransformations[0] : null;
         }
+
+        private bool HasMultipleTransformationsWithSameOrder(IStepArgumentTransformationBinding[] transformations) =>
+            transformations
+                .GroupBy(t => t.Order)
+                .Any(group => group.Count() > 1);
 
         public async Task<object> ConvertAsync(object value, IBindingType typeToConvertTo, CultureInfo cultureInfo)
         {

--- a/Reqnroll/StepArgumentTransformationAttribute.cs
+++ b/Reqnroll/StepArgumentTransformationAttribute.cs
@@ -17,9 +17,17 @@ namespace Reqnroll
         /// </summary>
         public string Name { get; set; }
 
-        public StepArgumentTransformationAttribute(string regex)
+        /// <summary>
+        /// Specifies the deterministic order for step argument transformations. Lower numbers have higher priority.
+        /// Before .NET 7, step argument transformations with the same priority will execute in a non-deterministic order.
+        /// Default value is 0.
+        /// </summary>
+        public int Order { get; set; }
+
+        public StepArgumentTransformationAttribute(string regex, int order = default)
         {
             Regex = regex;
+            Order = order;
         }
 
         public StepArgumentTransformationAttribute()

--- a/Reqnroll/StepArgumentTransformationAttribute.cs
+++ b/Reqnroll/StepArgumentTransformationAttribute.cs
@@ -19,12 +19,13 @@ namespace Reqnroll
 
         /// <summary>
         /// Specifies the deterministic order for step argument transformations. Lower numbers have higher priority.
-        /// Before .NET 7, step argument transformations with the same priority will execute in a non-deterministic order.
-        /// Default value is 0.
+        /// Default value is <see cref="StepArgumentTransformationAttribute.DefaultOrder">10000</see>.
         /// </summary>
         public int Order { get; set; }
+        
+        public const int DefaultOrder = 10000;
 
-        public StepArgumentTransformationAttribute(string regex, int order = default)
+        public StepArgumentTransformationAttribute(string regex, int order = DefaultOrder)
         {
             Regex = regex;
             Order = order;

--- a/Tests/Reqnroll.RuntimeTests/Bindings/BindingRegistryTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/Bindings/BindingRegistryTests.cs
@@ -40,5 +40,25 @@ namespace Reqnroll.RuntimeTests.Bindings
 
             result.Should().BeEquivalentTo(new List<HookBinding> { hook1, hook2 });
         }
+        
+        [Fact]
+        public void GetStepTransformations_should_return_all_step_transformers_in_correct_order()
+        {
+            var sut = new BindingRegistry();
+
+            var sat1 = new StepArgumentTransformationBinding(string.Empty, new Mock<IBindingMethod>().Object);
+            var sat2 = new StepArgumentTransformationBinding(string.Empty, new Mock<IBindingMethod>().Object);
+            var sat3 = new StepArgumentTransformationBinding(string.Empty, new Mock<IBindingMethod>().Object, order: 1);
+            var sat4 = new StepArgumentTransformationBinding(string.Empty, new Mock<IBindingMethod>().Object, null, 2);
+
+            sut.RegisterStepArgumentTransformationBinding(sat4);
+            sut.RegisterStepArgumentTransformationBinding(sat1);
+            sut.RegisterStepArgumentTransformationBinding(sat3);
+            sut.RegisterStepArgumentTransformationBinding(sat2);
+
+            var result = sut.GetStepTransformations();
+
+            result.Should().BeEquivalentTo(new List<StepArgumentTransformationBinding> { sat1, sat2, sat3, sat4 });
+        }
     }
 }

--- a/Tests/Reqnroll.RuntimeTests/RuntimeBindingRegistryBuilderTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/RuntimeBindingRegistryBuilderTests.cs
@@ -319,7 +319,7 @@ namespace Reqnroll.RuntimeTests
             Assert.Single(
                 bindingSourceProcessorStub.StepArgumentTransformationBindings,
                 sat =>
-                    sat.Method.Name == nameof(StepTransformationExample.Transform) && sat.Order == default);
+                    sat.Method.Name == nameof(StepTransformationExample.Transform) && sat.Order == StepArgumentTransformationAttribute.DefaultOrder);
             
             Assert.Single(
                 bindingSourceProcessorStub.StepArgumentTransformationBindings,

--- a/Tests/Reqnroll.RuntimeTests/RuntimeBindingRegistryBuilderTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/RuntimeBindingRegistryBuilderTests.cs
@@ -21,29 +21,23 @@ namespace Reqnroll.RuntimeTests
         [Binding]
         public class StepTransformationExample
         {
-            [StepArgumentTransformation("prop1 .*")]
-            public int TransformProperty1(string val)
+            [StepArgumentTransformation("BindingRegistryTests")]
+            public int Transform(string val)
             {
                 return 42;
             }
             
-            [StepArgumentTransformation(Regex="prop2 .*")]
-            public int TransformProperty2(string val)
+            [StepArgumentTransformation(Regex="BindingRegistryTests2", Order = 5)]
+            public int TransformWithRegexAndOrder(string val)
             {
                 return 43;
             }
             
-            [StepArgumentTransformation(Regex="prop3 .*", Order = 5)]
-            public int TransformProperty3(string val)
+            [StepArgumentTransformation(Order = 10)]
+            public int TransformWithOrderAndWithoutRegex(string val)
             {
                 return 44;
-            }
-            
-            [StepArgumentTransformation(Order = 10)]
-            public int TransformGlobal(string val)
-            {
-                return 45;
-            }
+            } 
         }
 
         private BindingSourceProcessorStub bindingSourceProcessorStub;
@@ -325,22 +319,17 @@ namespace Reqnroll.RuntimeTests
             Assert.Single(
                 bindingSourceProcessorStub.StepArgumentTransformationBindings,
                 sat =>
-                    sat.Method.Name == nameof(StepTransformationExample.TransformProperty1) && sat.Order == default);
+                    sat.Method.Name == nameof(StepTransformationExample.Transform) && sat.Order == default);
             
             Assert.Single(
                 bindingSourceProcessorStub.StepArgumentTransformationBindings,
                 sat =>
-                    sat.Method.Name == nameof(StepTransformationExample.TransformProperty2) && sat.Order == default);
+                    sat.Method.Name == nameof(StepTransformationExample.TransformWithRegexAndOrder) && sat.Order == 5);
             
             Assert.Single(
                 bindingSourceProcessorStub.StepArgumentTransformationBindings,
                 sat =>
-                    sat.Method.Name == nameof(StepTransformationExample.TransformProperty3) && sat.Order == 5);
-            
-            Assert.Single(
-                bindingSourceProcessorStub.StepArgumentTransformationBindings,
-                sat =>
-                    sat.Method.Name == nameof(StepTransformationExample.TransformGlobal) && sat.Order == 10);
+                    sat.Method.Name == nameof(StepTransformationExample.TransformWithOrderAndWithoutRegex) && sat.Order == 10);
         }
 
         [Fact]

--- a/Tests/Reqnroll.RuntimeTests/RuntimeBindingRegistryBuilderTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/RuntimeBindingRegistryBuilderTests.cs
@@ -21,10 +21,28 @@ namespace Reqnroll.RuntimeTests
         [Binding]
         public class StepTransformationExample
         {
-            [StepArgumentTransformation("BindingRegistryTests")]
-            public int Transform(string val)
+            [StepArgumentTransformation("prop1 .*")]
+            public int TransformProperty1(string val)
             {
                 return 42;
+            }
+            
+            [StepArgumentTransformation(Regex="prop2 .*")]
+            public int TransformProperty2(string val)
+            {
+                return 43;
+            }
+            
+            [StepArgumentTransformation(Regex="prop3 .*", Order = 5)]
+            public int TransformProperty3(string val)
+            {
+                return 44;
+            }
+            
+            [StepArgumentTransformation(Order = 10)]
+            public int TransformGlobal(string val)
+            {
+                return 45;
             }
         }
 
@@ -295,6 +313,34 @@ namespace Reqnroll.RuntimeTests
                     s =>
                         s.HookType == HookType.AfterTestRun && s.Method.Name == "AfterOrderTenThousandAnd4" &&
                         s.HookOrder == 10004));
+        }
+        
+         [Fact]
+        public void ShouldFindStepArgumentTransformations_WithSpecifiedOrder()
+        {
+            var builder = CreateSut();
+
+            BuildCompleteBindingFromType(builder, typeof (StepTransformationExample));
+
+            Assert.Single(
+                bindingSourceProcessorStub.StepArgumentTransformationBindings,
+                sat =>
+                    sat.Method.Name == nameof(StepTransformationExample.TransformProperty1) && sat.Order == default);
+            
+            Assert.Single(
+                bindingSourceProcessorStub.StepArgumentTransformationBindings,
+                sat =>
+                    sat.Method.Name == nameof(StepTransformationExample.TransformProperty2) && sat.Order == default);
+            
+            Assert.Single(
+                bindingSourceProcessorStub.StepArgumentTransformationBindings,
+                sat =>
+                    sat.Method.Name == nameof(StepTransformationExample.TransformProperty3) && sat.Order == 5);
+            
+            Assert.Single(
+                bindingSourceProcessorStub.StepArgumentTransformationBindings,
+                sat =>
+                    sat.Method.Name == nameof(StepTransformationExample.TransformGlobal) && sat.Order == 10);
         }
 
         [Fact]

--- a/Tests/Reqnroll.RuntimeTests/StepArgumentTransformationTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/StepArgumentTransformationTests.cs
@@ -79,14 +79,14 @@ namespace Reqnroll.RuntimeTests
         }
     }
 
-    public class StepTransformationTests
+    public class StepArgumentTransformationTests
     {
         private readonly Mock<IBindingRegistry> bindingRegistryStub = new Mock<IBindingRegistry>();
         private readonly Mock<IContextManager> contextManagerStub = new Mock<IContextManager>();
         private readonly Mock<IAsyncBindingInvoker> methodBindingInvokerStub = new Mock<IAsyncBindingInvoker>();
         private readonly List<IStepArgumentTransformationBinding> stepTransformations = new List<IStepArgumentTransformationBinding>();
 
-        public StepTransformationTests()
+        public StepArgumentTransformationTests()
         {
             // ScenarioContext is needed, because the [Binding]-instances live there
             var scenarioContext = new ScenarioContext(new ObjectContainer(), null, new TestObjectResolver());

--- a/docs/automation/step-argument-conversions.md
+++ b/docs/automation/step-argument-conversions.md
@@ -18,7 +18,7 @@ A step argument transformation is used to convert an argument if:
 * The regular expression (if specified) matches the original (string) argument
 
 ```{note}
-If multiple matching transformations are available and no order is specified, a warning is output in the trace and the first transformation is used. If the order is specified, the transformation with the lowest order value is used.
+If multiple matching transformations are available, a warning is output in the trace and the first transformation is used.
 ```
 
 The following example transforms a relative period of time (`in 3 days`) into a `DateTime` structure.
@@ -68,6 +68,10 @@ public class Transforms
 }
 ```
 
+By default, selection among matching step argument transformations is undeterministic.
+To specify selection order, use the `Order` property in the `StepArgumentTransformation` attribute, where the transformation with lower numbers takes precedence. 
+If no order is specified, the default value is 10000.
+
 The following example transforms a string argument to a Rating model. If regex matches the expression, the given rating score will be parsed. Otherwise, the default rating will be used.
 
 ```{code-block} csharp
@@ -75,13 +79,13 @@ The following example transforms a string argument to a Rating model. If regex m
 [Binding]
 public class Transforms
 {
-    [StepArgumentTransformation(@"with (\d+) score")]
+    [StepArgumentTransformation(@"with (\d+) score", Order = 1)]
     public Rating RatingTransformation(int score)
     {
       return new Rating(score);
     }
     
-    [StepArgumentTransformation(Order = 10)]
+    [StepArgumentTransformation]
     public Rating GlobalRatingTransformation(string input) 
     {
         return Rating.DefaultRating;

--- a/docs/automation/step-argument-conversions.md
+++ b/docs/automation/step-argument-conversions.md
@@ -18,7 +18,7 @@ A step argument transformation is used to convert an argument if:
 * The regular expression (if specified) matches the original (string) argument
 
 ```{note}
-If multiple matching transformation are available, a warning is output in the trace and the first transformation is used.
+If multiple matching transformations are available and no order is specified, a warning is output in the trace and the first transformation is used. If the order is specified, the transformation with the lowest order value is used.
 ```
 
 The following example transforms a relative period of time (`in 3 days`) into a `DateTime` structure.
@@ -65,6 +65,32 @@ public class Transforms
     {
        return booksTable.CreateSet<Books>();
     }
+}
+```
+
+The following example transforms a string argument to a Rating model. If regex matches the expression, the given rating score will be parsed. Otherwise, the default rating will be used.
+
+```{code-block} csharp
+:caption: C# File
+[Binding]
+public class Transforms
+{
+    [StepArgumentTransformation(@"with (\d+) score")]
+    public Rating RatingTransformation(int score)
+    {
+      return new Rating(score);
+    }
+    
+    [StepArgumentTransformation(Order = 10)]
+    public Rating GlobalRatingTransformation(string input) 
+    {
+        return Rating.DefaultRating;
+    }
+}
+
+public record Rating(int Value) 
+{
+    public static Rating DefaultRating => new Rating(50);
 }
 ```
 


### PR DESCRIPTION
### 🤔 What's changed?

* Added an optional `Order` parameter for `StepArgumentTransformation` to prioritize global type handlers effectively, ensuring they're considered last when needed.
* Renamed `StepTransformationTests` file to `StepArgumentTransformationTests` as this change should've be done with [this commit](https://github.com/reqnroll/Reqnroll/commit/63181711bc88437ef2d97bff4b7482a4e4982509)

### ⚡️ What's your motivation? 

> In .NET 6 and earlier versions, the [GetMethods](https://learn.microsoft.com/en-us/dotnet/api/system.type.getmethods?view=net-8.0) method does not return methods in a particular order, such as alphabetical or declaration order. Your code must not depend on the order in which methods are returned, because that order varies. However, starting with .NET 7, the ordering is deterministic based upon the metadata ordering in the assembly.

[(source)](https://learn.microsoft.com/en-us/dotnet/api/system.type.getmethods?view=net-8.0)

`Type.GetMethods` is used to find all `StepArgumentTransformation` functions, but the order is not deterministic before .NET 7. This inconsistency made it tricky to handle type transformations, especially when setting up global handlers for optional parameters.

### 🏷️ What kind of change is this?

- :book: Documentation (improvements without changing code)
- :zap: New feature (non-breaking change which adds new behaviour)

### 📋 Checklist:

- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [x] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.
