### PR TITLE
MsTest: Only use TestContext for output and not Console.WriteLine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Improve parameter type naming for generic types (#343)
 
 ## Bug fixes:
+* MsTest: Only use TestContext for output and not Console.WriteLine (#368) 
 
 *Contributors of this release (in alphabetical order):* @clrudolphi, @obligaron, @olegKoshmeliuk
 

--- a/Plugins/Reqnroll.MSTest.ReqnrollPlugin/MSTestTraceListener.cs
+++ b/Plugins/Reqnroll.MSTest.ReqnrollPlugin/MSTestTraceListener.cs
@@ -15,13 +15,11 @@ namespace Reqnroll.MSTest.ReqnrollPlugin
         public override void WriteTestOutput(string message)
         {
             _testContextProvider.GetTestContext().WriteLine(message);
-            base.WriteTestOutput(message);
         }
 
         public override void WriteToolOutput(string message)
         {
             _testContextProvider.GetTestContext().WriteLine("-> " + message);
-            base.WriteToolOutput(message);
         }
     }
 }

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/TRXParser.cs
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/TRXParser.cs
@@ -184,7 +184,7 @@ namespace Reqnroll.TestProjectGenerator
 
             var logLines = stdOutText.Split(new string[] { "\r\n", "\r", "\n" }, StringSplitOptions.RemoveEmptyEntries);
 
-            var primaryOutput = logLines.TakeWhile(line => line != "TestContext Messages:");
+            var primaryOutput = logLines.Where(line => line != "TestContext Messages:");
 
             TestStepResult step = null;
 


### PR DESCRIPTION
### 🤔 What's changed?

When writing output, Reqnroll only uses `TestContext` and don't write to `Console`.
The same happens already for [NUnit](https://github.com/reqnroll/Reqnroll/blob/main/Plugins/Reqnroll.NUnit.ReqnrollPlugin/NUnitTraceListener.cs#L23-L25) and [xUnit](https://github.com/reqnroll/Reqnroll/blob/main/Plugins/Reqnroll.xUnit.ReqnrollPlugin/XUnitTraceListener.cs#L33-L36).

### ⚡️ What's your motivation? 

Fixes #298

This avoids duplicate output and that Console output of tests get mixed up.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

Is there a particular reason why currently both `TestContext` and `Console` output is used?

### 📋 Checklist:

- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes. (see unit test changes)
- [x] Users should know about my change
  - [x] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.
