### PR TITLE
SystemTests: avoid unneeded assemblies copies in Testprojects

### DIFF
--- a/Tests/Reqnroll.Specs/Features/Execution/AsyncSupport.feature
+++ b/Tests/Reqnroll.Specs/Features/Execution/AsyncSupport.feature
@@ -1,6 +1,7 @@
 Feature: AsyncSupport
 
 Background:
+    Given fluent assertion nuget package is added
 	Given the following binding class
 		"""
 		using System;

--- a/Tests/Reqnroll.Specs/StepDefinitions/ProjectSteps.cs
+++ b/Tests/Reqnroll.Specs/StepDefinitions/ProjectSteps.cs
@@ -41,6 +41,12 @@ namespace Reqnroll.Specs.StepDefinitions
             _projectsDriver.CreateProject(language);
         }
 
+        [Given(@"fluent assertion nuget package is added")]
+        public void GivenFluentAssertion()
+        {
+            _projectsDriver.AddNuGetPackage("FluentAssertions", "5.3.0");
+        }
+
         [When(@"I compile the solution")]
         public void WhenTheProjectIsCompiled()
         {

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/FilesystemWriter/NewFormatProjectWriter.cs
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/FilesystemWriter/NewFormatProjectWriter.cs
@@ -43,6 +43,7 @@ namespace Reqnroll.TestProjectGenerator.FilesystemWriter
             WriteAssemblyReferences(project, projectElement);
             WriteNuGetPackages(project, projectElement);
             WriteFileReferences(project, projectElement);
+            WriteSatelliteResourceLanguages(project, projectElement);
 
             SetTreatWarningsAsErrors(project, projectElement);
 
@@ -110,6 +111,17 @@ namespace Reqnroll.TestProjectGenerator.FilesystemWriter
             {
                 projectElement.Add(itemGroup);
             }
+        }
+
+        /// <summary>
+        /// This avoids the need to copy language-specific files (reduced I/O) and therefore increases test execution time.
+        /// </summary>
+        private void WriteSatelliteResourceLanguages(Project project, XElement projectElement)
+        {
+            var propertyGroupElement = projectElement.Element("PropertyGroup") ?? throw new ProjectCreationNotPossibleException();
+            var satelliteResourceLanguagesElement = new XElement("SatelliteResourceLanguages");
+            satelliteResourceLanguagesElement.SetValue("en");
+            propertyGroupElement.Add(satelliteResourceLanguagesElement);
         }
 
         private void WriteFileReference(XmlWriter xw, ProjectFile projectFile)

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/ProjectBuilder.cs
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/ProjectBuilder.cs
@@ -239,9 +239,6 @@ namespace Reqnroll.TestProjectGenerator
                 // TODO: dei replace this hack with better logic when SpecFlow 3 can be strong name signed
                 _project.AddNuGetPackage("Reqnroll", _currentVersionDriver.ReqnrollNuGetVersion, new NuGetPackageAssembly("Reqnroll", "net462\\Reqnroll.dll"));
 
-                _project.AddNuGetPackage("System.Threading.Tasks.Extensions", "4.5.4", new NuGetPackageAssembly("System.Threading.Tasks.Extensions", "netstandard2.0\\System.Threading.Tasks.Extensions.dll"));
-                _project.AddNuGetPackage("Microsoft.Bcl.AsyncInterfaces", "8.0.0", new NuGetPackageAssembly("Microsoft.Bcl.AsyncInterfaces", "netstandard2.0\\Microsoft.Bcl.AsyncInterfaces.dll"));
-
                 var generator = _bindingsGeneratorFactory.FromLanguage(_project.ProgrammingLanguage);
                 _project.AddFile(generator.GenerateLoggerClass(_testProjectFolders.LogFilePath));
 
@@ -254,11 +251,6 @@ namespace Reqnroll.TestProjectGenerator
                     case ProgrammingLanguage.CSharp:
                         AddUnitTestProviderSpecificConfig();
                         break;
-                }
-
-                if (IsReqnrollFeatureProject)
-                {
-                    _project.AddNuGetPackage("Reqnroll.Tools.MsBuild.Generation", _currentVersionDriver.ReqnrollNuGetVersion);
                 }
 
                 switch (Configuration.UnitTestProvider)
@@ -277,8 +269,6 @@ namespace Reqnroll.TestProjectGenerator
                 }
             }
 
-            _project.AddNuGetPackage("FluentAssertions", "5.3.0");
-            AddInternalJson();
             AddAdditionalStuff();
         }
 
@@ -413,11 +403,6 @@ namespace Reqnroll.TestProjectGenerator
         {
             EnsureProjectExists();
             _project.AddNuGetPackage(nugetPackage, nugetVersion);
-        }
-
-        private void AddInternalJson()
-        {
-            _project.AddNuGetPackage($"{InternalJsonPackageName}", $"{InternalJsonVersion}", new NuGetPackageAssembly($"{InternalJsonPackageName}", "net45\\SpecFlow.Internal.Json.dll"));
         }
     }
 }


### PR DESCRIPTION
### What's changed?

This PR reduces the number of assemblies copied to the bin directory by the `TestProjectGenerator` in the system tests. This happens because
- Fewer nuget packages are referenced
- Satellite assemblies are not copied

This reduces the bin directory size of a typical test project from 4.91 MB (98 files) to 2.46 MB (28 files).

### ⚡️ What's your motivation? 

To improve system test execution time and reduce test project dependencies (and therefore complexity).
Interestingly, on my machine, the execution time didn't change that much. But I still think the change is a win because we have less I/O and the generated projects have fewer dependencies to maintain and understand.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

I have checked that all tests run successfully on my local machine and on CI. But I'm not sure if all the tests run on CI.

### 📋 Checklist:

- [x] I've changed the behaviour of the code

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
