### PR TITLE
Replace custom namespace globalization with idiomatic approach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Improve parameter type naming for generic types (#343)
 * Reduced MsBuild log output and consistent use of [Reqnroll] prefix (#381)
 * Update behavior of `ObjectContainer.IsRegistered()` to check base container for registrations, to match `Resolve()` behavior (#367)
+* Replaced custom approach for avoiding namespace collisions with .net idiomatic approach
 
 ## Bug fixes:
 * MsTest: Only use TestContext for output and not Console.WriteLine (#368) 

--- a/Reqnroll.Generator/CodeDom/CodeDomHelper.cs
+++ b/Reqnroll.Generator/CodeDom/CodeDomHelper.cs
@@ -289,21 +289,6 @@ namespace Reqnroll.Generator.CodeDom
             };
         }
 
-        public string GetGlobalizedTypeName(Type type)
-        {
-            return GetGlobalizedTypeName(type.FullName!);
-        }
-
-        public string GetGlobalizedTypeName(string typeName)
-        {
-            if (TargetLanguage == CodeDomProviderLanguage.CSharp)
-            {
-                return "global::" + typeName;
-            }
-            // Global namespaces not yet supported in VB
-            return typeName;
-        }
-
         public CodeExpression CreateOptionalArgumentExpression(string parameterName, CodeVariableReferenceExpression valueExpression)
         {
             switch (TargetLanguage)

--- a/Reqnroll.Generator/CodeDom/CodeDomHelper.cs
+++ b/Reqnroll.Generator/CodeDom/CodeDomHelper.cs
@@ -289,6 +289,23 @@ namespace Reqnroll.Generator.CodeDom
             };
         }
 
+        [Obsolete("Not used anymore, will be removed with Reqnroll future versions")]
+        public string GetGlobalizedTypeName(Type type)
+        {
+            return GetGlobalizedTypeName(type.FullName!);
+        }
+
+        [Obsolete("Not used anymore, will be removed with Reqnroll future versions")]
+        public string GetGlobalizedTypeName(string typeName)
+        {
+            if (TargetLanguage == CodeDomProviderLanguage.CSharp)
+            {
+                return "global::" + typeName;
+            }
+            // Global namespaces not yet supported in VB
+            return typeName;
+        }
+
         public CodeExpression CreateOptionalArgumentExpression(string parameterName, CodeVariableReferenceExpression valueExpression)
         {
             switch (TargetLanguage)

--- a/Reqnroll.Generator/Generation/ScenarioPartHelper.cs
+++ b/Reqnroll.Generator/Generation/ScenarioPartHelper.cs
@@ -140,7 +140,7 @@ namespace Reqnroll.Generator.Generation
         {
             if (tableArg == null)
             {
-                return new CodeCastExpression(_codeDomHelper.GetGlobalizedTypeName(typeof(Table)), new CodePrimitiveExpression(null));
+                return new CodeCastExpression(new CodeTypeReference(typeof(Table), CodeTypeReferenceOptions.GlobalReference), new CodePrimitiveExpression(null));
             }
 
             _tableCounter++;
@@ -152,9 +152,9 @@ namespace Reqnroll.Generator.Generation
             //Table table0 = new Table(header...);
             var tableVar = new CodeVariableReferenceExpression("table" + _tableCounter);
             statements.Add(
-                new CodeVariableDeclarationStatement(_codeDomHelper.GetGlobalizedTypeName(typeof(Table)), tableVar.VariableName,
+                new CodeVariableDeclarationStatement(new CodeTypeReference(typeof(Table), CodeTypeReferenceOptions.GlobalReference), tableVar.VariableName,
                     new CodeObjectCreateExpression(
-                        _codeDomHelper.GetGlobalizedTypeName(typeof(Table)),
+                        new CodeTypeReference(typeof(Table), CodeTypeReferenceOptions.GlobalReference),
                         GetStringArrayExpression(header.Cells.Select(c => c.Value), paramToIdentifier))));
 
             foreach (var row in body)

--- a/Reqnroll.Generator/Generation/UnitTestFeatureGenerator.cs
+++ b/Reqnroll.Generator/Generation/UnitTestFeatureGenerator.cs
@@ -157,7 +157,7 @@ namespace Reqnroll.Generator.Generation
 
         private CodeMemberField DeclareTestRunnerMember(CodeTypeDeclaration type)
         {
-            var testRunnerField = new CodeMemberField(_codeDomHelper.GetGlobalizedTypeName(typeof(ITestRunner)), GeneratorConstants.TESTRUNNER_FIELD);
+            var testRunnerField = new CodeMemberField(new CodeTypeReference(typeof(ITestRunner), CodeTypeReferenceOptions.GlobalReference), GeneratorConstants.TESTRUNNER_FIELD);
             type.Members.Add(testRunnerField);
             return testRunnerField;
         }
@@ -173,16 +173,16 @@ namespace Reqnroll.Generator.Generation
         private void DeclareFeatureInfoMember(TestClassGenerationContext generationContext)
         {
             var featureInfoField = new CodeMemberField(
-                _codeDomHelper.GetGlobalizedTypeName(typeof(FeatureInfo)), GeneratorConstants.FEATUREINFO_FIELD);
+                new CodeTypeReference(typeof(FeatureInfo), CodeTypeReferenceOptions.GlobalReference), GeneratorConstants.FEATUREINFO_FIELD);
             featureInfoField.Attributes |= MemberAttributes.Static;
-            featureInfoField.InitExpression = new CodeObjectCreateExpression(_codeDomHelper.GetGlobalizedTypeName(typeof(FeatureInfo)),
+            featureInfoField.InitExpression = new CodeObjectCreateExpression(new CodeTypeReference(typeof(FeatureInfo), CodeTypeReferenceOptions.GlobalReference),
                 new CodeObjectCreateExpression(typeof(CultureInfo),
                                                new CodePrimitiveExpression(generationContext.Feature.Language)),
                 new CodePrimitiveExpression(generationContext.Document.DocumentLocation?.FeatureFolderPath),
                 new CodePrimitiveExpression(generationContext.Feature.Name),
                 new CodePrimitiveExpression(generationContext.Feature.Description),
                 new CodeFieldReferenceExpression(
-                    new CodeTypeReferenceExpression(_codeDomHelper.GetGlobalizedTypeName(typeof(ProgrammingLanguage))),
+                    new CodeTypeReferenceExpression(new CodeTypeReference(typeof(ProgrammingLanguage), CodeTypeReferenceOptions.GlobalReference)),
                     _codeDomHelper.TargetLanguage.ToString()),
                 new CodeFieldReferenceExpression(null, GeneratorConstants.FEATURE_TAGS_VARIABLE_NAME));
 
@@ -230,7 +230,7 @@ namespace Reqnroll.Generator.Generation
             var testRunnerField = _scenarioPartHelper.GetTestRunnerExpression();
 
             var getTestRunnerExpression = new CodeMethodInvokeExpression(
-                new CodeTypeReferenceExpression(_codeDomHelper.GetGlobalizedTypeName(typeof(TestRunnerManager))),
+                new CodeTypeReferenceExpression(new CodeTypeReference(typeof(TestRunnerManager), CodeTypeReferenceOptions.GlobalReference)),
                 nameof(TestRunnerManager.GetTestRunnerForAssembly),
                 _codeDomHelper.CreateOptionalArgumentExpression("featureHint", 
                     new CodeVariableReferenceExpression(GeneratorConstants.FEATUREINFO_FIELD)));
@@ -323,7 +323,7 @@ namespace Reqnroll.Generator.Generation
             // TestRunnerManager.ReleaseTestRunner(testRunner);
             testCleanupMethod.Statements.Add(
                 new CodeMethodInvokeExpression(
-                    new CodeTypeReferenceExpression(_codeDomHelper.GetGlobalizedTypeName(typeof(TestRunnerManager))),
+                    new CodeTypeReferenceExpression(new CodeTypeReference(typeof(TestRunnerManager), CodeTypeReferenceOptions.GlobalReference)),
                     nameof(TestRunnerManager.ReleaseTestRunner),
                     testRunnerField));
         }
@@ -335,7 +335,7 @@ namespace Reqnroll.Generator.Generation
             scenarioInitializeMethod.Attributes = MemberAttributes.Public | MemberAttributes.Final;
             scenarioInitializeMethod.Name = GeneratorConstants.SCENARIO_INITIALIZE_NAME;
             scenarioInitializeMethod.Parameters.Add(
-                new CodeParameterDeclarationExpression(_codeDomHelper.GetGlobalizedTypeName(typeof(ScenarioInfo)), "scenarioInfo"));
+                new CodeParameterDeclarationExpression(new CodeTypeReference(typeof(ScenarioInfo), CodeTypeReferenceOptions.GlobalReference), "scenarioInfo"));
 
             //testRunner.OnScenarioInitialize(scenarioInfo);
             var testRunnerField = _scenarioPartHelper.GetTestRunnerExpression();

--- a/Reqnroll.Generator/Generation/UnitTestMethodGenerator.cs
+++ b/Reqnroll.Generator/Generation/UnitTestMethodGenerator.cs
@@ -191,8 +191,8 @@ namespace Reqnroll.Generator.Generation
             AddVariableForArguments(testMethod, paramToIdentifier);
 
             testMethod.Statements.Add(
-                new CodeVariableDeclarationStatement(_codeDomHelper.GetGlobalizedTypeName(typeof(ScenarioInfo)), "scenarioInfo",
-                    new CodeObjectCreateExpression(_codeDomHelper.GetGlobalizedTypeName(typeof(ScenarioInfo)),
+                new CodeVariableDeclarationStatement(new CodeTypeReference(typeof(ScenarioInfo), CodeTypeReferenceOptions.GlobalReference), "scenarioInfo",
+                    new CodeObjectCreateExpression(new CodeTypeReference(typeof(ScenarioInfo), CodeTypeReferenceOptions.GlobalReference),
                         new CodePrimitiveExpression(scenarioDefinition.Name),
                         new CodePrimitiveExpression(scenarioDefinition.Description),
                         new CodeVariableReferenceExpression(GeneratorConstants.SCENARIO_TAGS_VARIABLE_NAME),
@@ -279,7 +279,7 @@ namespace Reqnroll.Generator.Generation
 
             var scenarioCombinedTagsPropertyExpression = new CodePropertyReferenceExpression(new CodeVariableReferenceExpression("scenarioInfo"), "CombinedTags");
 
-            var tagHelperReference = new CodeTypeReferenceExpression(_codeDomHelper.GetGlobalizedTypeName(typeof(TagHelper)));
+            var tagHelperReference = new CodeTypeReferenceExpression(new CodeTypeReference(typeof(TagHelper), CodeTypeReferenceOptions.GlobalReference));
             var scenarioTagIgnoredCheckStatement = new CodeMethodInvokeExpression(tagHelperReference, nameof(TagHelper.ContainsIgnoreTag), scenarioCombinedTagsPropertyExpression);
             var featureTagIgnoredCheckStatement = new CodeMethodInvokeExpression(tagHelperReference, nameof(TagHelper.ContainsIgnoreTag), featureFileTagFieldReferenceExpression);
 

--- a/Reqnroll.Generator/UnitTestProvider/NUnit3TestGeneratorProvider.cs
+++ b/Reqnroll.Generator/UnitTestProvider/NUnit3TestGeneratorProvider.cs
@@ -75,7 +75,7 @@ namespace Reqnroll.Generator.UnitTestProvider
             CodeDomHelper.AddAttribute(generationContext.TestClass, DESCRIPTION_ATTR, featureTitle);
             CodeDomHelper.AddAttribute(generationContext.TestClass, FIXTURELIFECYCLE_ATTR, 
                 new CodeAttributeArgument(
-                    new CodeSnippetExpression($"{CodeDomHelper.GetGlobalizedTypeName(LIFECYCLE_CLASS)}.{LIFECYCLE_INSTANCEPERTESTCASE}")));
+                    new CodeSnippetExpression($"{LIFECYCLE_CLASS}.{LIFECYCLE_INSTANCEPERTESTCASE}")));
         }
 
         public void SetTestClassCategories(TestClassGenerationContext generationContext, IEnumerable<string> featureCategories)


### PR DESCRIPTION
### 🤔 What's changed?

We had built a custom CodeDomHelper function to create the "global::" prefix to Reqnroll type names in order to avoid namespace collisions with user-provided test names.
This change eliminates that custom function in favor of using the idiomatic means provided by .net: a CodeTypeReference with a constructor argument of CodeTypeReferenceOptions.GlobalReference.

### ⚡️ What's your motivation? 

Code clean-up.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)



### 📋 Checklist:


- [X ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ X] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

