### PR TITLE
Fix for #271 Fix External Data Plugin support of Rule Background Steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # [vNext]
-
+* Fix: Rule Backgounds cause External Data Plugin to fail (#271) @clrudolphi
 ## Bug fixes:
 * Modified VersionInfo class to force it to pull version information from the Reqnroll assembly
 * Fix: Reqnroll.CustomPlugin NuGet package has a version mismatch for the System.CodeDom dependency (#244)

--- a/Plugins/Reqnroll.ExternalData/Reqnroll.ExternalData.ReqnrollPlugin.IntegrationTest/Features/ExternalDataWithRuleBackgroundFromCSV.feature
+++ b/Plugins/Reqnroll.ExternalData/Reqnroll.ExternalData.ReqnrollPlugin.IntegrationTest/Features/ExternalDataWithRuleBackgroundFromCSV.feature
@@ -1,0 +1,17 @@
+﻿Feature: ExternalDataWithRuleBackgroundFromCSV
+
+This feature demonstrates that Rule Background steps are handled appropriately when using the External Data Plugin.
+This test validates a regression.
+
+Rule: Steps in Background are properly executed
+	Background:
+	Given my favorite color is blue
+@DataSource:products.csv
+Scenario: The basket price is calculated correctly
+	The scenario will be treated as a scenario outline with the examples from the CSV file.
+	The CSV file contains multile fields, including product and price.
+	Given the price of <product> is €<price>
+	And the customer has put 1 pcs of <product> to the basket
+	When the basket price is calculated
+	Then the basket price should be €<price>
+	And the color given as my favorite was blue

--- a/Plugins/Reqnroll.ExternalData/Reqnroll.ExternalData.ReqnrollPlugin.IntegrationTest/StepDefinitions/BackgroundStepsDefinitions.cs
+++ b/Plugins/Reqnroll.ExternalData/Reqnroll.ExternalData.ReqnrollPlugin.IntegrationTest/StepDefinitions/BackgroundStepsDefinitions.cs
@@ -1,0 +1,28 @@
+﻿using NUnit.Framework;
+using Reqnroll;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace XReqnroll.ExternalData.ReqnrollPlugin.IntegrationTest.StepDefinitions
+{
+    [Binding]
+    internal class BackgroundStepsDefinitions
+    {
+        [Given("my favorite color is {word}")]
+        public void GivenMyFavoriteColorIs(string color)
+        {
+            _color = color;
+        }
+
+        private string _color;
+
+        [Then("the color given as my favorite was {word}")]
+        public void ThenTheColorGivenAsMyFavoriteWas(string color)
+        {
+            Assert.That(_color, Is.EqualTo(color));
+        }
+    }
+}

--- a/Plugins/Reqnroll.ExternalData/Reqnroll.ExternalData.ReqnrollPlugin/Transformation/GherkinDocumentVisitor.cs
+++ b/Plugins/Reqnroll.ExternalData/Reqnroll.ExternalData.ReqnrollPlugin/Transformation/GherkinDocumentVisitor.cs
@@ -69,7 +69,8 @@ namespace Reqnroll.ExternalData.ReqnrollPlugin.Transformation
             OnRuleVisiting(rule);
             foreach (var ruleChild in rule.Children)
             {
-                if (ruleChild is ScenarioOutline scenarioOutline) AcceptScenarioOutline(scenarioOutline);
+                if (ruleChild is Background background) AcceptBackground(background);
+                else if (ruleChild is ScenarioOutline scenarioOutline) AcceptScenarioOutline(scenarioOutline);
                 else if (ruleChild is Scenario scenario) AcceptScenario(scenario);
             }
             OnRuleVisited(rule);

--- a/Plugins/Reqnroll.ExternalData/Reqnroll.ExternalData.ReqnrollPlugin/Transformation/ScenarioTransformation.cs
+++ b/Plugins/Reqnroll.ExternalData/Reqnroll.ExternalData.ReqnrollPlugin/Transformation/ScenarioTransformation.cs
@@ -66,7 +66,7 @@ namespace Reqnroll.ExternalData.ReqnrollPlugin.Transformation
 
         protected override void OnBackgroundVisited(Background background)
         {
-            _featureChildren.Add(background);
+            _currentChildren.Add(background);
         }
 
         protected override void OnRuleVisiting(Rule rule)


### PR DESCRIPTION

### 🤔 What's changed?

Modified the AST visitor used by the External Data Plugin that modifies Feature ASTs such that is properly navigates through Rules and Rule Backgrounds.
This fixes the error reported in #271 

### ⚡️ What's your motivation? 

Found this bug while testing a similar implementation for Cucumber Messages. Rule Background steps should be properly handled by all Reqnroll components.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?



### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [X ] I've changed the behaviour of the code
  - [X ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [X ] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

