### PR TITLE
Add documentation build to the CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
     branches: 
       - 'main'
     paths-ignore:
-      - 'docs/**'
       - README.md
       - CHANGELOG.md
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,9 +295,29 @@ jobs:
         if-no-files-found: error
         path: "TestResults/*.trx"
     
+  build-docs:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install Doc Dependencies
+      working-directory: docs
+      run: | 
+        pip install -r requirements.txt
+    - name: Build Doc
+      working-directory: docs
+      run: |
+        sphinx-build -M html . _build
+    - name: Upload HTML Doc Files
+      uses: actions/upload-artifact@v4
+      with:
+        name: html-docs
+        if-no-files-found: error
+        path: "docs/_build/html/**/*"
+    
   release:
     runs-on: ubuntu-latest
-    needs: [build, specs, system-tests-windows, system-tests-linux]
+    needs: [build, specs, system-tests-windows, system-tests-linux, build-docs]
     environment: production_environment
     if: github.ref == 'refs/heads/main' && needs.build.outputs.deploy_packages == 'true'
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,7 +316,7 @@ jobs:
     
   release:
     runs-on: ubuntu-latest
-    needs: [build, specs, system-tests-windows, system-tests-linux, build-docs]
+    needs: [build, specs, system-tests-windows, system-tests-linux]
     environment: production_environment
     if: github.ref == 'refs/heads/main' && needs.build.outputs.deploy_packages == 'true'
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,7 +307,7 @@ jobs:
     - name: Build Doc
       working-directory: docs
       run: |
-        sphinx-build -M html . _build
+        sphinx-build -M html . _build --fail-on-warning
     - name: Upload HTML Doc Files
       uses: actions/upload-artifact@v4
       with:

--- a/docs/guides/migrating-from-specflow.md
+++ b/docs/guides/migrating-from-specflow.md
@@ -7,9 +7,9 @@ The key differences between SpecFlow and Reqnroll are the following:
 * All packages have been renamed from `SpecFlow.*` to `Reqnroll.*`. E.g. `Reqnroll.MsTest`.
 * The namespace of the classes has been changed from `TechTalk.SpecFlow` to `Reqnroll` and some classes that had SpecFlow in their name (e.g. `ISpecFlowOutputHelper`) have been renamed accordingly. An optional *SpecFlow Compatibility Package* has been created to migrate without changing all namespaces, see below.
 * There is a new `DataTable` alias for the `Table` class to better match Gherkin terminology. The `Table` class can still be used.
-* The main extension methods of the *Assist helpers* have been moved to the `Reqnroll` namespace, so that they can be used without an additional namespace using statement. The helpers are now referred to as [](../automation/datatable-helpers-broken.md).
+* The main extension methods of the *Assist helpers* have been moved to the `Reqnroll` namespace, so that they can be used without an additional namespace using statement. The helpers are now referred to as [](../automation/datatable-helpers.md).
 * The namespace of `IObjectContainer` has been changed from `BoDi` to `Reqnroll.BoDi`. If you have used special customizations that required to access the dependency injection container directly, you might need to update the namespace usings.
