### PR TITLE
fix: optional regex groups

### DIFF
--- a/Reqnroll/Infrastructure/StepDefinitionMatchService.cs
+++ b/Reqnroll/Infrastructure/StepDefinitionMatchService.cs
@@ -38,9 +38,9 @@ namespace Reqnroll.Infrastructure
             _errorProvider = errorProvider;
         }
 
-        private object[] CalculateArguments(Match match, StepInstance stepInstance)
+        private object[] CalculateArguments(Match match, StepInstance stepInstance, bool isRegularExpression)
         {
-            var regexArgs = match.Groups.Cast<Group>().Skip(1).Where(g => g.Success).Select(g => g.Value);
+            var regexArgs = match.Groups.Cast<Group>().Skip(1).Where(g => g.Success || isRegularExpression).Select(g => g.Value);
             var arguments = regexArgs.Cast<object>().ToList();
             if (stepInstance.MultilineTextArgument != null)
                 arguments.Add(stepInstance.MultilineTextArgument);
@@ -85,7 +85,7 @@ namespace Reqnroll.Infrastructure
             if (useScopeMatching && stepDefinitionBinding.IsScoped && stepInstance.StepContext != null && !stepDefinitionBinding.BindingScope.Match(stepInstance.StepContext, out scopeMatches))
                 return BindingMatch.NonMatching;
 
-            var arguments = match == null ? Array.Empty<object>() : CalculateArguments(match, stepInstance);
+            var arguments = match == null ? Array.Empty<object>() : CalculateArguments(match, stepInstance, stepDefinitionBinding.ExpressionType == StepDefinitionExpressionTypes.RegularExpression);
 
             if (useParamMatching)
             {


### PR DESCRIPTION
<!---
Thanks for helping to make Reqnroll better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻

You can delete these comment sections as you process them.
-->

### 🤔 What's changed?
Fix to return old binding regex behavior from Specflow v3.9.74 [link](https://github.com/SpecFlowOSS/SpecFlow/blame/db3878239927cbb4418355bbd5091ae764a80024/TechTalk.SpecFlow/Infrastructure/StepDefinitionMatchService.cs#L40)
During implementation of `Cucumber expressions support ` in Specflow 4.0 beta this behaviour was changed by adding `Where(g => g.Success)` [here](https://github.com/SpecFlowOSS/SpecFlow/blame/8e0e7d4cecacc0dd3267f12c34477c30c84a2c37/TechTalk.SpecFlow/Infrastructure/StepDefinitionMatchService.cs#L43) 

In this PR I added condition to apply old way of CalculateArguments only for regex bindings.
<!-- Describe your changes in detail -->

### ⚡️ What's your motivation? 

<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->
This PR must fix different parameters for optional regex groups:
regex `Task finished(| in (\d+) seconds)` based on input is resolved with 1-2 parameters
* `Task finished` - 1 parameter with emtpy string
* `Task finished in 10 seconds` - 2 parameters "in 10 seconds" and "10"

In Specflow 3.9.74 this regex was always resolved with 2 parameters.

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [X] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
