### PR TITLE
Enable to use TaskHostFactory on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ## Bug fixes:
 
-*Contributors of this release (in alphabetical order): @obligaron* 
+* Fix: Visual Studio locks Reqnroll.Tools.MsBuild.Generation task files. Using `TaskHostFactory` for our tasks on Windows. (#293)
+
+*Contributors of this release (in alphabetical order):* @gasparnagy, @obligaron, @Tiberriver256
 
 # v2.1.1 - 2024-10-08
 

--- a/Reqnroll.Tools.MsBuild.Generation/build/Reqnroll.Tools.MsBuild.Generation.props
+++ b/Reqnroll.Tools.MsBuild.Generation/build/Reqnroll.Tools.MsBuild.Generation.props
@@ -79,7 +79,7 @@
     <!-- Using `TaskHostFactory` ensures that the task assembly will not be locked by Visual Studio on Windows. See: https://learn.microsoft.com/en-us/visualstudio/msbuild/how-to-configure-targets-and-tasks?view=vs-2022#task-factories -->
     <!-- Note: `TaskHostFactory` is not compatible with some macOS versions. https://github.com/reqnroll/Reqnroll/issues/152 -->
     <_Reqnroll_TaskFactory Condition="'$(_Reqnroll_TaskFactory)' == '' And $([MSBuild]::IsOsPlatform('Windows'))">TaskHostFactory</_Reqnroll_TaskFactory>
-    <_Reqnroll_TaskFactory Condition="'$(_Reqnroll_TaskFactory)' == '' And Not($([MSBuild]::IsOsPlatform('Windows')))">AssemblyTaskFactory</_Reqnroll_TaskFactory>
+    <_Reqnroll_TaskFactory Condition="'$(_Reqnroll_TaskFactory)' == '' And !($([MSBuild]::IsOsPlatform('Windows')))">AssemblyTaskFactory</_Reqnroll_TaskFactory>
   </PropertyGroup>
 
   <Import Project="Reqnroll.Tools.MsBuild.Generation.tasks" Condition="'$(_ReqnrollTasksImported)' =='' " />

--- a/Reqnroll.Tools.MsBuild.Generation/build/Reqnroll.Tools.MsBuild.Generation.props
+++ b/Reqnroll.Tools.MsBuild.Generation/build/Reqnroll.Tools.MsBuild.Generation.props
@@ -75,6 +75,11 @@
     <_Reqnroll_TaskFolder Condition=" '$(MSBuildRuntimeType)' == 'Core' And '$(_Reqnroll_TaskFolder)' == ''">netstandard2.0</_Reqnroll_TaskFolder>
     <_Reqnroll_TaskFolder Condition=" '$(MSBuildRuntimeType)' != 'Core' And '$(_Reqnroll_TaskFolder)' == ''">net462</_Reqnroll_TaskFolder>
     <_Reqnroll_TaskAssembly Condition=" '$(_Reqnroll_TaskAssembly)' == '' ">..\tasks\$(_Reqnroll_TaskFolder)\Reqnroll.Tools.MsBuild.Generation.dll</_Reqnroll_TaskAssembly>
+
+    <!-- Using `TaskHostFactory` ensures that the task assembly will not be locked by Visual Studio on Windows. See: https://learn.microsoft.com/en-us/visualstudio/msbuild/how-to-configure-targets-and-tasks?view=vs-2022#task-factories -->
+    <!-- Note: `TaskHostFactory` is not compatible with some macOS versions. https://github.com/reqnroll/Reqnroll/issues/152 -->
+    <_Reqnroll_TaskFactory Condition="'$(_Reqnroll_TaskFactory)' == '' And $([MSBuild]::IsOsPlatform('Windows'))">TaskHostFactory</_Reqnroll_TaskFactory>
+    <_Reqnroll_TaskFactory Condition="'$(_Reqnroll_TaskFactory)' == '' And Not($([MSBuild]::IsOsPlatform('Windows')))">AssemblyTaskFactory</_Reqnroll_TaskFactory>
   </PropertyGroup>
 
   <Import Project="Reqnroll.Tools.MsBuild.Generation.tasks" Condition="'$(_ReqnrollTasksImported)' =='' " />

--- a/Reqnroll.Tools.MsBuild.Generation/build/Reqnroll.Tools.MsBuild.Generation.tasks
+++ b/Reqnroll.Tools.MsBuild.Generation/build/Reqnroll.Tools.MsBuild.Generation.tasks
@@ -1,6 +1,6 @@
 <Project>
-  <UsingTask TaskName="Reqnroll.Tools.MsBuild.Generation.GenerateFeatureFileCodeBehindTask" AssemblyFile="$(_Reqnroll_TaskAssembly)" />
-  <UsingTask TaskName="Reqnroll.Tools.MsBuild.Generation.ReplaceTokenInFileTask" AssemblyFile="$(_Reqnroll_TaskAssembly)" />
+  <UsingTask TaskName="Reqnroll.Tools.MsBuild.Generation.GenerateFeatureFileCodeBehindTask" AssemblyFile="$(_Reqnroll_TaskAssembly)" TaskFactory="$(_Reqnroll_TaskFactory)" />
+  <UsingTask TaskName="Reqnroll.Tools.MsBuild.Generation.ReplaceTokenInFileTask" AssemblyFile="$(_Reqnroll_TaskAssembly)" TaskFactory="$(_Reqnroll_TaskFactory)" />
 
   <PropertyGroup>
     <_ReqnrollTasksImported>true</_ReqnrollTasksImported>


### PR DESCRIPTION
### 🤔 What's changed?

This is a re-apply of #64 by @Tiberriver256 that we had to revert because it caused problems on MacOS (#152).

As the file locking issue still happens (at least for Reqnroll contributors), the solution was still desirable, but this PR enables it for Windows only. (On Linux and macOS there is [anyway no file locking](https://unix.stackexchange.com/questions/223573/does-linux-have-file-locking-protection-when-trying-to-rename-deleting-files).)

### ⚡️ What's your motivation? 

Avoid task file locks

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

### 📋 Checklist:

- [x] I've changed the behaviour of the code
- [x] Users should know about my change
  - [x] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
