### PR TITLE
[Tests] Update Scrutor to Version 5.0.2 to fix vulnerability warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Bug fixes:
 
-*Contributors of this release (in alphabetical order):* 
+*Contributors of this release (in alphabetical order):* @obligaron
 
 # v2.2.1 - 2024-11-08
 

--- a/Tests/Reqnroll.SystemTests/Reqnroll.SystemTests.csproj
+++ b/Tests/Reqnroll.SystemTests/Reqnroll.SystemTests.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="Scrutor" Version="4.2.2" />
+    <PackageReference Include="Scrutor" Version="5.0.2" />
     <PackageReference Include="MSBuild.AdditionalTasks" Version="*" />
   </ItemGroup>
 

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator.Cli/Reqnroll.TestProjectGenerator.Cli.csproj
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator.Cli/Reqnroll.TestProjectGenerator.Cli.csproj
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="Scrutor" Version="4.2.2" />
+    <PackageReference Include="Scrutor" Version="5.0.2" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20253.1" />
   </ItemGroup>
 


### PR DESCRIPTION
### 🤔 What's changed?

Scrutor is updated to Version 5.0.2 in all test projects.

### ⚡️ What's your motivation? 

The following error occurs when compiling SystemTests and TestProjectGenerator.Cli

> Warning As Error: Package 'System.Text.Json' 6.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-8g4q-xg66-9fp4

System.Text.Json 6.0.0 is a (sub)dependency of Scrutor. This has been fixed in Scrutor version [5.0.2](https://github.com/khellang/Scrutor/releases/tag/v5.0.2).

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [x] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
