### PR TITLE
Ideas/457 map table directly to constructor for stepargumenttransformers

### DIFF
--- a/Reqnroll/Assist/InstanceCreationOptions.cs
+++ b/Reqnroll/Assist/InstanceCreationOptions.cs
@@ -1,8 +1,10 @@
 namespace Reqnroll.Assist
 {
-    public  class InstanceCreationOptions
+    public class InstanceCreationOptions
     {
         public bool VerifyAllColumnsBound { get; set; }
-        public bool UseStrictTableToConstructorBinding { get; set; }
+        public bool RequireTableToProvideAllConstructorParameters { get; set; }
+
+        internal bool AssumeInstanceIsAlreadyCreated { get; set; }
     }
 }

--- a/Reqnroll/Assist/InstanceCreationOptions.cs
+++ b/Reqnroll/Assist/InstanceCreationOptions.cs
@@ -3,5 +3,6 @@ namespace Reqnroll.Assist
     public  class InstanceCreationOptions
     {
         public bool VerifyAllColumnsBound { get; set; }
+        public bool UseStrictTableToConstructorBinding { get; set; }
     }
 }

--- a/Reqnroll/Assist/TEHelpers.cs
+++ b/Reqnroll/Assist/TEHelpers.cs
@@ -48,6 +48,7 @@ namespace Reqnroll.Assist
                         {
                             var valueRetriever = Service.Instance.GetValueRetrieverFor(row, typeof(T), parameter.ParameterType);
                             parameterValues.Add(valueRetriever!.Retrieve(new KeyValuePair<string, string>(row[0], row[1]), typeof(T), parameter.ParameterType));
+                            break;
                         }
                     }
                 }
@@ -58,7 +59,7 @@ namespace Reqnroll.Assist
                 }
             }
             
-            throw new MissingMethodException($"Unable to find a suitable constructor to create instance of {typeof(T).Name}");
+            throw new MissingMethodException($"Unable to find a suitable constructor to create instance of {nameof(T)}");
         }
 
         internal static T ConstructInstanceFromLenientTable<T>(Table table, InstanceCreationOptions creationOptions)

--- a/Reqnroll/Assist/TEHelpers.cs
+++ b/Reqnroll/Assist/TEHelpers.cs
@@ -13,104 +13,43 @@ namespace Reqnroll.Assist
         private static readonly Regex invalidPropertyNameRegex = new Regex(InvalidPropertyNamePattern, RegexOptions.Compiled);
         private const string InvalidPropertyNamePattern = @"[^\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Lo}\p{Nl}\p{Nd}_]";
 
-        internal static T CreateTheInstanceWithTheDefaultConstructor<T>(Table table, InstanceCreationOptions creationOptions)
+        internal static T CreateInstanceAndInitializeWithValuesFromTheTable<T>(Table table, InstanceCreationOptions creationOptions)
         {
             var instance = (T)Activator.CreateInstance(typeof(T));
             LoadInstanceWithKeyValuePairs(table, instance, creationOptions);
             return instance;
         }
 
