### PR TITLE
Enhance bodi exceptions to include name of interface when duplicate registrations attempted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Improvements:
 
 ## Bug fixes:
+* Enhance BoDi error handling to provide the name of the Interface being registered when that Interface has already been resolved.
 
 *Contributors of this release (in alphabetical order):* 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Enhance BoDi error handling to provide the name of the Interface being registered when that Interface has already been resolved.
 
 *Contributors of this release (in alphabetical order):* 
+clrudolphi
 
 # v2.2.1 - 2024-11-08
 

--- a/Reqnroll/BoDi/ObjectContainer.cs
+++ b/Reqnroll/BoDi/ObjectContainer.cs
@@ -364,7 +364,7 @@ public class ObjectContainer : IObjectContainer
     public IStrategyRegistration RegisterTypeAs(Type implementationType, Type interfaceType, string name = null)
     {
         if (!IsValidTypeMapping(implementationType, interfaceType))
-            throw new InvalidOperationException($"type mapping is not valid: {implementationType} -> {interfaceType}");
+            throw new InvalidOperationException($"The type mapping is not valid. The {implementationType} is not assignable to the interface {interfaceType}");
         return RegisterTypeAsInternal(implementationType, interfaceType, name);
     }
 

--- a/Reqnroll/BoDi/ObjectContainer.cs
+++ b/Reqnroll/BoDi/ObjectContainer.cs
@@ -364,7 +364,7 @@ public class ObjectContainer : IObjectContainer
     public IStrategyRegistration RegisterTypeAs(Type implementationType, Type interfaceType, string name = null)
     {
         if (!IsValidTypeMapping(implementationType, interfaceType))
-            throw new InvalidOperationException("type mapping is not valid");
+            throw new InvalidOperationException($"type mapping is not valid: {implementationType} -> {interfaceType}");
         return RegisterTypeAsInternal(implementationType, interfaceType, name);
     }
 
@@ -500,7 +500,7 @@ public class ObjectContainer : IObjectContainer
     private void AssertNotResolved(RegistrationKey interfaceType)
     {
         if (_resolvedKeys.Contains(interfaceType))
-            throw new ObjectContainerException("An object has been resolved for this interface already.", null);
+            throw new ObjectContainerException($"An object has been resolved for this interface ({interfaceType.ToString()}) already.", null);
     }
 
     private void ClearRegistrations(RegistrationKey registrationKey)

--- a/Reqnroll/BoDi/ObjectContainer.cs
+++ b/Reqnroll/BoDi/ObjectContainer.cs
@@ -500,7 +500,7 @@ public class ObjectContainer : IObjectContainer
     private void AssertNotResolved(RegistrationKey interfaceType)
     {
         if (_resolvedKeys.Contains(interfaceType))
-            throw new ObjectContainerException($"An object has been resolved for this interface ({interfaceType.ToString()}) already.", null);
+            throw new ObjectContainerException($"An object has already been resolved for the interface \"{interfaceType}\".", null);
     }
 
     private void ClearRegistrations(RegistrationKey registrationKey)

--- a/Tests/Reqnroll.RuntimeTests/BoDi/RegisterTypeTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/BoDi/RegisterTypeTests.cs
@@ -65,8 +65,8 @@ namespace Reqnroll.RuntimeTests.BoDi
 
             // when 
             Action act = () => container.RegisterTypeAs<SimpleClassWithDefaultCtor, IInterface1>();
-            var e = act.Should().ThrowExactly<ObjectContainerException>();
-            e.Which.Message.Should().Contain("IInterface1");
+            act.Should().ThrowExactly<ObjectContainerException>()
+                .And.Message.Should().Contain("IInterface1");
         }
 
         [Fact]

--- a/Tests/Reqnroll.RuntimeTests/BoDi/RegisterTypeTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/BoDi/RegisterTypeTests.cs
@@ -65,7 +65,8 @@ namespace Reqnroll.RuntimeTests.BoDi
 
             // when 
             Action act = () => container.RegisterTypeAs<SimpleClassWithDefaultCtor, IInterface1>();
-            act.Should().ThrowExactly<ObjectContainerException>();
+            var e = act.Should().ThrowExactly<ObjectContainerException>();
+            e.Which.Message.Should().Contain("IInterface1");
         }
 
         [Fact]


### PR DESCRIPTION
Once an interface has been registered and an instance of an object for that registration has been resolved, BoDi does not allow that registration to be altered. The exception message however is vague and does not indicate which Interface registration attempt caused the exception. 



### 🤔 What's changed?

The error messages given to the BoDi exceptions have been enhanced to include type/interface information.

### ⚡️ What's your motivation? 

Ease of diagnosing error situations when enhancing Reqnroll and Plugins.

### 🏷️ What kind of change is this?


- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)


### 📋 Checklist:

- [X ] I've changed the behaviour of the code
  - [X ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ X] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.
