### PR TITLE
Added registration of ReqnrollFeatureFiles for Rider/ReSharper Build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,14 @@
 * Support DateTimeOffset in value comparer (#180)
 * Support 'Order' parameter for `StepArgumentTransformationAttribute` to prioritize execution (#185)
 * Upgrade to Gherkin v28 from v19 (see [Gherkin changelog](https://github.com/cucumber/gherkin/blob/main/CHANGELOG.md)) (#205)
+* Added registration of `ReqnrollFeatureFiles` for Rider/ReSharper Build (#231)
 
 ## Bug fixes:
 
 * Fix: Reqnroll.Autofac: Objects registered in the global container cannot be relsolved in BeforeTestRun/AfterTestRun hooks (#183)
 * Fix: Process cannot access the file when building a multi-target project (#197)
 
-*Contributors of this release (in alphabetical order):* @ajeckmans, @cimnine, @gasparnagy, @obligaron, @stbychkov
+*Contributors of this release (in alphabetical order):* @ajeckmans, @cimnine, @gasparnagy, @obligaron, @runnerok, @stbychkov
 
 # v2.0.3 - 2024-06-10
 

--- a/Reqnroll.Tools.MsBuild.Generation/build/Reqnroll.Tools.MsBuild.Generation.props
+++ b/Reqnroll.Tools.MsBuild.Generation/build/Reqnroll.Tools.MsBuild.Generation.props
@@ -44,6 +44,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+
+    <!-- Registration of custom item type for ReSharper Build -->
+    <!-- https://www.jetbrains.com/help/resharper/Building_Solution.html#supported-build-items -->
+    <AvailableItemName Include="ReqnrollFeatureFiles"/>
+    
     <ReqnrollFeatureFiles Include="**\*.feature" >
       <CodeBehindFile>%(RelativeDir)%(Filename).feature$(DefaultLanguageSourceExtension)</CodeBehindFile>
       <Visible>$(UsingMicrosoftNETSdk)</Visible>


### PR DESCRIPTION
<!---
Thanks for helping to make Reqnroll better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻

You can delete these comment sections as you process them.
-->

### 🤔 What's changed?

Added registration of custom "ReqnrollFeatureFiles" type in Reqnroll.Tools.MsBuild.Generation.props

Per [suggestion](https://github.com/reqnroll/Reqnroll.Rider/issues/1#issuecomment-2050945048) from @Socolin

### ⚡️ What's your motivation? 
#57 and [issue](https://github.com/reqnroll/Reqnroll.Rider/issues/1) in Reqnroll.Rider

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

In my understanding this change shouldn't break anything for Visual Studio, but if i'm not correct please let me know

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->
<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->
----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