-        internal static T CreateTheInstanceWithTheValuesFromTheTable<T>(Table table, InstanceCreationOptions creationOptions)
+        internal static T ConstructInstanceWithValuesFromTheTable<T>(Table table, InstanceCreationOptions creationOptions)
         {
-            if (creationOptions?.UseStrictTableToConstructorBinding == true)
+            creationOptions ??= new InstanceCreationOptions();
+            creationOptions.AssumeInstanceIsAlreadyCreated = false;
+
+            var (memberHandlers, constructorInfo) = GetMembersThatNeedToBeSet(table, typeof(T), creationOptions);
+
+            VerifyAllColumn(table, creationOptions, memberHandlers.Select(m => m.MemberName));
+
+            var parameters = constructorInfo.GetParameters();
+            var parameterValues = new object[parameters.Length];
+
+            for (var i = 0; i < parameters.Length; ++i)
             {
-                return ConstructInstanceFromStrictTable<T>(table);
+                var parameter = parameters[i];
+                var matchingHandler = memberHandlers.FirstOrDefault(memberHandler => memberHandler.MatchesParameter(parameter));
+                parameterValues[i] = matchingHandler?.GetValue() ?? (parameter.HasDefaultValue ? parameter.DefaultValue : null);
+                
+                memberHandlers.Remove(matchingHandler);
             }
 
-            return ConstructInstanceFromLenientTable<T>(table, creationOptions);
-        }
-        
-        internal static T ConstructInstanceFromStrictTable<T>(Table table)
-        {
-            var numberOfParameters = table.RowCount;
-            var candidateConstructors = typeof(T).GetConstructors().Where(c => c.GetParameters().Length == numberOfParameters).ToList();
-
-            List<object> parameterValues;
-            foreach (var constructor in candidateConstructors)
-            {
-                parameterValues = new List<object>();
-                var parameters = constructor.GetParameters();
-                foreach (var parameter in parameters)
-                {
-                    foreach (var row in table.Rows)
-                    {
-                        if (parameter.Name.MatchesThisColumnName(row.Id()) && TheseTypesMatch(typeof(T), parameter.ParameterType, row))
-                        {
-                            var valueRetriever = Service.Instance.GetValueRetrieverFor(row, typeof(T), parameter.ParameterType);
-                            parameterValues.Add(valueRetriever!.Retrieve(new KeyValuePair<string, string>(row[0], row[1]), typeof(T), parameter.ParameterType));
-                            break;
-                        }
-                    }
-                }
-
-                if (parameterValues.Count == numberOfParameters)
-                {
-                    return (T)constructor.Invoke(parameterValues.ToArray());
-                }
-            }
+            var instance = (T)constructorInfo.Invoke(parameterValues);
+            memberHandlers.ForEach(x => x.Setter(instance, x.GetValue()));
             
-            throw new MissingMethodException($"Unable to find a suitable constructor to create instance of {nameof(T)}");
+            return instance;
         }
 
-        internal static T ConstructInstanceFromLenientTable<T>(Table table, InstanceCreationOptions creationOptions)
-        {
-            var constructor = GetConstructorMatchingToColumnNames<T>(table);
-            if (constructor == null)
-                throw new MissingMethodException($"Unable to find a suitable constructor to create instance of {typeof(T).Name}");
-
-            var membersThatNeedToBeSet = GetMembersThatNeedToBeSet(table, typeof(T));
-
-            var constructorParameters = constructor.GetParameters();
-            var parameterValues = new object[constructorParameters.Length];
-
-            var members = new List<string>(constructorParameters.Length);
-            for (var parameterIndex = 0; parameterIndex < constructorParameters.Length; parameterIndex++)
-            {
-                var parameter = constructorParameters[parameterIndex];
-                var parameterName = parameter.Name;
-                var member = (from m in membersThatNeedToBeSet
-                              where string.Equals(m.MemberName, parameterName, StringComparison.OrdinalIgnoreCase)
-                              select m).FirstOrDefault();
-                if (member != null)
-                {
-                    members.Add(member.MemberName);
-                    parameterValues[parameterIndex] = member.GetValue();
-                }
-                else if (parameter.HasDefaultValue)
-                    parameterValues[parameterIndex] = parameter.DefaultValue;
-            }
-
-            VerifyAllColumn(table, creationOptions, members);
-            return (T)constructor.Invoke(parameterValues);
-        }
-        
         internal static bool ThisTypeHasADefaultConstructor<T>()
         {
             return typeof(T).GetConstructors().Any(c => c.GetParameters().Length == 0);
-        }
-
-        internal static ConstructorInfo GetConstructorMatchingToColumnNames<T>(Table table)
-        {
-            var projectedPropertyNames = from property in typeof(T).GetProperties()
-                                         from row in table.Rows
-                                         where IsMemberMatchingToColumnName(property, row.Id())
-                                         select property.Name;
-
-            return (from constructor in typeof(T).GetConstructors()
-                    where !projectedPropertyNames.Except(
-                        from parameter in constructor.GetParameters()
-                        select parameter.Name, StringComparer.OrdinalIgnoreCase).Any()
-                    select constructor).FirstOrDefault();
         }
 
         internal static bool IsMemberMatchingToColumnName(MemberInfo member, string columnName)
@@ -119,7 +58,7 @@ namespace Reqnroll.Assist
                 || IsMatchingAlias(member, columnName);
         }
 
