### PR TITLE
Docs: enable file nesting in vscode config file

### DIFF
--- a/docs/installation/setup-ide.md
+++ b/docs/installation/setup-ide.md
@@ -51,6 +51,7 @@ The following Visual Studio configuration shows a typical configuration.
 ```{code-block} json
 :caption: .vscode/settings.json
 {
+  "explorer.fileNesting.enabled": true,
   "explorer.fileNesting.patterns": {  // shows *.feature.cs files as nested items
     "*.feature": "${capture}.feature.cs"
   },


### PR DESCRIPTION
### 🤔 What's changed?

Added a line in the Visual Studio Code settings example to enable the file nesting functionality.

### ⚡️ What's your motivation? 

The proposed example was not working for me. The help menu of the property `explorer.fileNesting.patterns` showed that we need to enable it manually. 
![image](https://github.com/user-attachments/assets/92c7db17-f5a9-49f9-8fab-be3c7f420873)

As seen in the [Visual Studio Code default settings](https://code.visualstudio.com/docs/getstarted/settings#_default-settings), it is disabled by default.


### 🏷️ What kind of change is this?

- :book: Documentation (improvements without changing code)

### ♻️ Anything particular you want feedback on?

### 📋 Checklist:

- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
