### PR TITLE
Fix: Attempting to set the `ConcurrentObjectResolutionTimeout` value on the `ObjectContainer` to `TimeSpan.Zero` sometimes throws an exception if running multiple tests in parallel.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Fix: Deprecated dependency `Specflow.Internal.Json` is used. Relpaced with `System.Text.Json`. The dependency was used for laoding `reqnroll.json`, for Visual Studio integration and for telemetry. (#373)
 * Fix: Error with NUnit 4: "Only static OneTimeSetUp and OneTimeTearDown are allowed for InstancePerTestCase mode" (#379)
 * Fix: Reqnroll.Autofac: FeatureContext cannot be resolved in BeforeFeature/AfterFeature hooks (#340)
+* Fix: Attempting to set the `ConcurrentObjectResolutionTimeout` value on the `ObjectContainer` to `TimeSpan.Zero` sometimes throws an exception if running multiple tests in parallel. (#440)
 
 *Contributors of this release (in alphabetical order):* @Antwane, @clrudolphi, @gasparnagy, @obligaron, @olegKoshmeliuk, @SeanKilleen, @StefH
 

--- a/Reqnroll/BoDi/ObjectContainer.cs
+++ b/Reqnroll/BoDi/ObjectContainer.cs
@@ -238,7 +238,17 @@ public class ObjectContainer : IObjectContainer
                 return obj;
 
             if (timeout == TimeSpan.Zero)
-                return factory();
+            {
+                Monitor.Enter(lockObject);
+                try
+                {
+                    return factory();
+                }
+                finally
+                {
+                    Monitor.Exit(lockObject);
+                }
+            }
 
             if (Monitor.TryEnter(lockObject, timeout))
             {


### PR DESCRIPTION
### 🤔 What's changed?

Changed the behavior of the non-default 0 timeout case that it also acquires a lock, because that seems to be needed for the thread safety of the container. 
The default behavior is not changed. 

### ⚡️ What's your motivation? 

Fixes #440

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

n/a

### 📋 Checklist:

- [x] I've changed the behaviour of the code
- [x] Users should know about my change
  - [x] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