-        internal static bool MatchesThisColumnName(this string propertyName, string columnName)
+        private static bool MatchesThisColumnName(this string propertyName, string columnName)
         {
             var normalizedColumnName = NormalizePropertyNameToMatchAgainstAColumnName(RemoveAllCharactersThatAreNotValidInAPropertyName(columnName));
             var normalizedPropertyName = NormalizePropertyNameToMatchAgainstAColumnName(propertyName);
@@ -127,13 +66,13 @@ namespace Reqnroll.Assist
             return normalizedPropertyName.Equals(normalizedColumnName, StringComparison.OrdinalIgnoreCase);
         }
 
-        internal static string RemoveAllCharactersThatAreNotValidInAPropertyName(string name)
+        private static string RemoveAllCharactersThatAreNotValidInAPropertyName(string name)
         {
             //Unicode groups allowed: Lu, Ll, Lt, Lm, Lo, Nl or Nd see https://msdn.microsoft.com/en-us/library/aa664670%28v=vs.71%29.aspx
             return invalidPropertyNameRegex.Replace(name, string.Empty);
         }
 
-        internal static string NormalizePropertyNameToMatchAgainstAColumnName(string name)
+        private static string NormalizePropertyNameToMatchAgainstAColumnName(string name)
         {
             // we remove underscores, because they should be equivalent to spaces that were removed too from the column names
             // we also ignore accents
@@ -142,8 +81,10 @@ namespace Reqnroll.Assist
 
         internal static void LoadInstanceWithKeyValuePairs(Table table, object instance, InstanceCreationOptions creationOptions)
         {
-            var membersThatNeedToBeSet = GetMembersThatNeedToBeSet(table, instance.GetType());
-            var memberHandlers = membersThatNeedToBeSet.ToList();
+            creationOptions ??= new InstanceCreationOptions();
+            creationOptions.AssumeInstanceIsAlreadyCreated = true;
+
+            var (memberHandlers, _) = GetMembersThatNeedToBeSet(table, instance.GetType(), creationOptions);
             var memberNames = memberHandlers.Select(h => h.MemberName);
 
             VerifyAllColumn(table, creationOptions, memberNames);
@@ -165,9 +106,13 @@ namespace Reqnroll.Assist
             }
         }
 
-        internal static List<MemberHandler> GetMembersThatNeedToBeSet(Table table, Type type)
-
+        private static (List<MemberHandler>, ConstructorInfo) GetMembersThatNeedToBeSet(Table table, Type type, InstanceCreationOptions creationOptions)
         {
+            if (creationOptions is null)
+            {
+                throw new ArgumentNullException(nameof(creationOptions));
+            }
+
             var properties = (from property in type.GetProperties()
                               from row in table.Rows
                               where TheseTypesMatch(type, property.PropertyType, row)
@@ -216,7 +161,86 @@ namespace Reqnroll.Assist
                 }
             }
 
