### PR TITLE
Clarify/Add .NET 9.0 Support to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Reqnroll is a .NET port of [Cucumber](https://cucumber.io/) and it is based on t
 
 Reqnroll enables writing executable specifications for BDD using [Gherkin](https://cucumber.io/docs/gherkin/), the widely-accepted *feature file* specification format. With that you can define the requirements using *Given-When-Then* style *scenarios* and turn them to automated tests in order to verify their implementation.
 
-Reqnroll works on all major operating systems (Windows, Linux, macOS), on all commonly used .NET implementations (including .NET Framework 4.6.2+ and .NET 8.0). For executing the automated scenarios, Reqnroll can use [MsTest](https://learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-with-mstest), [NUnit](https://nunit.org/) or [xUnit](https://xunit.net/). On Reqnroll projects you can work using Visual Studio 2022, Visual Studio Core and Rider, but you can also use Reqnroll without any IDE.
+Reqnroll works on all major operating systems (Windows, Linux, macOS), on all commonly used .NET implementations (including .NET Framework 4.6.2+ and up to .NET 9.0). For executing the automated scenarios, Reqnroll can use [MsTest](https://learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-with-mstest), [NUnit](https://nunit.org/) or [xUnit](https://xunit.net/). On Reqnroll projects you can work using Visual Studio 2022, Visual Studio Core and Rider, but you can also use Reqnroll without any IDE.
 
 ## Useful links
 


### PR DESCRIPTION
### 🤔 What's changed?
I changed the README text from supporting .NET 8 to .NET 9.

### ⚡️ What's your motivation? 
I'm currently researching Reqnroll, and it was not clear whether .NET 9.0 is supported (or not). If found the [compatibility page](https://docs.reqnroll.net/latest/installation/compatibility.html), where it clearly lists the supported OS, .NET versions, and testing frameworks and where .NET 9.0 is included.

### 🏷️ What kind of change is this?
- :book: Documentation (improvements without changing code)

### ♻️ Anything particular you want feedback on?
I personally prefer the simpler to scan listing style used in the [docs page](https://docs.reqnroll.net/latest/installation/compatibility.html).

I believe the supported .NET versions are very important information and should clearly be visible on the README page of any GitHub project. It helps developers quickly decide whether this project is suitable to their needs. I'm okay with the supported test frameworks and/or supported operating systems being stated as part of a paragraph to keep the README more concise.

Let me know if you also prefer the bullet point list, and I will edit the README accordingly, or feel free to use the PR as created to update the text. Staying with the current state is (in my opinion) misleading, as it suggests that Reqnroll only supports up to .NET 8.0.