### PR TITLE
support exact match for table aliases

### DIFF
--- a/Reqnroll/Assist/Attributes/TableAliasesAttribute.cs
+++ b/Reqnroll/Assist/Attributes/TableAliasesAttribute.cs
@@ -13,6 +13,13 @@ namespace Reqnroll.Assist.Attributes
             Aliases = aliases;
         }
 
+        public TableAliasesAttribute(bool useExactMatch, params string[] aliases)
+        {
+            UseExactMatch = useExactMatch;
+            Aliases = aliases;
+        }
+
         public string[] Aliases { get; }
+        public bool UseExactMatch { get; }
     }
 }

--- a/Reqnroll/Assist/TEHelpers.cs
+++ b/Reqnroll/Assist/TEHelpers.cs
@@ -1,10 +1,10 @@
+using Reqnroll.Assist.Attributes;
+using Reqnroll.Tracing;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
-using Reqnroll.Assist.Attributes;
-using Reqnroll.Tracing;
 
 namespace Reqnroll.Assist
 {
@@ -180,7 +180,7 @@ namespace Reqnroll.Assist
         private static bool IsMatchingAlias(MemberInfo field, string id)
         {
             var aliases = field.GetCustomAttributes().OfType<TableAliasesAttribute>();
-            return aliases.Any(a => a.Aliases.Any(al => Regex.Match(id, al).Success));
+            return aliases.Any(a => a.Aliases.Any(al => a.UseExactMatch ? id == al : Regex.Match(id, al).Success));
         }
 
         private static bool TheseTypesMatch(Type targetType, Type memberType, DataTableRow row)


### PR DESCRIPTION
### 🤔 What's changed?

It adds support for exact match comparison of table aliases.

### ⚡️ What's your motivation? 

This allows to use table aliases that are substring of another one.
Like:
Amount
Amount Calculation Method

### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)

### 📋 Checklist:

- [x] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
