### PR TITLE
Fix: Could not load System.CodeDom exception with xRetry.Reqnroll plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 * Fix: Visual Studio locks Reqnroll.Tools.MsBuild.Generation task files. Using `TaskHostFactory` for our tasks on Windows. (#293)
 * Fix: Project dependencies transiently refer to System.Text.Json 8.0.4 that has security vulnerability. Microsoft.Extensions.DependencyModel updated to v8.0.2. (#291)
+* Fix: Could not load System.CodeDom exception with xRetry.Reqnroll plugin (#310)
 
 *Contributors of this release (in alphabetical order):* @gasparnagy, @obligaron, @Romfos, @Tiberriver256
 

--- a/Reqnroll.Tools.MsBuild.Generation/AssemblyResolveLogger.cs
+++ b/Reqnroll.Tools.MsBuild.Generation/AssemblyResolveLogger.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Reflection;
 
 namespace Reqnroll.Tools.MsBuild.Generation
@@ -22,6 +23,18 @@ namespace Reqnroll.Tools.MsBuild.Generation
         public Assembly CurrentDomain_AssemblyResolve(object sender, ResolveEventArgs args)
         {
             _taskLoggingWrapper.LogMessage(args.Name);
+
+            try
+            {
+                var requestedAssemblyName = new AssemblyName(args.Name);
+                var loadedAssembly = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(a => a.GetName().Name == requestedAssemblyName.Name);
+                if (loadedAssembly != null) return loadedAssembly;
+            }
+            catch (Exception ex)
+            {
+                _taskLoggingWrapper.LogError(ex.Message);
+                return null;
+            }
 
             return null;
         }

--- a/Tests/Reqnroll.SystemTests/Plugins/XRetryPluginTest.cs
+++ b/Tests/Reqnroll.SystemTests/Plugins/XRetryPluginTest.cs
@@ -31,6 +31,7 @@ public class XRetryPluginTest : SystemTestBase
     }
 
     [TestMethod]
+    [TestCategory("MsBuild")] 
     public void XRetry_should_work_with_Reqnroll_on_DotNetFramework_generation()
     {
         // compiling with MsBuild forces the generation to run with .NET Framework

--- a/Tests/Reqnroll.SystemTests/Plugins/XRetryPluginTest.cs
+++ b/Tests/Reqnroll.SystemTests/Plugins/XRetryPluginTest.cs
@@ -19,50 +19,8 @@ public class XRetryPluginTest : SystemTestBase
     [TestMethod]
     public void XRetry_should_work_with_Reqnroll()
     {
-        AddScenario(
-            """
-            @retry
-            Scenario: Scenario with Retry
-                When fail for first 2 times A
-            """);
-        AddScenario(
-            """
-            @retry
-            Scenario Outline: Scenario outline with Retry
-                When fail for first 2 times <label>
-            Examples:
-                | label |
-                | B     |
-                | C     |
-            """);
-        AddBindingClass(
-            """
-            using System.Collections.Generic;
-            namespace XRetryPluginTest.StepDefinitions
-            {
-                [Binding]
-                public class XRetryPluginTestStepDefinitions
-                {
-                    private static readonly Dictionary<string, int> RetriesByLabel = new Dictionary<string, int>();
-                
-                    [When("fail for first {int} times {word}")]
-                    public void WhenFailForFirstTwoTimes(int retryCount, string label)
-                    {
-                        if (!RetriesByLabel.TryGetValue(label, out var retries))
-                        {
-                            retries = 0;
-                        }
-                        var failTest = retries < retryCount;
-                        RetriesByLabel[label] = ++retries;
-                        if (failTest)
-                        {
-                            Log.LogCustom("simulated-error", label);
-                            throw new Exception($"simulated error for {label}");
-                        }
-                    }
-                }
-            }
-            """);
+        AddFeatureFileFromResource("XRetryPlugin/XRetryPluginTestFeature.feature");
+        AddBindingClassFromResource("XRetryPlugin/XRetryPluginTestStepDefinitions.cs");
 
         ExecuteTests();
 

--- a/Tests/Reqnroll.SystemTests/Plugins/XRetryPluginTest.cs
+++ b/Tests/Reqnroll.SystemTests/Plugins/XRetryPluginTest.cs
@@ -1,0 +1,82 @@
+﻿using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Reqnroll.TestProjectGenerator;
+using Reqnroll.TestProjectGenerator.Driver;
+using System.Linq;
+
+namespace Reqnroll.SystemTests.Plugins;
+
+[TestClass]
+public class XRetryPluginTest : SystemTestBase
+{
+    protected override void TestInitialize()
+    {
+        base.TestInitialize();
+        _testRunConfiguration.UnitTestProvider = UnitTestProvider.xUnit;
+        _projectsDriver.AddNuGetPackage("xRetry.Reqnroll", "1.0.0");
+    }
+
+    [TestMethod]
+    public void XRetry_should_work_with_Reqnroll()
+    {
+        AddScenario(
+            """
+            @retry
+            Scenario: Scenario with Retry
+                When fail for first 2 times A
+            """);
+        AddScenario(
+            """
+            @retry
+            Scenario Outline: Scenario outline with Retry
+                When fail for first 2 times <label>
+            Examples:
+                | label |
+                | B     |
+                | C     |
+            """);
+        AddBindingClass(
+            """
+            using System.Collections.Generic;
+            namespace XRetryPluginTest.StepDefinitions
+            {
+                [Binding]
+                public class XRetryPluginTestStepDefinitions
+                {
+                    private static readonly Dictionary<string, int> RetriesByLabel = new Dictionary<string, int>();
+                
+                    [When("fail for first {int} times {word}")]
+                    public void WhenFailForFirstTwoTimes(int retryCount, string label)
+                    {
+                        if (!RetriesByLabel.TryGetValue(label, out var retries))
+                        {
+                            retries = 0;
+                        }
+                        var failTest = retries < retryCount;
+                        RetriesByLabel[label] = ++retries;
+                        if (failTest)
+                        {
+                            Log.LogCustom("simulated-error", label);
+                            throw new Exception($"simulated error for {label}");
+                        }
+                    }
+                }
+            }
+            """);
+
+        ExecuteTests();
+
+        ShouldAllScenariosPass();
+
+        var simulatedErrors = _bindingDriver.GetActualLogLines("simulated-error").ToList();
+        simulatedErrors.Should().HaveCount(_preparedTests * 2); // two simulated error per test
+    }
+
+    [TestMethod]
+    public void XRetry_should_work_with_Reqnroll_on_DotNetFramework_generation()
+    {
+        // compiling with MsBuild forces the generation to run with .NET Framework
+        _compilationDriver.SetBuildTool(BuildTool.MSBuild);
+        XRetry_should_work_with_Reqnroll();
+    }
+}

--- a/Tests/Reqnroll.SystemTests/Reqnroll.SystemTests.csproj
+++ b/Tests/Reqnroll.SystemTests/Reqnroll.SystemTests.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="Resources\GeneratorAllInSample1.feature" />
-    <EmbeddedResource Include="Resources\GeneratorAllInSample2.feature" />
+    <Compile Remove="Resources\**\*.cs" />
+    <EmbeddedResource Include="Resources\**\*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/Reqnroll.SystemTests/Resources/XRetryPlugin/XRetryPluginTestFeature.feature
+++ b/Tests/Reqnroll.SystemTests/Resources/XRetryPlugin/XRetryPluginTestFeature.feature
@@ -1,0 +1,15 @@
+﻿Feature: XRetryPluginFeature
+
+Used by Reqnroll.SystemTests.Plugins.XRetryPluginTest
+
+@retry
+Scenario: Scenario with Retry
+	When fail for first 2 times A
+
+@retry
+Scenario Outline: Scenario outline with Retry
+	When fail for first 2 times <label>
+Examples:
+    | label |
+    | B     |
+    | C     |

--- a/Tests/Reqnroll.SystemTests/Resources/XRetryPlugin/XRetryPluginTestStepDefinitions.cs
+++ b/Tests/Reqnroll.SystemTests/Resources/XRetryPlugin/XRetryPluginTestStepDefinitions.cs
@@ -1,0 +1,26 @@
+﻿// Used by Reqnroll.SystemTests.Plugins.XRetryPluginTest
+using System.Collections.Generic;
+namespace XRetryPluginTest.StepDefinitions
+{
+    [Binding]
+    public class XRetryPluginTestStepDefinitions
+    {
+        private static readonly Dictionary<string, int> RetriesByLabel = new Dictionary<string, int>();
+
+        [When("fail for first {int} times {word}")]
+        public void WhenFailForFirstTwoTimes(int retryCount, string label)
+        {
+            if (!RetriesByLabel.TryGetValue(label, out var retries))
+            {
+                retries = 0;
+            }
+            var failTest = retries < retryCount;
+            RetriesByLabel[label] = ++retries;
+            if (failTest)
+            {
+                Log.LogCustom("simulated-error", label);
+                throw new Exception($"simulated error for {label}");
+            }
+        }
+    }
+}

--- a/Tests/Reqnroll.SystemTests/SystemTestBase.cs
+++ b/Tests/Reqnroll.SystemTests/SystemTestBase.cs
@@ -107,6 +107,12 @@ public abstract class SystemTestBase
         AddFeatureFile(featureFileContent, preparedTests);
     }
 
+    protected void AddBindingClassFromResource(string fileName)
+    {
+        var bindingClassContent = _testFileManager.GetTestFileContent(fileName);
+        AddBindingClass(bindingClassContent);
+    }
+
     private int? GetTestCount(string gherkinContent)
     {
         var matches = Regex.Matches(gherkinContent, @"^\s*((?<scenario>Scenario:|Scenario Outline:)|(?<exmaples>Examples:)|(?<row>\|)).*?\s*$", RegexOptions.Multiline);


### PR DESCRIPTION
### 🤔 What's changed?

When the code-behind generation runs on .NET Framework (e.g. when the project is built from Visual Studio), the assembly versions are verified strictly, so if a dependency of the Reqnroll generator is updated (e.g. System.CodeDom or Gherkin), the plugins that were compiled for an earlier version fail, although they would be compatible with the new dependency.

The solution is to hook on the assembly resolve event and if the same assembly has been loaded already, we use the loaded one even if the version number is different.

### ⚡️ What's your motivation? 

Fixes #310: Could not load System.CodeDom exception with xRetry.Reqnroll plugin.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

n/a

### 📋 Checklist:

- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] Users should know about my change
  - [x] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