-* The [Reqnroll Visual Studio extension](../installation/setup-ide.md#setup-visual-studio-2022broken) has been reworked in a way that it can handle both SpecFlow and Reqnroll projects (also for .NET 8.0).
+* The [Reqnroll Visual Studio extension](../installation/setup-ide.md#setup-visual-studio-2022) has been reworked in a way that it can handle both SpecFlow and Reqnroll projects (also for .NET 8.0).
 * The integration plugins that have been managed by SpecFlow have been also ported to work with Reqnroll (e.g. `Reqnroll.Autofac`). See [](../integrations/available-plugins.md).
 * The "SpecFlow.Actions" plugins that provide a ready-to-use support for different automation technologies (e.g. Selenium) are ported as `Reqnroll.SpecFlowCompatibility.Actions.*` packages (e.g. `Reqnroll.SpecFlowCompatibility.Actions.Selenium`). 
 

--- a/docs/guides/migrating-from-specflow.md
+++ b/docs/guides/migrating-from-specflow.md
@@ -7,7 +7,7 @@ The key differences between SpecFlow and Reqnroll are the following:
 * All packages have been renamed from `SpecFlow.*` to `Reqnroll.*`. E.g. `Reqnroll.MsTest`.
 * The namespace of the classes has been changed from `TechTalk.SpecFlow` to `Reqnroll` and some classes that had SpecFlow in their name (e.g. `ISpecFlowOutputHelper`) have been renamed accordingly. An optional *SpecFlow Compatibility Package* has been created to migrate without changing all namespaces, see below.
 * There is a new `DataTable` alias for the `Table` class to better match Gherkin terminology. The `Table` class can still be used.
-* The main extension methods of the *Assist helpers* have been moved to the `Reqnroll` namespace, so that they can be used without an additional namespace using statement. The helpers are now referred to as [](../automation/datatable-helpers.md).
+* The main extension methods of the *Assist helpers* have been moved to the `Reqnroll` namespace, so that they can be used without an additional namespace using statement. The helpers are now referred to as [](../automation/datatable-helpers-broken.md).
 * The namespace of `IObjectContainer` has been changed from `BoDi` to `Reqnroll.BoDi`. If you have used special customizations that required to access the dependency injection container directly, you might need to update the namespace usings.
 * The [Reqnroll Visual Studio extension](../installation/setup-ide.md#setup-visual-studio-2022broken) has been reworked in a way that it can handle both SpecFlow and Reqnroll projects (also for .NET 8.0).
 * The integration plugins that have been managed by SpecFlow have been also ported to work with Reqnroll (e.g. `Reqnroll.Autofac`). See [](../integrations/available-plugins.md).

--- a/docs/guides/migrating-from-specflow.md
+++ b/docs/guides/migrating-from-specflow.md
@@ -9,7 +9,7 @@ The key differences between SpecFlow and Reqnroll are the following:
 * There is a new `DataTable` alias for the `Table` class to better match Gherkin terminology. The `Table` class can still be used.
 * The main extension methods of the *Assist helpers* have been moved to the `Reqnroll` namespace, so that they can be used without an additional namespace using statement. The helpers are now referred to as [](../automation/datatable-helpers.md).
 * The namespace of `IObjectContainer` has been changed from `BoDi` to `Reqnroll.BoDi`. If you have used special customizations that required to access the dependency injection container directly, you might need to update the namespace usings.
-* The [Reqnroll Visual Studio extension](../installation/setup-ide.md#setup-visual-studio-2022) has been reworked in a way that it can handle both SpecFlow and Reqnroll projects (also for .NET 8.0).
+* The [Reqnroll Visual Studio extension](../installation/setup-ide.md#setup-visual-studio-2022broken) has been reworked in a way that it can handle both SpecFlow and Reqnroll projects (also for .NET 8.0).
 * The integration plugins that have been managed by SpecFlow have been also ported to work with Reqnroll (e.g. `Reqnroll.Autofac`). See [](../integrations/available-plugins.md).
 * The "SpecFlow.Actions" plugins that provide a ready-to-use support for different automation technologies (e.g. Selenium) are ported as `Reqnroll.SpecFlowCompatibility.Actions.*` packages (e.g. `Reqnroll.SpecFlowCompatibility.Actions.Selenium`). 
 


### PR DESCRIPTION
### 🤔 What's changed?

Added documentation build to the CI pipeline

### ⚡️ What's your motivation? 

To verify doc inconsistencies, broken links, etc.

IMPORTANT: the result of this build is (currently) not used as public documentation. But the public documentation is built based on the same sources by read-the-docs.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?


### 📋 Checklist:

- [x] I've changed the behaviour of the code

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
