### PR TITLE
Force the VersionInfo class to use Assembly.GetExecutingAssembly() 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,10 @@
 ## Improvements:
 
 ## Bug fixes:
+* Modified VersionInfo class to force it to pull version information from the Reqnroll assembly
 
 *Contributors of this release (in alphabetical order):* 
+* clrudolphi
 
 # v2.1.0 - 2024-08-30
 

--- a/Reqnroll/VersionInfo.cs
+++ b/Reqnroll/VersionInfo.cs
@@ -11,7 +11,7 @@ internal class VersionInfo
 
     static VersionInfo()
     {
-        var assembly = Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly();
+        var assembly = Assembly.GetExecutingAssembly();
         AssemblyVersion = assembly.GetName().Version.ToString();
         AssemblyFileVersion = assembly.GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version;
         AssemblyInformationalVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;


### PR DESCRIPTION
### 🤔 What's changed?
Force the VersionInfo class to use Assembly.GetExecutingAssembly() in order to reliably obtain version information about Reqnroll.
### ⚡️ What's your motivation? 

Existing code calls Assembly.GetEntryAssembly(), which would return the test framework being used (NUnit, MSTest or XUnit).

Impact of this change is limited as the only consumer within Reqnroll is the AnalyticsEventProvider.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?



### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [x ] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.
