### PR TITLE
Changed Output API documentation _outputHelper to _reqnrollOutputHelper in constructor

### DIFF
--- a/docs/execution/output-api.md
+++ b/docs/execution/output-api.md
@@ -11,7 +11,7 @@ private readonly IReqnrollOutputHelper _reqnrollOutputHelper;
 
 public CalculatorStepDefinitions(IReqnrollOutputHelper outputHelper)
 {
-    _outputHelper = outputHelper;
+    _reqnrollOutputHelper = outputHelper;
 }
 ```
 


### PR DESCRIPTION
### 🤔 What's changed?

I changed the documentation output API constructor to contain _reqnrollOutputHelper instead of _outputHelper

### ⚡️ What's your motivation? 

I noticed this small error while reading the documentation

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :book: Documentation (improvements without changing code)

### ♻️ Anything particular you want feedback on?

Not sure if refacotring the field to _outputHelper would've been more appriciated than changing the constructor

### 📋 Checklist:


- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
