### PR TITLE
Improve code-behind feature file compilation speed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Improvements:
 
 * Enhance BoDi error handling to provide the name of the interface being registered when that interface has already been resolved (#324)
+* Improve code-behind feature file compilation speed (#336)
 
 ## Bug fixes:
 

--- a/Reqnroll.Generator/Generation/ScenarioPartHelper.cs
+++ b/Reqnroll.Generator/Generation/ScenarioPartHelper.cs
@@ -1,3 +1,4 @@
+using System;
 using System.CodeDom;
 using System.Collections.Generic;
 using System.Linq;
@@ -94,9 +95,18 @@ namespace Reqnroll.Generator.Generation
             
             using (new SourceLineScope(_reqnrollConfiguration, _codeDomHelper, statements, generationContext.Document.SourceFilePath, gherkinStep.Location))
             {
+                string stepKeyWord = scenarioStep.StepKeyword switch
+                {
+                    StepKeyword.Given => "Given",
+                    StepKeyword.When => "When",
+                    StepKeyword.Then => "Then",
+                    StepKeyword.And => "And",
+                    StepKeyword.But => "But",
+                    _ => throw new NotImplementedException(),
+                };
                 var expression = new CodeMethodInvokeExpression(
                     testRunnerField,
-                    scenarioStep.StepKeyword + "Async",
+                    stepKeyWord + "Async",
                     arguments.ToArray());
 
                 _codeDomHelper.MarkCodeMethodInvokeExpressionAsAwait(expression);

--- a/Reqnroll.Parser/ReqnrollGherkinParser.cs
+++ b/Reqnroll.Parser/ReqnrollGherkinParser.cs
@@ -11,7 +11,13 @@ namespace Reqnroll.Parser
     public class ReqnrollGherkinParser : IGherkinParser
     {
         private readonly IGherkinDialectProvider dialectProvider;
-        private readonly List<ISemanticValidator> semanticValidators;
+        private static readonly List<ISemanticValidator> semanticValidators = new List<ISemanticValidator>(4)
+        {
+            new DuplicateScenariosValidator(),
+            new DuplicateExamplesValidator(),
+            new MissingExamplesValidator(),
+            new DuplicateExamplesColumnHeadersValidator()
+        };
 
         public IGherkinDialectProvider DialectProvider
         {
@@ -26,13 +32,7 @@ namespace Reqnroll.Parser
         public ReqnrollGherkinParser(CultureInfo defaultLanguage)
             : this(new ReqnrollGherkinDialectProvider(defaultLanguage.Name))
         {
-            semanticValidators = new List<ISemanticValidator>
-            {
-                new DuplicateScenariosValidator(),
-                new DuplicateExamplesValidator(),
-                new MissingExamplesValidator(),
-                new DuplicateExamplesColumnHeadersValidator()
-            };
+
         }
 
         private static StepKeyword GetStepKeyword(GherkinDialect dialect, string stepKeyword)

--- a/Reqnroll.Parser/ReqnrollGherkinParserFactory.cs
+++ b/Reqnroll.Parser/ReqnrollGherkinParserFactory.cs
@@ -1,12 +1,17 @@
 using Gherkin;
+using System;
+using System.Collections.Concurrent;
 using System.Globalization;
 
 namespace Reqnroll.Parser
 {
     public class ReqnrollGherkinParserFactory : IGherkinParserFactory
     {
+        readonly ConcurrentDictionary<string, ReqnrollGherkinDialectProvider> _CachedDialectProvider = new ConcurrentDictionary<string, ReqnrollGherkinDialectProvider>();
+        static readonly Func<string, ReqnrollGherkinDialectProvider> _DialectProviderFactory = (defaultLanguage) => new ReqnrollGherkinDialectProvider(defaultLanguage);
+
         public IGherkinParser Create(IGherkinDialectProvider dialectProvider) => new ReqnrollGherkinParser(dialectProvider);
 
-        public IGherkinParser Create(CultureInfo cultureInfo) => new ReqnrollGherkinParser(cultureInfo);
+        public IGherkinParser Create(CultureInfo cultureInfo) => new ReqnrollGherkinParser(_CachedDialectProvider.GetOrAdd(cultureInfo.Name, _DialectProviderFactory));
     }
 }

--- a/Reqnroll/Parser/ReqnrollGherkinDialectProvider.cs
+++ b/Reqnroll/Parser/ReqnrollGherkinDialectProvider.cs
@@ -13,16 +13,13 @@ namespace Reqnroll.Parser
         {
             if (language.Contains("-"))
             {
-                try
-                {
-                    return base.GetDialect(language, location);
-                }
-                catch (NoSuchLanguageException)
-                {
-                    var languageBase = language.Split('-')[0];
-                    var languageBaseDialect = base.GetDialect(languageBase, location);
-                    return new GherkinDialect(language, languageBaseDialect.FeatureKeywords, languageBaseDialect.RuleKeywords, languageBaseDialect.BackgroundKeywords, languageBaseDialect.ScenarioKeywords, languageBaseDialect.ScenarioOutlineKeywords, languageBaseDialect.ExamplesKeywords, languageBaseDialect.GivenStepKeywords, languageBaseDialect.WhenStepKeywords, languageBaseDialect.ThenStepKeywords, languageBaseDialect.AndStepKeywords, languageBaseDialect.ButStepKeywords);
-                }
+                // Use TryGetDialect to avoid NoSuchLanguageException, if culture specific language is not present
+                if (TryGetDialect(language, location, out var dialect))
+                    return dialect;
+                
+                var languageBase = language.Split('-')[0];
+                var languageBaseDialect = base.GetDialect(languageBase, location);
+                return new GherkinDialect(language, languageBaseDialect.FeatureKeywords, languageBaseDialect.RuleKeywords, languageBaseDialect.BackgroundKeywords, languageBaseDialect.ScenarioKeywords, languageBaseDialect.ScenarioOutlineKeywords, languageBaseDialect.ExamplesKeywords, languageBaseDialect.GivenStepKeywords, languageBaseDialect.WhenStepKeywords, languageBaseDialect.ThenStepKeywords, languageBaseDialect.AndStepKeywords, languageBaseDialect.ButStepKeywords);
             }
 
             return base.GetDialect(language, location);


### PR DESCRIPTION
### 🤔 What's changed?

When generating a Reqnroll project with many feature files, compilation can be improved (times for `BigReqnrollProject` with 500 feature files) from 5.4s to 1.1s:

- original/main 5.4s
- making FixVB RegEx static 5.2s
- don't call VBFix in C# project 2.1s
- cache gherkin dialect (provider) and avoid assembly resource loads 1.2s
- avoid enum boxing 1.1s

This PR reduces compilation time by 80% (for large projects).

### ⚡️ What's your motivation? 

Trying to improve the compilation time of Reqnroll projects.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

I used the 

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] Users should know about my change
  - [x] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.