### PR TITLE
Fix: Reqnroll generates invalid code for rule backgrounds in Visual Basic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 # [vNext]
-* Fix: Rule Backgounds cause External Data Plugin to fail (#271) @clrudolphi
-## Bug fixes:
-* Modified VersionInfo class to force it to pull version information from the Reqnroll assembly
-* Fix: Reqnroll.CustomPlugin NuGet package has a version mismatch for the System.CodeDom dependency (#244)
-* Reqnroll.Verify fails to run parallel tests determinately (#254). See our [verify documentation](docs/integrations/verify.md) on how to set up your test code to enable parallel testing.
 
-*Contributors of this release (in alphabetical order):* @ajeckmans, @clrudolphi, @UL-ChrisGlew
+## Bug fixes:
+
+* Fix: Rule Backgounds cause External Data Plugin to fail (#271)
+* Fix: VersionInfo class might provide the version of the runner instead of the version of Reqnroll (#248)
+* Fix: Reqnroll.CustomPlugin NuGet package has a version mismatch for the System.CodeDom dependency (#244)
+* Fix: Reqnroll.Verify fails to run parallel tests determinately (#254). See our [verify documentation](docs/integrations/verify.md) on how to set up your test code to enable parallel testing.
+* Fix: Reqnroll generates invalid code for rule backgrounds in Visual Basic (#283)
+
+*Contributors of this release (in alphabetical order):* @ajeckmans, @clrudolphi, @gasparnagy, @UL-ChrisGlew
 
 # v2.1.0 - 2024-08-30
 

--- a/Reqnroll.Generator/CodeDom/CodeDomHelper.cs
+++ b/Reqnroll.Generator/CodeDom/CodeDomHelper.cs
@@ -107,7 +107,7 @@ namespace Reqnroll.Generator.CodeDom
                 case CodeDomProviderLanguage.CSharp:
                     return new CodeSnippetStatement("#pragma warning disable");
                 case CodeDomProviderLanguage.VB:
-                    return new CodeCommentStatement("#pragma warning disable"); //not supported in VB
+                    return new CodeSnippetStatement("#Disable Warning BC42356"); //in VB warning codes must be listed explicitly
             }
             return new CodeCommentStatement("#pragma warning disable");
         }
@@ -119,7 +119,7 @@ namespace Reqnroll.Generator.CodeDom
                 case CodeDomProviderLanguage.CSharp:
                     return new CodeSnippetStatement("#pragma warning restore");
                 case CodeDomProviderLanguage.VB:
-                    return new CodeCommentStatement("#pragma warning restore"); //not supported in VB
+                    return new CodeSnippetStatement("#Enable Warning BC42356"); //in VB warning codes must be listed explicitly
             }
             return new CodeCommentStatement("#pragma warning restore");
         }

--- a/Reqnroll.Generator/Generation/ScenarioPartHelper.cs
+++ b/Reqnroll.Generator/Generation/ScenarioPartHelper.cs
@@ -68,12 +68,9 @@ namespace Reqnroll.Generator.Generation
             if (background == null) return new List<CodeStatement>();
 
             var statements = new List<CodeStatement>();
-            using (new SourceLineScope(_reqnrollConfiguration, _codeDomHelper, statements, context.Document.SourceFilePath, background.Location))
+            foreach (var step in background.Steps)
             {
-                foreach (var step in background.Steps)
-                {
-                    GenerateStep(context, statements, step, null);
-                }
+                GenerateStep(context, statements, step, null);
             }
 
             return statements;

--- a/Tests/Reqnroll.SystemTests/Generation/GenerationTestBase.cs
+++ b/Tests/Reqnroll.SystemTests/Generation/GenerationTestBase.cs
@@ -22,6 +22,18 @@ public abstract class GenerationTestBase : SystemTestBase
     }
 
     [TestMethod]
+    public void GeneratorAllIn_sample_can_be_handled_with_VisualBasic()
+    {
+        _testRunConfiguration.ProgrammingLanguage = ProgrammingLanguage.VB;
+
+        PrepareGeneratorAllInSamples();
+
+        ExecuteTests();
+
+        ShouldAllScenariosPass();
+    }
+
+    [TestMethod]
     public void Handles_simple_scenarios_without_namespace_collisions()
     {
         _projectsDriver.CreateProject("CollidingNamespace.Reqnroll", "C#");


### PR DESCRIPTION
### 🤔 What's changed?

Fixes #283 

The important bit is just the removal of the unnecessary `using (new SourceLineScope(_reqnrollConfiguration, _codeDomHelper, statements, context.Document.SourceFilePath, background.Location))` line from the `ScenarioPartHelper` class, the rest is just to have a test.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] Users should know about my change
  - [x] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
