### PR TITLE
Improve System Test performance with stubbing dotnet new

### DIFF
--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/BaseCommandBuilder.cs
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/BaseCommandBuilder.cs
@@ -10,7 +10,7 @@ namespace Reqnroll.TestProjectGenerator.Dotnet
             _outputWriter = outputWriter;
         }
 
-        public CommandBuilder Build()
+        public virtual CommandBuilder Build()
         {
             return new CommandBuilder(_outputWriter, ExecutablePath, BuildArguments(), GetWorkingDirectory());
         }

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/CacheAndCopyCommandBuilder.cs
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/CacheAndCopyCommandBuilder.cs
@@ -6,14 +6,18 @@ namespace Reqnroll.TestProjectGenerator.Dotnet;
 
 public class CacheAndCopyCommandBuilder : CommandBuilder
 {
+    private const string TemplateName = "TName";
     private readonly CommandBuilder _baseCommandBuilder;
     private readonly string _targetPath;
+    private readonly string _nameToReplace;
     private static readonly ConcurrentDictionary<string, object> LockObjects = new();
 
-    public CacheAndCopyCommandBuilder(IOutputWriter outputWriter, CommandBuilder baseCommandBuilder, string targetPath) : base(outputWriter, baseCommandBuilder.ExecutablePath, baseCommandBuilder.ArgumentsFormat, baseCommandBuilder.WorkingDirectory)
+    public CacheAndCopyCommandBuilder(IOutputWriter outputWriter, CommandBuilder baseCommandBuilder, string targetPath, string nameToReplace = null) 
+        : base(outputWriter, baseCommandBuilder.ExecutablePath, baseCommandBuilder.ArgumentsFormat, baseCommandBuilder.WorkingDirectory)
     {
         _baseCommandBuilder = baseCommandBuilder;
         _targetPath = targetPath;
+        _nameToReplace = nameToReplace;
     }
 
     private string CalculateCacheTargetPath(string suffix = "")
@@ -21,6 +25,11 @@ public class CacheAndCopyCommandBuilder : CommandBuilder
         var targetPathInfo = new DirectoryInfo(_targetPath);
         var directoryName = targetPathInfo.Name;
         string argsCleaned = ArgumentsFormat.Replace(_targetPath, "").Replace(" ", "").Replace("\"", "")+directoryName;
+        if (_nameToReplace != null)
+        {
+            argsCleaned = argsCleaned.Replace(_nameToReplace, TemplateName);
+            directoryName = directoryName.Replace(_nameToReplace, TemplateName);
+        }
         return Path.Combine(Path.GetTempPath(), "RRC", $"RRC_{argsCleaned}{suffix}", directoryName);
     }
 
@@ -38,7 +47,9 @@ public class CacheAndCopyCommandBuilder : CommandBuilder
                 if (!Directory.Exists(cachePath))
                 {
                     var tempPath = CalculateCacheTargetPath($"-tmp{Guid.NewGuid():N}");
-                    var commandBuilder = new CommandBuilder(_outputWriter, ExecutablePath, ArgumentsFormat.Replace(_targetPath, tempPath), WorkingDirectory);
+                    var arguments = ArgumentsFormat.Replace(_targetPath, tempPath);
+                    if (_nameToReplace != null) arguments = arguments.Replace(_nameToReplace, TemplateName);
+                    var commandBuilder = new CommandBuilder(_outputWriter, ExecutablePath, arguments, WorkingDirectory);
 
                     originalResult = commandBuilder.Execute(exceptionFunction);
                     try
@@ -63,7 +74,7 @@ public class CacheAndCopyCommandBuilder : CommandBuilder
             }
         }
 
