### PR TITLE
Fix: Reqnroll.Autofac: FeatureContext cannot be resolved in BeforeFeature/AfterFeature hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Fix: Replace deprecated dependency `Specflow.Internal.Json` with `System.Text.Json`. The dependency was used for laoding `reqnroll.json`, for Visual Studio integration and for telemetry. (#373)
 * Fix: Support loading plugin dependencies from .deps.json on .NET Framework and Visual Studio MSBuild (#408)
 * Fix: Error with NUnit 4: "Only static OneTimeSetUp and OneTimeTearDown are allowed for InstancePerTestCase mode" (#379)
+* Fix: Reqnroll.Autofac: FeatureContext cannot be resolved in BeforeFeature/AfterFeature hooks (#340)
 
 *Contributors of this release (in alphabetical order):* @clrudolphi, @gasparnagy, @obligaron, @olegKoshmeliuk, @SeanKilleen
 

--- a/Plugins/Reqnroll.Autofac.ReqnrollPlugin/AutofacTestObjectResolver.cs
+++ b/Plugins/Reqnroll.Autofac.ReqnrollPlugin/AutofacTestObjectResolver.cs
@@ -9,25 +9,29 @@ namespace Reqnroll.Autofac
     {
         public object ResolveBindingInstance(Type bindingType, IObjectContainer container)
         {
-            if (container.IsRegistered<IComponentContext>())
+            var componentContext = container switch
             {
-                var componentContext = container.Resolve<IComponentContext>();
-                return componentContext.Resolve(bindingType);
+                _ when container.IsRegistered<IComponentContext>() => container.Resolve<IComponentContext>(),
+                _ when container.IsRegistered<ILifetimeScope>() => container.Resolve<ILifetimeScope>(),
+                _ when container.IsRegistered<IContainer>() => container.Resolve<IContainer>(),
+                _ => null
+            };
+
+            if (componentContext == null)
+                return container.Resolve(bindingType);
+
+            if (container.IsRegistered(bindingType))
+            {
+                // If the requested object is registered in the Reqnroll container, 
+                // we give a chance to the Autofac container to resolve
+                // but fall back to the Reqnroll one.
+                if (componentContext.TryResolve(bindingType, out object instance))
+                    return instance;
+                return container.Resolve(bindingType);
             }
 
-            if (container.IsRegistered<ILifetimeScope>())
-            {
-                var lifeTimeScope = container.Resolve<ILifetimeScope>();
-                return lifeTimeScope.Resolve(bindingType);
-            }
-
-            if (container.IsRegistered<IContainer>())
-            {
-                var lifeTimeScope = container.Resolve<IContainer>();
-                return lifeTimeScope.Resolve(bindingType);
-            }
-
-            return container.Resolve(bindingType);
+            // If this is not in Reqnroll container we get it from Autofac and let it fail if it's not there.
+            return componentContext.Resolve(bindingType);
         }
     }
 }

--- a/Tests/Reqnroll.PluginTests/Autofac/AutofacPluginTests.cs
+++ b/Tests/Reqnroll.PluginTests/Autofac/AutofacPluginTests.cs
@@ -279,8 +279,8 @@ private readonly RuntimePluginEvents _runtimePluginEvents;
         _testThreadContainer.RegisterInstanceAs(testThreadContext);
 
         // Assert
-        //var resolvedContainer = resolver.ResolveBindingInstance(typeof(IObjectContainer), _featureContainer);
-        //resolvedContainer.Should().BeSameAs(_featureContainer);
+        var resolvedContainer = resolver.ResolveBindingInstance(typeof(IObjectContainer), _featureContainer);
+        resolvedContainer.Should().BeSameAs(_featureContainer);
 
         var resolvedFeatureContext = resolver.ResolveBindingInstance(typeof(FeatureContext), _featureContainer);
         resolvedFeatureContext.Should().BeSameAs(featureContext);

--- a/Tests/Reqnroll.PluginTests/Autofac/AutofacPluginTests.cs
+++ b/Tests/Reqnroll.PluginTests/Autofac/AutofacPluginTests.cs
@@ -231,7 +231,7 @@ private readonly RuntimePluginEvents _runtimePluginEvents;
 
 
     [Fact]
-    public void Should_allow_resolving_common_reqnroll_objects()
+    public void Should_allow_resolving_common_reqnroll_objects_from_scenario_container()
     {
         // Arrange
         var sut = new TestableAutofacPlugin(typeof(ContainerSetup1),
@@ -259,6 +259,33 @@ private readonly RuntimePluginEvents _runtimePluginEvents;
         resolvedFeatureContext.Should().BeSameAs(featureContext);
 
         var resolvedTestThreadContext = resolver.ResolveBindingInstance(typeof(TestThreadContext), scenarioContainer);
+        resolvedTestThreadContext.Should().BeSameAs(testThreadContext);
+    }
+
+    [Fact]
+    public void Should_allow_resolving_common_reqnroll_objects_from_feature_container()
+    {
+        // Arrange
+        var sut = new TestableAutofacPlugin(typeof(ContainerSetup1),
+                                            nameof(ContainerSetup1.SetupGlobalContainer),
+                                            nameof(ContainerSetup1.SetupScenarioContainer));
+
+        // Act
+        InitializeToScenarioContainer(sut);
+        var resolver = _testRunContainer.Resolve<ITestObjectResolver>();
+        var featureContext = new FeatureContext(_featureContainer, new FeatureInfo(CultureInfo.CurrentCulture, "", "", ""), ConfigurationLoader.GetDefault());
+        _featureContainer.RegisterInstanceAs(featureContext);
+        var testThreadContext = new TestThreadContext(_testThreadContainer);
+        _testThreadContainer.RegisterInstanceAs(testThreadContext);
+
+        // Assert
+        //var resolvedContainer = resolver.ResolveBindingInstance(typeof(IObjectContainer), _featureContainer);
+        //resolvedContainer.Should().BeSameAs(_featureContainer);
+
+        var resolvedFeatureContext = resolver.ResolveBindingInstance(typeof(FeatureContext), _featureContainer);
+        resolvedFeatureContext.Should().BeSameAs(featureContext);
+
+        var resolvedTestThreadContext = resolver.ResolveBindingInstance(typeof(TestThreadContext), _featureContainer);
         resolvedTestThreadContext.Should().BeSameAs(testThreadContext);
     }
 


### PR DESCRIPTION
### 🤔 What's changed?

Changed Reqnroll.Autofac `AutofacTestObjectResolver` to be able to resolve object (typically Renqroll internal objects) that are registered in the Reqnroll container but not in the Autofac one.

### ⚡️ What's your motivation? 

Fixes #340 

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

n/a 

### 📋 Checklist:

- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] Users should know about my change
  - [x] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
