### PR TITLE
Fix: Process cannot access the file when building a multi-target project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## Bug fixes:
 
 * Fix: Reqnroll.Autofac: Objects registered in the global container cannot be relsolved in BeforeTestRun/AfterTestRun hooks (#183)
+* Fix: Process cannot access the file when building a multi-target project (#197)
 
 *Contributors of this release (in alphabetical order):* @ajeckmans, @cimnine, @gasparnagy, @obligaron, @stbychkov
 

--- a/Reqnroll.Utils/FileSystemHelper.cs
+++ b/Reqnroll.Utils/FileSystemHelper.cs
@@ -103,10 +103,16 @@ namespace Reqnroll.Utils
         // files are not the same.
         public static bool FileCompareContent(string filePath1, string fileContent)
         {
-            var currentFileContent = File.ReadAllText(filePath1);
+            try
+            {
+                var currentFileContent = File.ReadAllText(filePath1);
 
-            return string.CompareOrdinal(currentFileContent, fileContent) == 0;
-
+                return string.CompareOrdinal(currentFileContent, fileContent) == 0;
+            }
+            catch (IOException)
+            {
+                return false;
+            }
         }
 
         public static string NormalizeDirectorySeparators(string path)


### PR DESCRIPTION
Fixes #197

### 🤔 What's changed?

When building a multi-targeted project, the build system may try to write the same file multiple times,
and this can cause an IOException ("The process cannot access the file because it is being used by another process."). See #197.

Once we move to Roslyn-based generation, this problem will go away, but for now, we use a workaround of retrying the write operation a few times (the content is anyway the same).

### ⚡️ What's your motivation? 

Fix #197 

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

I could not find a way to have automatic test for this. Even reproducing the issue is not trivial, even with larger feature file count.

I could only reproduce it by "slowing down" the file write, using the following method instead of `File.WriteAllText`:

```
private static void WriteAllText(string path, string contents, Encoding encoding)
{
    using (StreamWriter sw = new StreamWriter(path, false, encoding, 1024))
    {
        System.Threading.Thread.Sleep(100);
        sw.Write(contents);
    }
}
```

### 📋 Checklist:

- [x] I've changed the behaviour of the code
  - [x] I have done manual checks to verify the fix
- [x] Users should know about my change
  - [x] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