-            return memberHandlers;
+            if (creationOptions.AssumeInstanceIsAlreadyCreated)
+            {
+                return (memberHandlers, null);
+            }
+
+            var constructors = type.GetConstructors()
+                                   .Select(
+                                       c => new
+                                       {
+                                           Constructor = c,
+                                           Parameters = c.GetParameters()
+                                       })
+                                   .Where(i => i.Parameters.Length > 0);
+
+            if (!creationOptions.RequireTableToProvideAllConstructorParameters)
+            {
+                // Prefer constructor with the least parameters that takes all members
+                var candidateConstructors = constructors.OrderBy(c => c.Parameters.Length);
+                foreach (var candidate in candidateConstructors)
+                {
+                    var resolvedMembers = memberHandlers.Where(m => m.AnyParameterMatchesThisMemberHandler(candidate.Parameters)).ToList();
+                    if (resolvedMembers.Count == memberHandlers.Count)
+                    {
+                        return (memberHandlers, candidate.Constructor);
+                    }
+                }
+            }
+            else
+            {
+                // Prefer constructor with the most parameters
+                var candidateConstructors = constructors
+                                            .OrderByDescending(i => i.Parameters.Length)
+                                            .ToList();
+
+                foreach (var candidate in candidateConstructors)
+                {
+                    var unresolvedParameters = candidate.Parameters.Where(p => p.NoMemberHandlerMatchesThisParameter(memberHandlers)).ToList();
+                    if (unresolvedParameters.Count == 0)
+                    {
+                        return (memberHandlers, candidate.Constructor);
+                    }
+
+                    var matchingHandlers = (from parameter in unresolvedParameters
+                                            from row in table.Rows
+                                            where parameter.Name.MatchesThisColumnName(row.Id()) && TheseTypesMatch(type, parameter.ParameterType, row)
+                                            select new MemberHandler
+                                            {
+                                                Type = type,
+                                                Row = row,
+                                                MemberName = parameter.Name,
+                                                PropertyType = parameter.ParameterType,
+                                                Setter = (_, _) => throw new InvalidOperationException($"This {nameof(MemberHandler)} is used for a constructor parameter only")
+                                            }).ToList();
+
+                    if (matchingHandlers.Count == unresolvedParameters.Count)
+                    {
+                        // We found the correct constructor candidate
+                        memberHandlers.AddRange(matchingHandlers);
+                        return (memberHandlers, candidate.Constructor);
+                    }
+                }
+            }
+
+            throw new MissingMethodException($"Unable to find a suitable constructor to create instance of {type}");
+        }
+
+        private static bool MatchesParameter(this MemberHandler memberHandler, ParameterInfo parameter)
+        {
+            return memberHandler.MemberName.Equals(parameter.Name, StringComparison.OrdinalIgnoreCase)
+                   && memberHandler.PropertyType == parameter.ParameterType;
+        }
+
+        private static bool AnyParameterMatchesThisMemberHandler(this MemberHandler memberHandler, ParameterInfo[] parameters)
+        {
+            return parameters.Any(memberHandler.MatchesParameter);
+        }
+
+        private static bool NoMemberHandlerMatchesThisParameter(this ParameterInfo parameter, List<MemberHandler> memberHandlers)
+        {
+            return !memberHandlers.Any(m => m.MatchesParameter(parameter));
         }
 
         private static bool IsMatchingAlias(MemberInfo field, string id)
@@ -241,6 +265,11 @@ namespace Reqnroll.Assist
             public object GetValue()
             {
                 var valueRetriever = Service.Instance.GetValueRetrieverFor(Row, Type, PropertyType);
+                if (valueRetriever is null)
+                {
+                    throw new InvalidOperationException($"Unable to resolve value retriever for member {MemberName}");
+                }
+                
                 return valueRetriever.Retrieve(new KeyValuePair<string, string>(Row[0], Row[1]), Type, PropertyType);
             }
         }
@@ -276,7 +305,7 @@ namespace Reqnroll.Assist
                        .Any(property => IsMemberMatchingToColumnName(property, firstRowValue));
         }
 
-        public static bool IsValueTupleType(Type type, bool checkBaseTypes = false)
+        private static bool IsValueTupleType(Type type, bool checkBaseTypes = false)
         {
             if (type == null)
                 throw new ArgumentNullException(nameof(type));

--- a/Reqnroll/Assist/TableExtensionMethods.cs
+++ b/Reqnroll/Assist/TableExtensionMethods.cs
@@ -16,8 +16,8 @@ namespace Reqnroll
         {
             var instanceTable = TEHelpers.GetTheProperInstanceTable(table, typeof(T));
             return TEHelpers.ThisTypeHasADefaultConstructor<T>()
-                       ? TEHelpers.CreateTheInstanceWithTheDefaultConstructor<T>(instanceTable, creationOptions)
-                       : TEHelpers.CreateTheInstanceWithTheValuesFromTheTable<T>(instanceTable, creationOptions);
+                       ? TEHelpers.CreateInstanceAndInitializeWithValuesFromTheTable<T>(instanceTable, creationOptions)
+                       : TEHelpers.ConstructInstanceWithValuesFromTheTable<T>(instanceTable, creationOptions);
         }
 
         public static T CreateInstance<T>(this Table table, Func<T> methodToCreateTheInstance)

--- a/Tests/Reqnroll.RuntimeTests/AssistTests/CreateInstanceHelperMethodTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/AssistTests/CreateInstanceHelperMethodTests.cs
@@ -80,6 +80,18 @@ namespace Reqnroll.RuntimeTests.AssistTests
 
             act.Should().ThrowExactly<MissingMethodException>().WithMessage($"Unable to find a suitable constructor to create instance of {nameof(ProductCreatedMessage)}");
         }
