### PR TITLE
Fix: NUnit projects fail or provide warning as `TearDown : System.InvalidOperationException : Only static OneTimeSetUp and OneTimeTearDown are allowed for InstancePerTestCase mode.`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ## Bug fixes:
 
-*Contributors of this release (in alphabetical order):* 
+* Fix: NUnit projects fail or provide warning as `TearDown : System.InvalidOperationException : Only static OneTimeSetUp and OneTimeTearDown are allowed for InstancePerTestCase mode.` (#320)
+
+*Contributors of this release (in alphabetical order):* @gasparnagy
 
 # v2.2.0 - 2024-11-07
 

--- a/Reqnroll.Generator/UnitTestProvider/NUnit3TestGeneratorProvider.cs
+++ b/Reqnroll.Generator/UnitTestProvider/NUnit3TestGeneratorProvider.cs
@@ -57,7 +57,7 @@ namespace Reqnroll.Generator.UnitTestProvider
 
         public virtual void SetTestClassCleanupMethod(TestClassGenerationContext generationContext)
         {
-            generationContext.TestClassInitializeMethod.Attributes |= MemberAttributes.Static;
+            generationContext.TestClassCleanupMethod.Attributes |= MemberAttributes.Static;
             CodeDomHelper.AddAttribute(generationContext.TestClassCleanupMethod, TESTFIXTURETEARDOWN_ATTR_NUNIT3);
         }
 

--- a/Tests/Reqnroll.SystemTests/Generation/GenerationTestBase.cs
+++ b/Tests/Reqnroll.SystemTests/Generation/GenerationTestBase.cs
@@ -19,6 +19,8 @@ public abstract class GenerationTestBase : SystemTestBase
         ExecuteTests();
 
         ShouldAllScenariosPass();
+
+        ShouldFinishWithoutTestExecutionWarnings();
     }
 
     [TestMethod]

--- a/Tests/Reqnroll.SystemTests/Generation/NUnitGenerationTest.cs
+++ b/Tests/Reqnroll.SystemTests/Generation/NUnitGenerationTest.cs
@@ -18,6 +18,20 @@ public class NUnitGenerationTest : GenerationTestBase
         _testRunConfiguration.UnitTestProvider = UnitTestProvider.NUnit3;
     }
 
+    [TestMethod]
+    public void GeneratorAllIn_sample_can_be_handled_by_NUnit4()
+    {
+        _testRunConfiguration.UnitTestProvider = UnitTestProvider.NUnit4;
+
+        PrepareGeneratorAllInSamples();
+
+        ExecuteTests();
+
+        ShouldAllScenariosPass();
+
+        ShouldFinishWithoutTestExecutionWarnings();
+    }
+
     protected override void AssertIgnoredScenarioOutlineExampleHandled()
     {
         _vsTestExecutionDriver.LastTestExecutionResult.LeafTestResults

--- a/Tests/Reqnroll.SystemTests/SystemTestBase.cs
+++ b/Tests/Reqnroll.SystemTests/SystemTestBase.cs
@@ -226,6 +226,11 @@ public abstract class SystemTestBase
         _vsTestExecutionDriver.LastTestExecutionResult.Succeeded.Should().Be(expectedNrOfTests, "all tests should pass");
     }
 
