### PR TITLE
feat: move CalculateArguments to MatchArgumentCalculator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Support 'Order' parameter for `StepArgumentTransformationAttribute` to prioritize execution (#185)
 * Upgrade to Gherkin v29 from v19 (see [Gherkin changelog](https://github.com/cucumber/gherkin/blob/main/CHANGELOG.md)) (#205, #240)
 * Added registration of `ReqnrollFeatureFiles` for Rider/ReSharper Build (#231)
+* Added option to override regex group matching behavior (#243)
 
 ## Bug fixes:
 
@@ -16,7 +17,7 @@
 * Fix: Process cannot access the file when building a multi-target project (#197)
 * Fix: Project dependencies transiently refer to System.Net.Http <= v4.3.0 that has high severity security vulnerability (#240)
 
-*Contributors of this release (in alphabetical order):* @ajeckmans, @cimnine, @gasparnagy, @obligaron, @runnerok, @stbychkov
+*Contributors of this release (in alphabetical order):* @ajeckmans, @cimnine, @gasparnagy, @obligaron, @olegKoshmeliuk, @runnerok, @stbychkov
 
 # v2.0.3 - 2024-06-10
 

--- a/Reqnroll/Infrastructure/DefaultDependencyProvider.cs
+++ b/Reqnroll/Infrastructure/DefaultDependencyProvider.cs
@@ -47,6 +47,7 @@ namespace Reqnroll.Infrastructure
             container.RegisterTypeAs<CucumberExpressionStepDefinitionBindingBuilderFactory, ICucumberExpressionStepDefinitionBindingBuilderFactory>();
             container.RegisterTypeAs<CucumberExpressionDetector, ICucumberExpressionDetector>();
             container.RegisterTypeAs<StepDefinitionRegexCalculator, IStepDefinitionRegexCalculator>();
+            container.RegisterTypeAs<MatchArgumentCalculator, IMatchArgumentCalculator>();
 #pragma warning disable CS0618
             container.RegisterTypeAs<BindingInvoker, IBindingInvoker>();
 #pragma warning restore CS0618

--- a/Reqnroll/Infrastructure/MatchArgumentCalculator.cs
+++ b/Reqnroll/Infrastructure/MatchArgumentCalculator.cs
@@ -1,0 +1,26 @@
+﻿using Reqnroll.Bindings;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Reqnroll.Infrastructure
+{
+    public interface IMatchArgumentCalculator
+    {
+        object[] CalculateArguments(Match match, StepInstance stepInstance, IStepDefinitionBinding stepDefinitionBinding);
+    }
+
+    public class MatchArgumentCalculator : IMatchArgumentCalculator
+    {
+        public object[] CalculateArguments(Match match, StepInstance stepInstance, IStepDefinitionBinding stepDefinitionBinding)
+        {
+            var regexArgs = match.Groups.Cast<Group>().Skip(1).Where(g => g.Success).Select(g => g.Value);
+            var arguments = regexArgs.Cast<object>().ToList();
+            if (stepInstance.MultilineTextArgument != null)
+                arguments.Add(stepInstance.MultilineTextArgument);
+            if (stepInstance.TableArgument != null)
+                arguments.Add(stepInstance.TableArgument);
+
+            return arguments.ToArray();
+        }
+    }
+}

--- a/Tests/Reqnroll.RuntimeTests/Infrastructure/StepDefinitionMatchServiceTest.cs
+++ b/Tests/Reqnroll.RuntimeTests/Infrastructure/StepDefinitionMatchServiceTest.cs
@@ -31,7 +31,7 @@ namespace Reqnroll.RuntimeTests.Infrastructure
 
         private StepDefinitionMatchService CreateSUT()
         {
-            return new StepDefinitionMatchService(bindingRegistryMock.Object, stepArgumentTypeConverterMock.Object, new StubErrorProvider());
+            return new StepDefinitionMatchService(bindingRegistryMock.Object, stepArgumentTypeConverterMock.Object, new StubErrorProvider(), new MatchArgumentCalculator());
         }
 
         private static BindingMethod CreateBindingMethod(string name = "dummy")


### PR DESCRIPTION
### 🤔 What's changed?

As suggested in https://github.com/reqnroll/Reqnroll/pull/238#pullrequestreview-2260350422
Moved CalculateArguments to MatchArgumentCalculator. 

### ⚡️ What's your motivation? 

Allow override of how Reqnroll calculates parameters with old/legacy behavior.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behavior)

### ♻️ Anything particular you want feedback on?

I don't see useful writing tests for this new class or testing _StepDefinitionMatchService_ with mock MatchArgumentCalculator.

An alternative approach can be done by just changing **CalculateArguments** to protected virtual that will not require updating tests

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [ ] I've changed the behavior of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