-        var copyFolderCommandBuilder = new CopyFolderCommandBuilder(_outputWriter, cachePath, _targetPath);
+        var copyFolderCommandBuilder = new CopyFolderCommandBuilder(_outputWriter, cachePath, _targetPath, TemplateName, _nameToReplace);
         var copyFolderResult = copyFolderCommandBuilder.Execute(exceptionFunction);
         return originalResult == null ? copyFolderResult : 
             new CommandResult(originalResult.ExitCode, originalResult.ConsoleOutput + Environment.NewLine + copyFolderResult.ConsoleOutput);

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/CacheAndCopyCommandBuilder.cs
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/CacheAndCopyCommandBuilder.cs
@@ -24,7 +24,7 @@ public class CacheAndCopyCommandBuilder : CommandBuilder
     {
         var targetPathInfo = new DirectoryInfo(_targetPath);
         var directoryName = targetPathInfo.Name;
-        string argsCleaned = ArgumentsFormat.Replace(_targetPath, "").Replace(" ", "").Replace("\"", "")+directoryName;
+        string argsCleaned = ArgumentsFormat.Replace(_targetPath, "").Replace(" ", "").Replace("\"", "").Replace("/", "") + directoryName;
         if (_nameToReplace != null)
         {
             argsCleaned = argsCleaned.Replace(_nameToReplace, TemplateName);

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/CacheAndCopyCommandBuilder.cs
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/CacheAndCopyCommandBuilder.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Reqnroll.TestProjectGenerator.FilesystemWriter;
+using System;
 using System.Collections.Concurrent;
 using System.IO;
 
@@ -7,14 +8,16 @@ namespace Reqnroll.TestProjectGenerator.Dotnet;
 public class CacheAndCopyCommandBuilder : CommandBuilder
 {
     private const string TemplateName = "TName";
+    private readonly NetCoreSdkInfo _sdk;
     private readonly CommandBuilder _baseCommandBuilder;
     private readonly string _targetPath;
     private readonly string _nameToReplace;
     private static readonly ConcurrentDictionary<string, object> LockObjects = new();
 
-    public CacheAndCopyCommandBuilder(IOutputWriter outputWriter, CommandBuilder baseCommandBuilder, string targetPath, string nameToReplace = null) 
+    public CacheAndCopyCommandBuilder(IOutputWriter outputWriter, NetCoreSdkInfo sdk, CommandBuilder baseCommandBuilder, string targetPath, string nameToReplace = null)
         : base(outputWriter, baseCommandBuilder.ExecutablePath, baseCommandBuilder.ArgumentsFormat, baseCommandBuilder.WorkingDirectory)
     {
+        _sdk = sdk;
         _baseCommandBuilder = baseCommandBuilder;
         _targetPath = targetPath;
         _nameToReplace = nameToReplace;
@@ -30,7 +33,7 @@ public class CacheAndCopyCommandBuilder : CommandBuilder
             argsCleaned = argsCleaned.Replace(_nameToReplace, TemplateName);
             directoryName = directoryName.Replace(_nameToReplace, TemplateName);
         }
-        return Path.Combine(Path.GetTempPath(), "RRC", $"RRC_{argsCleaned}{suffix}", directoryName);
+        return Path.Combine(Path.GetTempPath(), "RRC", $"RRC_{_sdk.Version}_{argsCleaned}{suffix}", directoryName);
     }
 
     public override CommandResult Execute(Func<Exception, Exception> exceptionFunction)

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/CacheAndCopyCommandBuilder.cs
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/CacheAndCopyCommandBuilder.cs
@@ -33,7 +33,9 @@ public class CacheAndCopyCommandBuilder : CommandBuilder
             argsCleaned = argsCleaned.Replace(_nameToReplace, TemplateName);
             directoryName = directoryName.Replace(_nameToReplace, TemplateName);
         }
-        return Path.Combine(Path.GetTempPath(), "RRC", $"RRC_{_sdk.Version}_{argsCleaned}{suffix}", directoryName);
+
+        var sdkSpecifier = _sdk == null ? "" : $"_{_sdk.Version}";
+        return Path.Combine(Path.GetTempPath(), "RRC", $"RRC{sdkSpecifier}_{argsCleaned}{suffix}", directoryName);
     }
 
     public override CommandResult Execute(Func<Exception, Exception> exceptionFunction)

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/CacheAndCopyCommandBuilder.cs
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/CacheAndCopyCommandBuilder.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.IO;
+
+namespace Reqnroll.TestProjectGenerator.Dotnet;
+
+public class CacheAndCopyCommandBuilder : CommandBuilder
+{
+    private readonly CommandBuilder _baseCommandBuilder;
+    private readonly string _targetPath;
+    private static readonly ConcurrentDictionary<string, object> LockObjects = new();
+
+    public CacheAndCopyCommandBuilder(IOutputWriter outputWriter, CommandBuilder baseCommandBuilder, string targetPath) : base(outputWriter, baseCommandBuilder.ExecutablePath, baseCommandBuilder.ArgumentsFormat, baseCommandBuilder.WorkingDirectory)
+    {
+        _baseCommandBuilder = baseCommandBuilder;
+        _targetPath = targetPath;
+    }
+
+    private string CalculateCacheTargetPath(string suffix = "")
+    {
+        var targetPathInfo = new DirectoryInfo(_targetPath);
+        var directoryName = targetPathInfo.Name;
+        string argsCleaned = ArgumentsFormat.Replace(_targetPath, "").Replace(" ", "").Replace("\"", "")+directoryName;
+        return Path.Combine(Path.GetTempPath(), "RRC", $"RRC_{argsCleaned}{suffix}", directoryName);
+    }
+
+    public override CommandResult Execute(Func<Exception, Exception> exceptionFunction)
+    {
+        var cachePath = CalculateCacheTargetPath();
+
+        CommandResult originalResult = null;
+        if (!Directory.Exists(cachePath))
+        {
+            LockObjects.TryAdd(cachePath, new object());
+
+            lock (LockObjects[cachePath])
+            {
+                if (!Directory.Exists(cachePath))
+                {
+                    var tempPath = CalculateCacheTargetPath($"-tmp{Guid.NewGuid():N}");
+                    var commandBuilder = new CommandBuilder(_outputWriter, ExecutablePath, ArgumentsFormat.Replace(_targetPath, tempPath), WorkingDirectory);
+
+                    originalResult = commandBuilder.Execute(exceptionFunction);
+                    try
+                    {
+                        if (!Directory.Exists(cachePath))
+                            Directory.Move(Path.Combine(tempPath, ".."), Path.Combine(cachePath, ".."));
+                    }
+                    catch (IOException ex)
+                    {
+                        _outputWriter.WriteLine($"Unable to move TMP to CACHE: {ex.Message}");
+                    }
+                    try
+                    {
+                        if (Directory.Exists(tempPath))
+                            Directory.Delete(Path.Combine(tempPath, ".."), true);
+                    }
+                    catch (IOException ex)
+                    {
+                        _outputWriter.WriteLine($"Unable to delete TMP: {ex.Message}");
+                    }
+                }
+            }
+        }
+
+        var copyFolderCommandBuilder = new CopyFolderCommandBuilder(_outputWriter, cachePath, _targetPath);
+        var copyFolderResult = copyFolderCommandBuilder.Execute(exceptionFunction);
+        return originalResult == null ? copyFolderResult : 
+            new CommandResult(originalResult.ExitCode, originalResult.ConsoleOutput + Environment.NewLine + copyFolderResult.ConsoleOutput);
+    }
+}

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/CommandBuilder.cs
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/CommandBuilder.cs
@@ -6,19 +6,19 @@ namespace Reqnroll.TestProjectGenerator.Dotnet
 {
     public class CommandBuilder
     {
-        private readonly IOutputWriter _outputWriter;
-        private readonly string _workingDirectory;
+        protected readonly IOutputWriter _outputWriter;
 
         public CommandBuilder(IOutputWriter outputWriter, string executablePath, string argumentsFormat, string workingDirectory)
         {
             _outputWriter = outputWriter;
-            _workingDirectory = workingDirectory;
+            WorkingDirectory = workingDirectory;
             ExecutablePath = executablePath;
             ArgumentsFormat = argumentsFormat;
         }
 
         public string ArgumentsFormat { get; }
         public string ExecutablePath { get; }
+        public string WorkingDirectory { get; }
 
         public CommandResult ExecuteWithRetry(int times, TimeSpan interval, Func<Exception, Exception> exceptionFunction)
         {
@@ -45,11 +45,11 @@ namespace Reqnroll.TestProjectGenerator.Dotnet
             return Execute(innerException => new Exception($"Error while executing {ExecutablePath} {ArgumentsFormat}", innerException));
         }
 
-        public CommandResult Execute(Func<Exception, Exception> exceptionFunction) 
+        public virtual CommandResult Execute(Func<Exception, Exception> exceptionFunction) 
         {
             var solutionCreateProcessHelper = new ProcessHelper();
 
-            var processResult = solutionCreateProcessHelper.RunProcess(_outputWriter, _workingDirectory, ExecutablePath, ArgumentsFormat);
+            var processResult = solutionCreateProcessHelper.RunProcess(_outputWriter, WorkingDirectory, ExecutablePath, ArgumentsFormat);
             if (processResult.ExitCode != 0)
             {
                 var innerException = new Exception(processResult.CombinedOutput);

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/CopyFolderCommandBuilder.cs
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/CopyFolderCommandBuilder.cs
@@ -4,9 +4,20 @@ using System.IO;
 namespace Reqnroll.TestProjectGenerator.Dotnet;
 public class CopyFolderCommandBuilder : CommandBuilder
 {
-    public CopyFolderCommandBuilder(IOutputWriter outputWriter, string sourceFolder, string targetFolder) 
+    private readonly string _replaceFrom;
+    private readonly string _replaceTo;
+
+    public CopyFolderCommandBuilder(IOutputWriter outputWriter, string sourceFolder, string targetFolder, string replaceFrom = null, string replaceTo = null) 
         : base(outputWriter, "[copy folder]", sourceFolder, targetFolder)
     {
+        _replaceFrom = replaceFrom;
+        _replaceTo = replaceTo;
+    }
+
+    private string ReplaceName(string value)
+    {
+        if (_replaceFrom == null || _replaceTo == null) return value;
+        return value.Replace(_replaceFrom, _replaceTo);
     }
 
     private void CopyDirectoryRecursively(DirectoryInfo source, DirectoryInfo target)
@@ -16,8 +27,9 @@ public class CopyFolderCommandBuilder : CommandBuilder
         // Copy each file into the new directory.
         foreach (FileInfo fi in source.GetFiles())
         {
-            _outputWriter.WriteLine(@"Copying to {0}\{1}", target.FullName, fi.Name);
-            fi.CopyTo(Path.Combine(target.FullName, fi.Name), true);
+            string fiName = ReplaceName(fi.Name);
+            _outputWriter.WriteLine(@"Copying to {0}\{1}", target.FullName, fiName);
+            fi.CopyTo(Path.Combine(target.FullName, fiName), true);
         }
 
         // Copy each subdirectory using recursion.

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/CopyFolderCommandBuilder.cs
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/CopyFolderCommandBuilder.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.IO;
+
+namespace Reqnroll.TestProjectGenerator.Dotnet;
+public class CopyFolderCommandBuilder : CommandBuilder
+{
+    public CopyFolderCommandBuilder(IOutputWriter outputWriter, string sourceFolder, string targetFolder) 
+        : base(outputWriter, "[copy folder]", sourceFolder, targetFolder)
+    {
+    }
+
+    private void CopyDirectoryRecursively(DirectoryInfo source, DirectoryInfo target)
+    {
+        Directory.CreateDirectory(target.FullName);
+
+        // Copy each file into the new directory.
+        foreach (FileInfo fi in source.GetFiles())
+        {
+            _outputWriter.WriteLine(@"Copying to {0}\{1}", target.FullName, fi.Name);
+            fi.CopyTo(Path.Combine(target.FullName, fi.Name), true);
+        }
+
+        // Copy each subdirectory using recursion.
+        foreach (DirectoryInfo diSourceSubDir in source.GetDirectories())
+        {
+            DirectoryInfo nextTargetSubDir =
+                target.CreateSubdirectory(diSourceSubDir.Name);
+            CopyDirectoryRecursively(diSourceSubDir, nextTargetSubDir);
+        }
+    }
+
+    public override CommandResult Execute(Func<Exception, Exception> exceptionFunction)
+    {
+        var sourceFolder = ArgumentsFormat;
+        var targetFolder = WorkingDirectory;
+
+        try
+        {
+            _outputWriter.WriteLine($"Copying '{sourceFolder}' to '{targetFolder}'...");
+
+            CopyDirectoryRecursively(new DirectoryInfo(sourceFolder), new DirectoryInfo(targetFolder));
+
+            _outputWriter.WriteLine("Copying done.");
+
+            return new CommandResult(0, $"Copied '{sourceFolder}' to '{targetFolder}'.");
+        }
+        catch (Exception ex)
+        {
+            throw exceptionFunction(ex);
+        }
+    }
+}

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/DotNet.cs
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/DotNet.cs
@@ -1,8 +1,10 @@
+using Reqnroll.TestProjectGenerator.FilesystemWriter;
+
 namespace Reqnroll.TestProjectGenerator.Dotnet
 {
     public class DotNet
     {
-        public static NewCommandBuilder New(IOutputWriter outputWriter) => NewCommandBuilder.Create(outputWriter);
+        public static NewCommandBuilder New(IOutputWriter outputWriter, NetCoreSdkInfo sdk) => NewCommandBuilder.Create(outputWriter, sdk);
         public static BuildCommandBuilder Build(IOutputWriter outputWriter) => BuildCommandBuilder.Create(outputWriter);
         public static SolutionCommandBuilder Sln(IOutputWriter outputWriter) => SolutionCommandBuilder.Create(outputWriter);
         public static VersionCommandBuilder Version(IOutputWriter outputWriter) => VersionCommandBuilder.Create(outputWriter);

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/NewCommandBuilder.NewProjectCommandBuilder.cs
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/NewCommandBuilder.NewProjectCommandBuilder.cs
@@ -47,7 +47,7 @@ namespace Reqnroll.TestProjectGenerator.Dotnet
 
             protected override string BuildArguments()
             {
-                var arguments = AddArgument($"new {_templateName} --no-update-check", "-o", "\"" + _folder + "\"");
+                var arguments = AddArgument($"new {_templateName} --no-update-check --no-restore", "-o", "\"" + _folder + "\"");
                 arguments = AddArgument(
                     arguments,
                     "-lang",

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/NewCommandBuilder.NewProjectCommandBuilder.cs
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/NewCommandBuilder.NewProjectCommandBuilder.cs
@@ -6,10 +6,10 @@ namespace Reqnroll.TestProjectGenerator.Dotnet
     {
         public class NewProjectCommandBuilder : BaseCommandBuilder
         {
-            private string _templateName = "classlib";
-            private string _name = "ClassLib";
-            private string _folder;
-            private ProgrammingLanguage _language = ProgrammingLanguage.CSharp;
+            protected string _templateName = "classlib";
+            protected string _name = "ClassLib";
+            protected string _folder;
+            protected ProgrammingLanguage _language = ProgrammingLanguage.CSharp;
 
 
             public NewProjectCommandBuilder(IOutputWriter outputWriter) : base(outputWriter)

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/NewCommandBuilder.NewSolutionCommandBuilder.cs
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/NewCommandBuilder.NewSolutionCommandBuilder.cs
@@ -4,8 +4,8 @@ namespace Reqnroll.TestProjectGenerator.Dotnet
     {
         public class NewSolutionCommandBuilder : BaseCommandBuilder
         {
-            private string _name;
-            private string _rootPath;
+            protected string _name;
+            protected string _rootPath;
 
             public NewSolutionCommandBuilder InFolder(string rootPath)
             {

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/NewCommandBuilder.StubNewProjectCommandBuilder.cs
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/NewCommandBuilder.StubNewProjectCommandBuilder.cs
@@ -1,3 +1,4 @@
+using Reqnroll.TestProjectGenerator.FilesystemWriter;
 using System.IO;
 
 namespace Reqnroll.TestProjectGenerator.Dotnet
@@ -6,13 +7,16 @@ namespace Reqnroll.TestProjectGenerator.Dotnet
     {
         public class StubNewProjectCommandBuilder : NewProjectCommandBuilder
         {
-            public StubNewProjectCommandBuilder(IOutputWriter outputWriter) : base(outputWriter)
+            private readonly NetCoreSdkInfo _sdk;
+
+            public StubNewProjectCommandBuilder(IOutputWriter outputWriter, NetCoreSdkInfo sdk) : base(outputWriter)
             {
+                _sdk = sdk;
             }
 
             public override CommandBuilder Build()
             {
-                return new CacheAndCopyCommandBuilder(_outputWriter, base.Build(), _folder);
+                return new CacheAndCopyCommandBuilder(_outputWriter, _sdk, base.Build(), _folder);
 
                 //return new CopyFolderCommandBuilder(_outputWriter, @"C:\Temp\DotNetNewIssue\DotNetNewTest\DefaultTestProject", _folder);
                 //return base.Build();

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/NewCommandBuilder.StubNewProjectCommandBuilder.cs
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/NewCommandBuilder.StubNewProjectCommandBuilder.cs
@@ -1,26 +1,14 @@
 using Reqnroll.TestProjectGenerator.FilesystemWriter;
-using System.IO;
 
-namespace Reqnroll.TestProjectGenerator.Dotnet
+namespace Reqnroll.TestProjectGenerator.Dotnet;
+
+public partial class NewCommandBuilder
 {
-    public partial class NewCommandBuilder
+    public class StubNewProjectCommandBuilder(IOutputWriter outputWriter, NetCoreSdkInfo _sdk) : NewProjectCommandBuilder(outputWriter)
     {
-        public class StubNewProjectCommandBuilder : NewProjectCommandBuilder
+        public override CommandBuilder Build()
         {
-            private readonly NetCoreSdkInfo _sdk;
-
-            public StubNewProjectCommandBuilder(IOutputWriter outputWriter, NetCoreSdkInfo sdk) : base(outputWriter)
-            {
-                _sdk = sdk;
-            }
-
-            public override CommandBuilder Build()
-            {
-                return new CacheAndCopyCommandBuilder(_outputWriter, _sdk, base.Build(), _folder);
-
-                //return new CopyFolderCommandBuilder(_outputWriter, @"C:\Temp\DotNetNewIssue\DotNetNewTest\DefaultTestProject", _folder);
-                //return base.Build();
-            }
+            return new CacheAndCopyCommandBuilder(_outputWriter, _sdk, base.Build(), _folder);
         }
     }
 }

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/NewCommandBuilder.StubNewProjectCommandBuilder.cs
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/NewCommandBuilder.StubNewProjectCommandBuilder.cs
@@ -1,0 +1,22 @@
+using System.IO;
+
+namespace Reqnroll.TestProjectGenerator.Dotnet
+{
+    public partial class NewCommandBuilder
+    {
+        public class StubNewProjectCommandBuilder : NewProjectCommandBuilder
+        {
+            public StubNewProjectCommandBuilder(IOutputWriter outputWriter) : base(outputWriter)
+            {
+            }
+
+            public override CommandBuilder Build()
+            {
+                return new CacheAndCopyCommandBuilder(_outputWriter, base.Build(), _folder);
+
+                //return new CopyFolderCommandBuilder(_outputWriter, @"C:\Temp\DotNetNewIssue\DotNetNewTest\DefaultTestProject", _folder);
+                //return base.Build();
+            }
+        }
+    }
+}

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/NewCommandBuilder.StubNewSolutionCommandBuilder.cs
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/NewCommandBuilder.StubNewSolutionCommandBuilder.cs
@@ -1,16 +1,21 @@
+using Reqnroll.TestProjectGenerator.FilesystemWriter;
+
 namespace Reqnroll.TestProjectGenerator.Dotnet;
 
 public partial class NewCommandBuilder
 {
     public class StubNewSolutionCommandBuilder : NewSolutionCommandBuilder
     {
-        public StubNewSolutionCommandBuilder(IOutputWriter outputWriter) : base(outputWriter)
+        private readonly NetCoreSdkInfo _sdk;
+
+        public StubNewSolutionCommandBuilder(IOutputWriter outputWriter, NetCoreSdkInfo sdk) : base(outputWriter)
         {
+            _sdk = sdk;
         }
 
         public override CommandBuilder Build()
         {
-            return new CacheAndCopyCommandBuilder(_outputWriter, base.Build(), _rootPath, _name);
+            return new CacheAndCopyCommandBuilder(_outputWriter, _sdk, base.Build(), _rootPath, _name);
 
             //return new CopyFolderCommandBuilder(_outputWriter, @"C:\Temp\DotNetNewIssue\DotNetNewTest\DefaultTestProject", _folder);
             //return base.Build();

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/NewCommandBuilder.StubNewSolutionCommandBuilder.cs
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/NewCommandBuilder.StubNewSolutionCommandBuilder.cs
@@ -1,0 +1,19 @@
+namespace Reqnroll.TestProjectGenerator.Dotnet;
+
+public partial class NewCommandBuilder
+{
+    public class StubNewSolutionCommandBuilder : NewSolutionCommandBuilder
+    {
+        public StubNewSolutionCommandBuilder(IOutputWriter outputWriter) : base(outputWriter)
+        {
+        }
+
+        public override CommandBuilder Build()
+        {
+            return new CacheAndCopyCommandBuilder(_outputWriter, base.Build(), _rootPath, _name);
+
+            //return new CopyFolderCommandBuilder(_outputWriter, @"C:\Temp\DotNetNewIssue\DotNetNewTest\DefaultTestProject", _folder);
+            //return base.Build();
+        }
+    }
+}

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/NewCommandBuilder.StubNewSolutionCommandBuilder.cs
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/NewCommandBuilder.StubNewSolutionCommandBuilder.cs
@@ -4,21 +4,11 @@ namespace Reqnroll.TestProjectGenerator.Dotnet;
 
 public partial class NewCommandBuilder
 {
-    public class StubNewSolutionCommandBuilder : NewSolutionCommandBuilder
+    public class StubNewSolutionCommandBuilder(IOutputWriter outputWriter, NetCoreSdkInfo _sdk) : NewSolutionCommandBuilder(outputWriter)
     {
-        private readonly NetCoreSdkInfo _sdk;
-
-        public StubNewSolutionCommandBuilder(IOutputWriter outputWriter, NetCoreSdkInfo sdk) : base(outputWriter)
-        {
-            _sdk = sdk;
-        }
-
         public override CommandBuilder Build()
         {
             return new CacheAndCopyCommandBuilder(_outputWriter, _sdk, base.Build(), _rootPath, _name);
-
-            //return new CopyFolderCommandBuilder(_outputWriter, @"C:\Temp\DotNetNewIssue\DotNetNewTest\DefaultTestProject", _folder);
-            //return base.Build();
         }
     }
 }

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/NewCommandBuilder.cs
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/NewCommandBuilder.cs
@@ -13,6 +13,6 @@ namespace Reqnroll.TestProjectGenerator.Dotnet
 
         public NewSolutionCommandBuilder Solution() => new NewSolutionCommandBuilder(_outputWriter);
 
-        public NewProjectCommandBuilder Project() => new NewProjectCommandBuilder(_outputWriter);
+        public NewProjectCommandBuilder Project() => new StubNewProjectCommandBuilder(_outputWriter);
     }
 }

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/NewCommandBuilder.cs
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/NewCommandBuilder.cs
@@ -1,18 +1,22 @@
+using Reqnroll.TestProjectGenerator.FilesystemWriter;
+
 namespace Reqnroll.TestProjectGenerator.Dotnet
 {
     public partial class NewCommandBuilder
     {
         private readonly IOutputWriter _outputWriter;
+        private readonly NetCoreSdkInfo _sdk;
 
-        public NewCommandBuilder(IOutputWriter outputWriter)
+        public NewCommandBuilder(IOutputWriter outputWriter, NetCoreSdkInfo sdk)
         {
             _outputWriter = outputWriter;
+            _sdk = sdk;
         }
 
-        internal static NewCommandBuilder Create(IOutputWriter outputWriter) => new NewCommandBuilder(outputWriter);
+        internal static NewCommandBuilder Create(IOutputWriter outputWriter, NetCoreSdkInfo sdk) => new NewCommandBuilder(outputWriter, sdk);
 
-        public NewSolutionCommandBuilder Solution() => new StubNewSolutionCommandBuilder(_outputWriter);
+        public NewSolutionCommandBuilder Solution() => new StubNewSolutionCommandBuilder(_outputWriter, _sdk);
 
-        public NewProjectCommandBuilder Project() => new StubNewProjectCommandBuilder(_outputWriter);
+        public NewProjectCommandBuilder Project() => new StubNewProjectCommandBuilder(_outputWriter, _sdk);
     }
 }

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/NewCommandBuilder.cs
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/NewCommandBuilder.cs
@@ -11,7 +11,7 @@ namespace Reqnroll.TestProjectGenerator.Dotnet
 
         internal static NewCommandBuilder Create(IOutputWriter outputWriter) => new NewCommandBuilder(outputWriter);
 
-        public NewSolutionCommandBuilder Solution() => new NewSolutionCommandBuilder(_outputWriter);
+        public NewSolutionCommandBuilder Solution() => new StubNewSolutionCommandBuilder(_outputWriter);
 
         public NewProjectCommandBuilder Project() => new StubNewProjectCommandBuilder(_outputWriter);
     }

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/SolutionCommandBuilder.AddProjectSolutionCommandBuilder.cs
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/SolutionCommandBuilder.AddProjectSolutionCommandBuilder.cs
@@ -7,8 +7,8 @@ namespace Reqnroll.TestProjectGenerator.Dotnet
     {
         public class AddProjectSolutionCommandBuilder : BaseCommandBuilder
         {
-            private string _solutionPath;
-            private string _projectPath;
+            protected string _solutionPath;
+            protected string _projectPath;
 
          
             public AddProjectSolutionCommandBuilder ToSolution(string solutionPath)

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/SolutionCommandBuilder.StubAddProjectSolutionCommandBuilder.cs
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/SolutionCommandBuilder.StubAddProjectSolutionCommandBuilder.cs
@@ -1,0 +1,79 @@
+using System;
+using System.IO;
+using System.Text.RegularExpressions;
+
+namespace Reqnroll.TestProjectGenerator.Dotnet;
+
+public partial class SolutionCommandBuilder
+{
+    public class StubAddProjectSolutionCommandBuilder : AddProjectSolutionCommandBuilder
+    {
+        public StubAddProjectSolutionCommandBuilder(IOutputWriter outputWriter) : base(outputWriter)
+        {
+        }
+
+        public override CommandBuilder Build()
+        {
+            return new AddProjectSolutionCommand(_outputWriter, _solutionPath, _projectPath, GetWorkingDirectory());
+        }
+
+        class AddProjectSolutionCommand : CommandBuilder
+        {
+            private readonly string _solutionPath;
+            private readonly string _projectPath;
+
+            public AddProjectSolutionCommand(IOutputWriter outputWriter, string solutionPath, string projectPath, string workingDirectory) 
+                : base(outputWriter, "[add project to sln]", $"{projectPath} -> {solutionPath}", workingDirectory)
+            {
+                _solutionPath = solutionPath;
+                _projectPath = projectPath;
+            }
+
+            public override CommandResult Execute(Func<Exception, Exception> exceptionFunction)
+            {
+                try
+                {
+                    var projectGuid = Guid.NewGuid().ToString("B").ToUpperInvariant();
+                    var projectTypeGuid = Path.GetExtension(_projectPath).ToLowerInvariant().Equals(".vbproj") ? 
+                        "{F184B08F-C81C-45F6-A57F-5ABD9991F28F}" : 
+                        "{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}";
+                    var projectName = Path.GetFileNameWithoutExtension(_projectPath);
+                    var projectRelativePath = _projectPath!.Substring(Path.GetDirectoryName(_solutionPath)!.Length + 1);
+                    var slnContent = File.ReadAllText(_solutionPath);
+                    var projectReference =
+                        $$"""
+                        Project("{{projectTypeGuid}}") = "{{projectName}}", "{{projectRelativePath}}", "{{projectGuid}}"
+                        EndProject
+                        """;
+                    var projectConfPlatforms =
+                        """
+                        	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                        	EndGlobalSection
+                        """;
+                    var projectConfPlatformContent =
+                        $$"""
+                        		{{projectGuid}}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                        		{{projectGuid}}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                        		{{projectGuid}}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                        		{{projectGuid}}.Release|Any CPU.Build.0 = Release|Any CPU
+                        """;
+
+                    slnContent = Regex.Replace(slnContent, @"\r?\nGlobal\r?\n", match => Environment.NewLine + projectReference + match.Value);
+                    if (!slnContent.Contains("GlobalSection(ProjectConfigurationPlatforms)"))
+                    {
+                        slnContent = Regex.Replace(slnContent, @"\r?\nEndGlobal", match => Environment.NewLine + projectConfPlatforms + match.Value);
+                    }
+
+                    slnContent = Regex.Replace(slnContent, @"GlobalSection\(ProjectConfigurationPlatforms\) = postSolution\r?\n", match => match.Value + projectConfPlatformContent + Environment.NewLine);
+                    File.WriteAllText(_solutionPath, slnContent);
+                    _outputWriter.WriteLine($"Solution file updated: {ArgumentsFormat}");
+                    return new CommandResult(0, "Solution file updated.");
+                }
+                catch (Exception ex)
+                {
+                    throw exceptionFunction(ex);
+                }
+            }
+        }
+    }
+}

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/SolutionCommandBuilder.StubAddProjectSolutionCommandBuilder.cs
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/SolutionCommandBuilder.StubAddProjectSolutionCommandBuilder.cs
@@ -6,29 +6,16 @@ namespace Reqnroll.TestProjectGenerator.Dotnet;
 
 public partial class SolutionCommandBuilder
 {
-    public class StubAddProjectSolutionCommandBuilder : AddProjectSolutionCommandBuilder
+    public class StubAddProjectSolutionCommandBuilder(IOutputWriter outputWriter) : AddProjectSolutionCommandBuilder(outputWriter)
     {
-        public StubAddProjectSolutionCommandBuilder(IOutputWriter outputWriter) : base(outputWriter)
-        {
-        }
-
         public override CommandBuilder Build()
         {
             return new AddProjectSolutionCommand(_outputWriter, _solutionPath, _projectPath, GetWorkingDirectory());
         }
 
-        class AddProjectSolutionCommand : CommandBuilder
+        class AddProjectSolutionCommand(IOutputWriter outputWriter, string _solutionPath, string _projectPath, string workingDirectory)
+            : CommandBuilder(outputWriter, "[add project to sln]", $"{_projectPath} -> {_solutionPath}", workingDirectory)
         {
-            private readonly string _solutionPath;
-            private readonly string _projectPath;
-
-            public AddProjectSolutionCommand(IOutputWriter outputWriter, string solutionPath, string projectPath, string workingDirectory) 
-                : base(outputWriter, "[add project to sln]", $"{projectPath} -> {solutionPath}", workingDirectory)
-            {
-                _solutionPath = solutionPath;
-                _projectPath = projectPath;
-            }
-
             public override CommandResult Execute(Func<Exception, Exception> exceptionFunction)
             {
                 try

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/SolutionCommandBuilder.cs
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/SolutionCommandBuilder.cs
@@ -12,6 +12,6 @@ namespace Reqnroll.TestProjectGenerator.Dotnet
 
         public static SolutionCommandBuilder Create(IOutputWriter outputWriter) => new SolutionCommandBuilder(outputWriter);
 
-        public AddProjectSolutionCommandBuilder AddProject() => new AddProjectSolutionCommandBuilder(_outputWriter);
+        public AddProjectSolutionCommandBuilder AddProject() => new StubAddProjectSolutionCommandBuilder(_outputWriter);
     }
 }

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/FilesystemWriter/IProjectWriter.cs
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/FilesystemWriter/IProjectWriter.cs
@@ -4,7 +4,7 @@ namespace Reqnroll.TestProjectGenerator.FilesystemWriter
 {
     public interface IProjectWriter
     {
-        string WriteProject(Project project, string path);
+        string WriteProject(NetCoreSdkInfo sdk, Project project, string path);
 
         void WriteReferences(Project project, string projectFilePath);
     }

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/FilesystemWriter/NewFormatProjectWriter.cs
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/FilesystemWriter/NewFormatProjectWriter.cs
@@ -21,7 +21,7 @@ namespace Reqnroll.TestProjectGenerator.FilesystemWriter
             _targetFrameworkMonikerStringBuilder = targetFrameworkMonikerStringBuilder;
         }
 
-        public virtual string WriteProject(Project project, string projRootPath)
+        public virtual string WriteProject(NetCoreSdkInfo sdk, Project project, string projRootPath)
         {
             if (project is null)
             {
@@ -29,7 +29,7 @@ namespace Reqnroll.TestProjectGenerator.FilesystemWriter
             }
 
 
-            CreateProjectFile(project, projRootPath);
+            CreateProjectFile(sdk, project, projRootPath);
 
             string projFileName = $"{project.Name}.{project.ProgrammingLanguage.ToProjectFileExtension()}";
 
@@ -232,7 +232,7 @@ namespace Reqnroll.TestProjectGenerator.FilesystemWriter
             xw.WriteEndElement();
         }
 
-        private void CreateProjectFile(Project project, string projRootPath)
+        private void CreateProjectFile(NetCoreSdkInfo sdk, Project project, string projRootPath)
         {
             string template;
 
@@ -253,7 +253,7 @@ namespace Reqnroll.TestProjectGenerator.FilesystemWriter
 
             
 
-            var newProjCommand = DotNet.New(_outputWriter)
+            var newProjCommand = DotNet.New(_outputWriter, sdk)
                                        .Project()
                                        .InFolder(projRootPath)
                                        .WithName(project.Name)

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/FilesystemWriter/OldFormatProjectWriter.cs
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/FilesystemWriter/OldFormatProjectWriter.cs
@@ -20,7 +20,7 @@ namespace Reqnroll.TestProjectGenerator.FilesystemWriter
             _targetFrameworkVersionStringBuilder = targetFrameworkVersionStringBuilder;
         }
 
-        public virtual string WriteProject(Project project, string path)
+        public virtual string WriteProject(NetCoreSdkInfo sdk, Project project, string path)
         {
             if (project is null)
             {

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/FilesystemWriter/SolutionWriter.cs
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/FilesystemWriter/SolutionWriter.cs
@@ -43,14 +43,6 @@ namespace Reqnroll.TestProjectGenerator.FilesystemWriter
                 ? new NetCoreSdkInfo(solution.SdkVersion) 
                 : _netCoreSdkInfoProvider.GetSdkFromTargetFramework(targetFramework);
 
-            if (targetFramework != 0 && sdk != null)
-            {
-                var globalJsonBuilder = new GlobalJsonBuilder().WithSdk(sdk);
-
-                var globalJsonFile = globalJsonBuilder.ToProjectFile();
-                _fileWriter.Write(globalJsonFile, outputPath);
-            }
-
             DisableUsingSdkFromEnvironmentVariable();
 
             var createSolutionCommand = DotNet.New(_outputWriter).Solution().InFolder(outputPath).WithName(solution.Name).Build();
@@ -72,6 +64,14 @@ namespace Reqnroll.TestProjectGenerator.FilesystemWriter
             foreach (var file in solution.Files)
             {
                 _fileWriter.Write(file, outputPath);
+            }
+
+            if (targetFramework != 0 && sdk != null)
+            {
+                var globalJsonBuilder = new GlobalJsonBuilder().WithSdk(sdk);
+
+                var globalJsonFile = globalJsonBuilder.ToProjectFile();
+                _fileWriter.Write(globalJsonFile, outputPath);
             }
 
             return solutionFilePath;

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/FilesystemWriter/SolutionWriter.cs
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/FilesystemWriter/SolutionWriter.cs
@@ -56,7 +56,7 @@ namespace Reqnroll.TestProjectGenerator.FilesystemWriter
             var createSolutionCommand = DotNet.New(_outputWriter, sdk).Solution().InFolder(outputPath).WithName(solution.Name).Build();
             createSolutionCommand.ExecuteWithRetry(1, TimeSpan.FromSeconds(1), (innerException) =>
             {
-                if (innerException is AggregateException aggregateException && aggregateException.InnerExceptions.Any(x => x.InnerException.Message.Contains("Install the [" + sdk.Version)))
+                if (sdk != null && innerException is AggregateException aggregateException && aggregateException.InnerExceptions.Any(x => x.InnerException?.Message.Contains("Install the [" + sdk.Version) ?? false))
                     return new DotNetSdkNotInstalledException($"Sdk Version \"{sdk.Version}\" is not installed", innerException);
                 return new ProjectCreationNotPossibleException("Could not create solution.", innerException);
             });


### PR DESCRIPTION
### 🤔 What's changed?

The `TestProjectGenerator` that is used by System Tests (and currently Specs tests as well) has been improved:

* the `dotnet new sln` and the `dotnet new classlib` commands have been replaced by a "stub" version that calls the original command first, but caches the result in the temp folder and for the next time it only copies the files
* the `dotnet sln add` command has been replaced by a stub implementation that does the same by editing the `.sln` file directly

### ⚡️ What's your motivation? 

The main motivation is performance as these three basic command take significant time in local and CI execution.

With the changes I have achieved a good performance improvement locally:
- execution time of all system tests were 213 s (3:33) before
- with the changes and empty cache: 166 s (2:46), 22% improvement
- with the changes and populated cache: 158 s (2:38), **26% improvement**

I also hope that this fixes #249 too.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

It can happen that this changed the behavior of #109, so that needs to be retested.

### 📋 Checklist:

- [x] I've changed the behaviour of the code

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
