### PR TITLE
MSDI: Support returning `IServiceProvider` scenario dependencies with the ME.DI plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Enhance BoDi error handling to provide the name of the interface being registered when that interface has already been resolved (#324)
 * Improve code-behind feature file compilation speed (#336)
 * Improve parameter type naming for generic types (#343)
+* Support returning `IServiceProvider` from the Microsoft.Extensions.DependencyInjection plugin
 
 ## Bug fixes:
 

--- a/Plugins/Reqnroll.Microsoft.Extensions.DependencyInjection.ReqnrollPlugin/Context.cs
+++ b/Plugins/Reqnroll.Microsoft.Extensions.DependencyInjection.ReqnrollPlugin/Context.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Concurrent;
+using Microsoft.Extensions.DependencyInjection;
+using Reqnroll.Infrastructure;
+
+namespace Reqnroll.Microsoft.Extensions.DependencyInjection
+{
+    internal static class Context
+    {
+        public static readonly ConcurrentDictionary<IServiceProvider, IContextManager> BindMappings =
+            new ConcurrentDictionary<IServiceProvider, IContextManager>();
+
+        public static readonly ConcurrentDictionary<IReqnrollContext, IServiceScope> ActiveServiceScopes =
+            new ConcurrentDictionary<IReqnrollContext, IServiceScope>();
+    }
+}

--- a/Plugins/Reqnroll.Microsoft.Extensions.DependencyInjection.ReqnrollPlugin/IServiceCollectionFinder.cs
+++ b/Plugins/Reqnroll.Microsoft.Extensions.DependencyInjection.ReqnrollPlugin/IServiceCollectionFinder.cs
@@ -1,9 +1,7 @@
-﻿using Microsoft.Extensions.DependencyInjection;
-
-namespace Reqnroll.Microsoft.Extensions.DependencyInjection
+﻿namespace Reqnroll.Microsoft.Extensions.DependencyInjection
 {
     public interface IServiceCollectionFinder
     {
-        (IServiceCollection, ScopeLevelType) GetServiceCollection();
+        (ServicesEntryPoint, ScopeLevelType) GetServiceEntryPoint();
     }
 }

--- a/Plugins/Reqnroll.Microsoft.Extensions.DependencyInjection.ReqnrollPlugin/MissingScenarioDependenciesException.cs
+++ b/Plugins/Reqnroll.Microsoft.Extensions.DependencyInjection.ReqnrollPlugin/MissingScenarioDependenciesException.cs
@@ -6,7 +6,7 @@ namespace Reqnroll.Microsoft.Extensions.DependencyInjection
     public class MissingScenarioDependenciesException : ReqnrollException
     {
         public MissingScenarioDependenciesException()
-            : base("No method marked with [ScenarioDependencies] attribute found.")
+            : base("No method marked with [ScenarioDependencies] attribute found, or unsupported return type specified.")
         {
             HelpLink = "https://go.reqnroll.net/doc-msdi";
         }

--- a/Plugins/Reqnroll.Microsoft.Extensions.DependencyInjection.ReqnrollPlugin/ScenarioDependenciesAttribute.cs
+++ b/Plugins/Reqnroll.Microsoft.Extensions.DependencyInjection.ReqnrollPlugin/ScenarioDependenciesAttribute.cs
@@ -20,6 +20,9 @@ namespace Reqnroll.Microsoft.Extensions.DependencyInjection
         /// <summary>
         /// Automatically register all SpecFlow bindings.
         /// </summary>
+        /// <remarks>
+        /// This setting is ignored when returning an IServiceProvider from the method.
+        /// </remarks>
         public bool AutoRegisterBindings { get; set; } = true;
 
         /// <summary>

--- a/Plugins/Reqnroll.Microsoft.Extensions.DependencyInjection.ReqnrollPlugin/ServiceCollectionExtensions.cs
+++ b/Plugins/Reqnroll.Microsoft.Extensions.DependencyInjection.ReqnrollPlugin/ServiceCollectionExtensions.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Reqnroll.Bindings;
+using Reqnroll.Infrastructure;
+
+namespace Reqnroll.Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// Service collection extension methods.
+    /// </summary>
+    public static class ServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Add Reqnroll binding for classes in the assembly where typeof TAssemblyType resides.
+        /// </summary>
+        /// <typeparam name="TAssemblyType">Any type in an assembly to search for bindings.</typeparam>
+        /// <param name="services">The service collection.</param>
+        /// <returns>The service collection.</returns>
+        public static IServiceCollection AddReqnrollBindings<TAssemblyType>(this IServiceCollection services)
+        {
+            return services.AddReqnrollBindings(typeof(TAssemblyType));
+        }
+
+        /// <summary>
+        /// Add Reqnroll binding for classes in the assembly where the type resides.
+        /// </summary>
+        /// <param name="services">The service collection.</param>
+        /// <param name="type">Any type in an assembly to search for bindings.</param>
+        /// <returns>The service collection.</returns>
+        public static IServiceCollection AddReqnrollBindings(this IServiceCollection services, Type type)
+        {
+            return services.AddReqnrollBindings(type.Assembly);
+        }
+
+        /// <summary>
+        /// Add Reqnroll binding for classes in an assembly.
+        /// </summary>
+        /// <param name="services">The service collection.</param>
+        /// <param name="assembly">The assembly to search for bindings.</param>
+        /// <returns>The service collection.</returns>
+        public static IServiceCollection AddReqnrollBindings(this IServiceCollection services, Assembly assembly)
+        {
+            foreach (var type in assembly.GetTypes().Where(t => Attribute.IsDefined(t, typeof(BindingAttribute))))
+            {
+                services.AddScoped(type);
+            }
+
+            services.TryAddTransient(sp => sp.GetTestThreadDependency(cm => cm));
+            services.TryAddTransient(sp => sp.GetTestThreadDependency(cm => cm.TestThreadContext));
+            services.TryAddTransient(sp => sp.GetTestThreadDependency(cm => cm.FeatureContext));
+            services.TryAddTransient(sp => sp.GetTestThreadDependency(cm => cm.ScenarioContext));
+            services.TryAddTransient(sp => sp.GetTestThreadDependency(cm => cm.TestThreadContext.TestThreadContainer.Resolve<ITestRunner>()));
+            services.TryAddTransient(sp => sp.GetTestThreadDependency(cm => cm.TestThreadContext.TestThreadContainer.Resolve<ITestExecutionEngine>()));
+            services.TryAddTransient(sp => sp.GetTestThreadDependency(cm => cm.TestThreadContext.TestThreadContainer.Resolve<IStepArgumentTypeConverter>()));
+            services.TryAddTransient(sp => sp.GetTestThreadDependency(cm => cm.TestThreadContext.TestThreadContainer.Resolve<IStepDefinitionMatchService>()));
+            services.TryAddTransient(sp => sp.GetTestThreadDependency(cm => cm.TestThreadContext.TestThreadContainer.Resolve<IReqnrollOutputHelper>()));
+
+            return services;
+        }
+    }
+}

--- a/Plugins/Reqnroll.Microsoft.Extensions.DependencyInjection.ReqnrollPlugin/ServiceProviderExtensions.cs
+++ b/Plugins/Reqnroll.Microsoft.Extensions.DependencyInjection.ReqnrollPlugin/ServiceProviderExtensions.cs
@@ -1,0 +1,34 @@
+﻿using Reqnroll.Infrastructure;
+using System;
+
+namespace Reqnroll.Microsoft.Extensions.DependencyInjection
+{
+    internal static class ServiceProviderExtensions
+    {
+        public static TResult GetTestThreadDependency<TResult>(this IServiceProvider sp, Func<IContextManager, TResult> selector) where TResult : class
+        {
+            string GetErrorMessage()
+                => $"Unable to access test execution dependent service '{typeof(TResult).FullName}' with the Reqnroll.Microsoft.Extensions.DependencyInjection plugin. This service is only available once test execution has been started and cannot be used in '[BeforeTestRun]' hook. See https://go.reqnroll.net/doc-migrate-specflow-testrun-hooks for details.";
+
+            if (!Context.BindMappings.TryGetValue(sp, out var contextManager))
+            {
+                throw new ReqnrollException(GetErrorMessage());
+            }
+
+            TResult result;
+            try
+            {
+                result = selector(contextManager);
+            }
+            catch (Exception ex)
+            {
+                throw new ReqnrollException(GetErrorMessage(), ex);
+            }
+
+            if (result == null)
+                throw new ReqnrollException(GetErrorMessage());
+
+            return result;
+        }
+    }
+}

--- a/Plugins/Reqnroll.Microsoft.Extensions.DependencyInjection.ReqnrollPlugin/ServicesEntryPoint.cs
+++ b/Plugins/Reqnroll.Microsoft.Extensions.DependencyInjection.ReqnrollPlugin/ServicesEntryPoint.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Reqnroll.Microsoft.Extensions.DependencyInjection
+{
+    public class ServicesEntryPoint
+    {
+        public IServiceCollection ServiceCollection { get; set; }
+
+        public IServiceProvider ServiceProvider { get; set; }
+    }
+}


### PR DESCRIPTION
<!---
Thanks for helping to make Reqnroll better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻

You can delete these comment sections as you process them.
-->

### 🤔 What's changed?

The ME.DI plugin can now return an `IServiceProvider` from the static method, in addition to supporting the `IServiceCollection` type.

### ⚡️ What's your motivation? 

This supports scenarios when integration testing ASP.NET Core projects, where we have a service container built and owned by the `WebApplicationFactory` (or other scenarios). The downside is that you must manually register the bindings, but there is already precedent for this in the Windsor plugin, where we have to do the same.

There is no change to the public API other than being able to return `IServiceProvider` from the static method. The `AutoRegisterBindings` setting is ignored when returning `IServiceProvider` and I've added some xmldoc comments to that effect.

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :book: Documentation (improvements without changing code)
- :boom: Breaking change (incompatible changes to the API)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