+    protected void ShouldFinishWithoutTestExecutionWarnings()
+    {
+        _vsTestExecutionDriver.LastTestExecutionResult.Warnings.Should().BeEmpty();
+    }
+
     protected int ConfirmAllTestsRan(int? expectedNrOfTestsSpec)
     {
         if (expectedNrOfTestsSpec == null && _preparedTests == 0)

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Extensions/UnitTestProviderExtensions.cs
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Extensions/UnitTestProviderExtensions.cs
@@ -10,7 +10,9 @@ namespace Reqnroll.TestProjectGenerator.Extensions
             {
                 case UnitTestProvider.MSTest: return "MSTest";
                 case UnitTestProvider.NUnit2: return "NUnit2";
-                case UnitTestProvider.NUnit3: return "NUnit";
+                case UnitTestProvider.NUnit3: 
+                case UnitTestProvider.NUnit4: 
+                    return "NUnit";
                 case UnitTestProvider.xUnit: return "XUnit";
                 default: throw new ArgumentOutOfRangeException(nameof(unitTestProvider), unitTestProvider, "value is not known");
             }

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/ProjectBuilder.cs
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/ProjectBuilder.cs
@@ -15,6 +15,10 @@ namespace Reqnroll.TestProjectGenerator
         public const string NUnit3PackageVersion = "3.13.1";
         public const string NUnit3TestAdapterPackageName = "NUnit3TestAdapter";
         public const string NUnit3TestAdapterPackageVersion = "3.17.0";
+        public const string NUnit4PackageName = "NUnit";
+        public const string NUnit4PackageVersion = "4.2.2";
+        public const string NUnit4TestAdapterPackageName = "NUnit3TestAdapter";
+        public const string NUnit4TestAdapterPackageVersion = "4.6.0";
         private const string XUnitPackageVersion = "2.4.2";
         private const string MSTestPackageVersion = "2.2.8";
         private const string InternalJsonPackageName = "SpecFlow.Internal.Json";
@@ -253,7 +257,10 @@ namespace Reqnroll.TestProjectGenerator
                         ConfigureXUnit();
                         break;
                     case UnitTestProvider.NUnit3:
-                        ConfigureNUnit();
+                        ConfigureNUnit3();
+                        break;
+                    case UnitTestProvider.NUnit4:
+                        ConfigureNUnit4();
                         break;
                     default:
                         throw new InvalidOperationException(@"Invalid unit test provider.");
@@ -263,10 +270,24 @@ namespace Reqnroll.TestProjectGenerator
             AddAdditionalStuff();
         }
 
-        private void ConfigureNUnit()
+        private void ConfigureNUnit3()
         {
             _project.AddNuGetPackage(NUnit3PackageName, NUnit3PackageVersion);
             _project.AddNuGetPackage(NUnit3TestAdapterPackageName, NUnit3TestAdapterPackageVersion);
+
+
+            if (IsReqnrollFeatureProject)
+            {
+                _project.AddNuGetPackage("Reqnroll.NUnit", _currentVersionDriver.ReqnrollNuGetVersion,
+                    new NuGetPackageAssembly(GetReqnrollPublicAssemblyName("Reqnroll.NUnit.ReqnrollPlugin.dll"), "net462\\Reqnroll.NUnit.ReqnrollPlugin.dll"));
+                Configuration.Plugins.Add(new ReqnrollPlugin("Reqnroll.NUnit", ReqnrollPluginType.Runtime));
+            }
+        }
+
+        private void ConfigureNUnit4()
+        {
+            _project.AddNuGetPackage(NUnit4PackageName, NUnit4PackageVersion);
+            _project.AddNuGetPackage(NUnit4TestAdapterPackageName, NUnit4TestAdapterPackageVersion);
 
 
             if (IsReqnrollFeatureProject)
@@ -348,6 +369,7 @@ namespace Reqnroll.TestProjectGenerator
                     _project.AddFile(new ProjectFile("XUnitConfiguration.cs", "Compile", "using Xunit; [assembly: CollectionBehavior(CollectionBehavior.CollectionPerClass, MaxParallelThreads = 4)]"));
                     break;
                 case UnitTestProvider.NUnit3 when _parallelTestExecution:
+                case UnitTestProvider.NUnit4 when _parallelTestExecution:
                     _project.AddFile(new ProjectFile("NUnitConfiguration.cs", "Compile", "[assembly: NUnit.Framework.Parallelizable(NUnit.Framework.ParallelScope.All)]"));
                     break;
                 case UnitTestProvider.MSTest when _parallelTestExecution:

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/TestExecutionResult.cs
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/TestExecutionResult.cs
@@ -25,6 +25,8 @@ namespace Reqnroll.TestProjectGenerator
 
         public DateTime StartTime { get; set; }
         public DateTime EndTime { get; set; }
+
+        public string[] Warnings { get; set; }
     }
 
     public class TestResult

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/UnitTestProvider.cs
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/UnitTestProvider.cs
@@ -4,6 +4,7 @@ public enum UnitTestProvider
 {
     MSTest,
     xUnit,
+    NUnit4,
     NUnit3,
     NUnit2
 }


### PR DESCRIPTION
### 🤔 What's changed?

Fix: NUnit projects fail or provide warning as `TearDown : System.InvalidOperationException : Only static OneTimeSetUp and OneTimeTearDown are allowed for InstancePerTestCase mode.`

### ⚡️ What's your motivation? 

Fixes #320

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

n/a

### 📋 Checklist:

- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] Users should know about my change
  - [x] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