+
+        [Fact]
+        public void Create_instance_without_default_constructor_does_not_throw_if_all_projected_properties_have_matching_constructor_parameters()
+        {
+            var table = new Table("MessageCreatedAt", "ProductCode", "ProductName");
+            table.AddRow("2025-02-22T13:29:14+01:00", "X0010001B", "Teddy Bear");
+            
+            Action act = () => table.CreateInstance<ProductCreatedMessage>();
+
+            // This is odd behaviour! The constructor requires more parameters than the number of matching members. Missing constructor parameters get the default value for their Type. 
+            act.Should().NotThrow<MissingMethodException>();
+        }
         
         [Fact]
         public void When_one_row_exists_with_two_headers_and_the_first_row_value_is_not_a_property_then_treat_as_horizontal_table()

--- a/Tests/Reqnroll.RuntimeTests/AssistTests/CreateInstanceHelperMethodTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/AssistTests/CreateInstanceHelperMethodTests.cs
@@ -7,7 +7,6 @@ using Reqnroll.Assist;
 using Reqnroll.RuntimeTests.AssistTests.ExampleEntities;
 using Reqnroll.RuntimeTests.AssistTests.TestInfrastructure;
 
-
 namespace Reqnroll.RuntimeTests.AssistTests
 {
 
@@ -56,7 +55,7 @@ namespace Reqnroll.RuntimeTests.AssistTests
 
             var options = new InstanceCreationOptions
             {
-                UseStrictTableToConstructorBinding = true
+                RequireTableToProvideAllConstructorParameters = true
             };
             
             var expectedMessage = new ProductCreatedMessage(new DateTimeOffset(2025, 2, 22, 13, 29, 14, TimeSpan.FromHours(1)), "X0010001B", "Teddy Bear", new DateTime(2025, 3,1));
@@ -73,12 +72,12 @@ namespace Reqnroll.RuntimeTests.AssistTests
 
             var options = new InstanceCreationOptions
             {
-                UseStrictTableToConstructorBinding = true
+                RequireTableToProvideAllConstructorParameters = true
             };
             
             Action act = () => table.CreateInstance<ProductCreatedMessage>(options);
 
-            act.Should().ThrowExactly<MissingMethodException>().WithMessage($"Unable to find a suitable constructor to create instance of {nameof(ProductCreatedMessage)}");
+            act.Should().ThrowExactly<MissingMethodException>().WithMessage($"Unable to find a suitable constructor to create instance of {typeof(ProductCreatedMessage)}");
         }
 
         [Fact]

--- a/Tests/Reqnroll.RuntimeTests/AssistTests/CreateInstanceHelperMethodTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/AssistTests/CreateInstanceHelperMethodTests.cs
@@ -49,6 +49,39 @@ namespace Reqnroll.RuntimeTests.AssistTests
         }
 
         [Fact]
