### PR TITLE
Update mark-steps-as-not-implemented.md

### DIFF
--- a/docs/execution/mark-steps-as-not-implemented.md
+++ b/docs/execution/mark-steps-as-not-implemented.md
@@ -42,6 +42,6 @@ The `ScenarioContext` class has a static helper method to throw the default `Pen
 [When("I set the current ScenarioContext to pending")]
 public void WhenIHaveAPendingStep()
 {
-    ScenarioContext.Pending();
+    ScenarioContext.StepIsPending();
 }
 ```


### PR DESCRIPTION
### 🤔 What's changed?
The static method mentioned is called `StepIsPending`. The instance method is called `Pending` and could be called like `ScenarioContext.Current.Pending`.
The docs mention that there is a static helper method so I adjusted the example.

### ⚡️ What's your motivation?
Fix the docs!

### 🏷️ What kind of change is this?
- :book: Documentation (improvements without changing code)