+        public void Create_instance_will_use_strict_constructor_binding_when_option_use_strict_constructor_binding_is_true()
+        {
+            var table = new Table("MessageCreatedAt", "ProductCode", "ProductName", "StartOfSale");
+            table.AddRow("2025-02-22T13:29:14+01:00", "X0010001B", "Teddy Bear", "2025-03-01");
+
+            var options = new InstanceCreationOptions
+            {
+                UseStrictTableToConstructorBinding = true
+            };
+            
+            var expectedMessage = new ProductCreatedMessage(new DateTimeOffset(2025, 2, 22, 13, 29, 14, TimeSpan.FromHours(1)), "X0010001B", "Teddy Bear", new DateTime(2025, 3,1));
+            var actualMessage = table.CreateInstance<ProductCreatedMessage>(options);
+            
+            actualMessage.Should().BeEquivalentTo(expectedMessage);
+        }
+
+        [Fact]
+        public void Create_instance_will_use_strict_constructor_binding_when_option_use_strict_constructor_binding_is_true_and_throw_when_no_suitable_constructor_is_provided()
+        {
+            var table = new Table("MessageCreatedAt", "ProductCode", "ProductName");
+            table.AddRow("2025-02-22T13:29:14+01:00", "X0010001B", "Teddy Bear");
+
+            var options = new InstanceCreationOptions
+            {
+                UseStrictTableToConstructorBinding = true
+            };
+            
+            Action act = () => table.CreateInstance<ProductCreatedMessage>(options);
+
+            act.Should().ThrowExactly<MissingMethodException>().WithMessage($"Unable to find a suitable constructor to create instance of {nameof(ProductCreatedMessage)}");
+        }
+        
+        [Fact]
         public void When_one_row_exists_with_two_headers_and_the_first_row_value_is_not_a_property_then_treat_as_horizontal_table()
         {
             var table = new Table("AnotherValue", "YetAnotherValue");

--- a/Tests/Reqnroll.RuntimeTests/AssistTests/ExampleEntities/AbstractMessage.cs
+++ b/Tests/Reqnroll.RuntimeTests/AssistTests/ExampleEntities/AbstractMessage.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Reqnroll.RuntimeTests.AssistTests.ExampleEntities;
+
+public abstract class AbstractMessage<TMessageContent>
+{
+    public DateTimeOffset MessageCreatedAt { get; protected init; }
+    public string MessageContentType { get; } = nameof(TMessageContent);
+    public TMessageContent MessageContent { get; protected init; }
+}

--- a/Tests/Reqnroll.RuntimeTests/AssistTests/ExampleEntities/ProductCreatedMessage.cs
+++ b/Tests/Reqnroll.RuntimeTests/AssistTests/ExampleEntities/ProductCreatedMessage.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Reqnroll.RuntimeTests.AssistTests.ExampleEntities;
+
+public sealed class ProductCreatedMessage : AbstractMessage<ProductCreatedMessageContent>
+{
+    public ProductCreatedMessage(DateTimeOffset messageCreatedAt, string productCode, string productName, DateTime startOfSale)
+    {
+        MessageCreatedAt = messageCreatedAt;
+        MessageContent = new ProductCreatedMessageContent(productCode, productName, startOfSale);
+    }
+}

--- a/Tests/Reqnroll.RuntimeTests/AssistTests/ExampleEntities/ProductCreatedMessageContent.cs
+++ b/Tests/Reqnroll.RuntimeTests/AssistTests/ExampleEntities/ProductCreatedMessageContent.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace Reqnroll.RuntimeTests.AssistTests.ExampleEntities;
+
+public sealed class ProductCreatedMessageContent
+{
+    public ProductCreatedMessageContent(string productCode, string productName, DateTime startOfSale)
+    {
+        ProductCode = productCode;
+        ProductName = productName;
+        StartOfSale = startOfSale;
+    }
+    
+    public string ProductCode { get; init; }
+    public string ProductName { get; init; }
+    public DateTime StartOfSale { get; init; }
+}


### PR DESCRIPTION
### 🤔 What's changed?

A new option was added to change the behaviour of the table helper `CreateInstance`.
WIth the option set to true, the table helper will try to find a constructor that exactly matches the table.
If a matching constructor cannot be found, the helper will throw a `MissingMethodException`.

See https://github.com/orgs/reqnroll/discussions/457

### ⚡️ What's your motivation? 

In normal circumstances you would not need this feature, because you can just give the support model the correct properties or fields to resemble the table. However, in my use-case I need the support model to be serialized into an exact JSON structure. For example:

``` JSON
{
  "MessageCreatedAt" : "2025-02-22T14:13:38+01:00",
  "MessageContentType" : "ProductCreatedMessageContent",
  "MessageContent" : {
    "ProductCode" : "X0010001B",
    "ProductName" : "Teddy Bear",
    "StartOfSale" : "2025-03-01"
  }
}
```
``` GHERKIN
  | MessageCreatedAt          | ProductCode | ProductName | StartOfSale |
  | 2025-02-22T14:13:38+01:00 | X0010001B   | Teddy Bear  | 2025-03-01  |
```

Usage:
``` CSHARP
[StepArgumentTransformation]
public ProductCreatedMessage CreateInstance(Table table)
{
    var options = new InstanceCreationOptions
    {
        UseStrictTableToConstructorBinding = true
    };
    return table.CreateInstance<ProductCreatedMessage>(options);
}
```
### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :zap: New feature (non-breaking change which adds new behaviour)

### 📋 Checklist:

- [X] I've changed the behaviour of the code
  - [X] I have added/updated tests to cover my changes.
- [X] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [X] Users should know about my change
  - [ ] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
