### PR TITLE
Improved message when [ScenarioDependencies] can't be found or has an incorrect return type (Reqnroll.Microsoft.Extensions.DependencyInjection)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # [vNext]
 
 ## Improvements:
+* Microsoft.Extensions.DependencyInjection.ReqnrollPlugin: Improved message when [ScenarioDependencies] can't be found or has an incorrect return type (#494)
 
 ## Bug fixes:
 * Fix: Microsoft.Extensions.DependencyInjection.ReqnrollPlugin, the plugin was only searching for [ScenarioDependencies] in assemblies with step definitions (#477)

--- a/Plugins/Reqnroll.Microsoft.Extensions.DependencyInjection.ReqnrollPlugin/InvalidScenarioDependenciesException.cs
+++ b/Plugins/Reqnroll.Microsoft.Extensions.DependencyInjection.ReqnrollPlugin/InvalidScenarioDependenciesException.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Reqnroll.Microsoft.Extensions.DependencyInjection;
+
+[Serializable]
+public class InvalidScenarioDependenciesException(string message) : ReqnrollException(message)
+{
+    public override string HelpLink { get; set; } = "https://go.reqnroll.net/doc-msdi";
+}

--- a/Plugins/Reqnroll.Microsoft.Extensions.DependencyInjection.ReqnrollPlugin/InvalidScenarioDependenciesException.cs
+++ b/Plugins/Reqnroll.Microsoft.Extensions.DependencyInjection.ReqnrollPlugin/InvalidScenarioDependenciesException.cs
@@ -3,7 +3,7 @@
 namespace Reqnroll.Microsoft.Extensions.DependencyInjection;
 
 [Serializable]
-public class InvalidScenarioDependenciesException(string message) : ReqnrollException(message)
+public class InvalidScenarioDependenciesException(string reason) : ReqnrollException("[ScenarioDependencies] should return IServiceCollection but " + reason)
 {
     public override string HelpLink { get; set; } = "https://go.reqnroll.net/doc-msdi";
 }

--- a/Plugins/Reqnroll.Microsoft.Extensions.DependencyInjection.ReqnrollPlugin/MissingScenarioDependenciesException.cs
+++ b/Plugins/Reqnroll.Microsoft.Extensions.DependencyInjection.ReqnrollPlugin/MissingScenarioDependenciesException.cs
@@ -19,7 +19,7 @@ namespace Reqnroll.Microsoft.Extensions.DependencyInjection
 
         private static string CreateMessage(IList<string> assemblyNames)
         {
-            var message = "No method marked with [ScenarioDependencies] attribute found. It should be a (public or private) static method.";
+            var message = "No method marked with [ScenarioDependencies] attribute found. It should be a (public or non-public) static method.";
             if (assemblyNames.Count > 0)
             {
                 message += $" Scanned assemblies: {string.Join(", ", assemblyNames)}.";

--- a/Plugins/Reqnroll.Microsoft.Extensions.DependencyInjection.ReqnrollPlugin/MissingScenarioDependenciesException.cs
+++ b/Plugins/Reqnroll.Microsoft.Extensions.DependencyInjection.ReqnrollPlugin/MissingScenarioDependenciesException.cs
@@ -19,7 +19,7 @@ namespace Reqnroll.Microsoft.Extensions.DependencyInjection
 
         private static string CreateMessage(IList<string> assemblyNames)
         {
-            var message = "No method marked with [ScenarioDependencies] attribute found. It should be a static method.";
+            var message = "No method marked with [ScenarioDependencies] attribute found. It should be a (public or private) static method.";
             if (assemblyNames.Count > 0)
             {
                 message += $" Scanned assemblies: {string.Join(", ", assemblyNames)}.";

--- a/Plugins/Reqnroll.Microsoft.Extensions.DependencyInjection.ReqnrollPlugin/MissingScenarioDependenciesException.cs
+++ b/Plugins/Reqnroll.Microsoft.Extensions.DependencyInjection.ReqnrollPlugin/MissingScenarioDependenciesException.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace Reqnroll.Microsoft.Extensions.DependencyInjection
 {
@@ -6,9 +7,26 @@ namespace Reqnroll.Microsoft.Extensions.DependencyInjection
     public class MissingScenarioDependenciesException : ReqnrollException
     {
         public MissingScenarioDependenciesException()
-            : base("No method marked with [ScenarioDependencies] attribute found.")
+            : this([])
         {
-            HelpLink = "https://go.reqnroll.net/doc-msdi";
         }
+
+        public MissingScenarioDependenciesException(IList<string> assemblyNames)
+            : base(CreateMessage(assemblyNames))
+        {
+          
+        }
+
+        private static string CreateMessage(IList<string> assemblyNames)
+        {
+            var message = "No method marked with [ScenarioDependencies] attribute found. It should be a static method.";
+            if (assemblyNames.Count > 0)
+            {
+                message += $" Scanned assemblies: {string.Join(", ", assemblyNames)}.";
+            }
+            return message;
+        }
+
+        public override string HelpLink { get; set; } = "https://go.reqnroll.net/doc-msdi";
     }
 }

--- a/Plugins/Reqnroll.Microsoft.Extensions.DependencyInjection.ReqnrollPlugin/ServiceCollectionFinder.cs
+++ b/Plugins/Reqnroll.Microsoft.Extensions.DependencyInjection.ReqnrollPlugin/ServiceCollectionFinder.cs
@@ -44,9 +44,8 @@ namespace Reqnroll.Microsoft.Extensions.DependencyInjection
                     }
                 }
             }
-            // TODO which assemblies are scanned?
-            // TODO say something about static of fix static
-            throw new MissingScenarioDependenciesException();
+            var assemblyNames = assemblies.Select(a => a.GetName().Name).ToList();
+            throw new MissingScenarioDependenciesException(assemblyNames);
         }
 
         private static IServiceCollection GetServiceCollection(MethodInfo methodInfo)

--- a/Plugins/Reqnroll.Microsoft.Extensions.DependencyInjection.ReqnrollPlugin/ServiceCollectionFinder.cs
+++ b/Plugins/Reqnroll.Microsoft.Extensions.DependencyInjection.ReqnrollPlugin/ServiceCollectionFinder.cs
@@ -54,18 +54,18 @@ namespace Reqnroll.Microsoft.Extensions.DependencyInjection
             var serviceCollection = methodInfo.Invoke(null, null);
             if(methodInfo.ReturnType == typeof(void))
             {
-                throw new InvalidScenarioDependenciesException("[ScenarioDependencies] should return IServiceCollection but the method doesn't return a value.");
+                throw new InvalidScenarioDependenciesException("the method doesn't return a value.");
             }
 
             if (serviceCollection == null)
             {
-                throw new InvalidScenarioDependenciesException("[ScenarioDependencies] should return IServiceCollection but returned null.");
+                throw new InvalidScenarioDependenciesException("returned null.");
             }
 
             if (serviceCollection is not IServiceCollection collection)
             {
                 // TODO test
-                throw new InvalidScenarioDependenciesException($"[ScenarioDependencies] should return IServiceCollection but returned {serviceCollection.GetType()}.");
+                throw new InvalidScenarioDependenciesException($"returned {serviceCollection.GetType()}.");
             }
             return collection;
         }

--- a/Plugins/Reqnroll.Microsoft.Extensions.DependencyInjection.ReqnrollPlugin/ServiceCollectionFinder.cs
+++ b/Plugins/Reqnroll.Microsoft.Extensions.DependencyInjection.ReqnrollPlugin/ServiceCollectionFinder.cs
@@ -63,7 +63,6 @@ namespace Reqnroll.Microsoft.Extensions.DependencyInjection
 
             if (serviceCollection is not IServiceCollection collection)
             {
-                // TODO test
                 throw new InvalidScenarioDependenciesException($"returned {serviceCollection.GetType()}.");
             }
             return collection;

--- a/Plugins/Reqnroll.Microsoft.Extensions.DependencyInjection.ReqnrollPlugin/ServiceCollectionFinder.cs
+++ b/Plugins/Reqnroll.Microsoft.Extensions.DependencyInjection.ReqnrollPlugin/ServiceCollectionFinder.cs
@@ -28,7 +28,7 @@ namespace Reqnroll.Microsoft.Extensions.DependencyInjection
             {
                 foreach (var type in assembly.GetTypes())
                 {
-                    foreach (var methodInfo in type.GetMethods(BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public))
+                    foreach (MethodInfo methodInfo in type.GetMethods(BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public))
                     {
                         var scenarioDependenciesAttribute = (ScenarioDependenciesAttribute)Attribute.GetCustomAttribute(methodInfo, typeof(ScenarioDependenciesAttribute));
 
@@ -44,12 +44,30 @@ namespace Reqnroll.Microsoft.Extensions.DependencyInjection
                     }
                 }
             }
+            // TODO which assemblies are scanned?
+            // TODO say something about static of fix static
             throw new MissingScenarioDependenciesException();
         }
 
-        private static IServiceCollection GetServiceCollection(MethodBase methodInfo)
+        private static IServiceCollection GetServiceCollection(MethodInfo methodInfo)
         {
-            return (IServiceCollection)methodInfo.Invoke(null, null);
+            var serviceCollection = methodInfo.Invoke(null, null);
+            if(methodInfo.ReturnType == typeof(void))
+            {
+                throw new InvalidScenarioDependenciesException("[ScenarioDependencies] should return IServiceCollection but the method doesn't return a value.");
+            }
+
+            if (serviceCollection == null)
+            {
+                throw new InvalidScenarioDependenciesException("[ScenarioDependencies] should return IServiceCollection but returned null.");
+            }
+
+            if (serviceCollection is not IServiceCollection collection)
+            {
+                // TODO test
+                throw new InvalidScenarioDependenciesException($"[ScenarioDependencies] should return IServiceCollection but returned {serviceCollection.GetType()}.");
+            }
+            return collection;
         }
 
         private static void AddBindingAttributes(IEnumerable<Assembly> bindingAssemblies, IServiceCollection serviceCollection)

--- a/Tests/Reqnroll.PluginTests/Microsoft.Extensions.DependencyInjection/ServiceCollectionFinderTests.cs
+++ b/Tests/Reqnroll.PluginTests/Microsoft.Extensions.DependencyInjection/ServiceCollectionFinderTests.cs
@@ -40,9 +40,10 @@ public class ServiceCollectionFinderTests
         var act = () => sut.GetServiceCollection();
 
         // Assert
-        act.Should().Throw<InvalidScenarioDependenciesException>().WithMessage("[ScenarioDependencies] should return IServiceCollection but the method doesn't return a value.");
-    }  
-    
+        act.Should().Throw<InvalidScenarioDependenciesException>()
+           .WithMessage("[ScenarioDependencies] should return IServiceCollection but the method doesn't return a value.");
+    }
+
     [Fact]
     public void GetServiceCollection_MethodReturnsNull_ThrowsInvalidScenarioDependenciesException()
     {
@@ -54,10 +55,11 @@ public class ServiceCollectionFinderTests
         var act = () => sut.GetServiceCollection();
 
         // Assert
-        act.Should().Throw<InvalidScenarioDependenciesException>().WithMessage("[ScenarioDependencies] should return IServiceCollection but returned null.");
-    }   
-    
-    
+        act.Should().Throw<InvalidScenarioDependenciesException>()
+           .WithMessage("[ScenarioDependencies] should return IServiceCollection but returned null.");
+    }
+
+
     [Fact]
     public void GetServiceCollection_MethodReturnsInvalidType_ThrowsInvalidScenarioDependenciesException()
     {
@@ -69,9 +71,10 @@ public class ServiceCollectionFinderTests
         var act = () => sut.GetServiceCollection();
 
         // Assert
-        act.Should().Throw<InvalidScenarioDependenciesException>().WithMessage("[ScenarioDependencies] should return IServiceCollection but returned System.Collections.Generic.List`1[System.String].");
-    }   
-    
+        act.Should().Throw<InvalidScenarioDependenciesException>()
+           .WithMessage("[ScenarioDependencies] should return IServiceCollection but returned System.Collections.Generic.List`1[System.String].");
+    }
+
     [Fact]
     public void GetServiceCollection_NotFound_ThrowsMissingScenarioDependenciesException()
     {
@@ -83,9 +86,10 @@ public class ServiceCollectionFinderTests
         var act = () => sut.GetServiceCollection();
 
         // Assert
-        act.Should().Throw<MissingScenarioDependenciesException>().WithMessage("No method marked with [ScenarioDependencies] attribute found. It should be a static method. Scanned assemblies: Reqnroll.PluginTests.");
+        act.Should().Throw<MissingScenarioDependenciesException>()
+           .WithMessage("No method marked with [ScenarioDependencies] attribute found. It should be a (public or private) static method. Scanned assemblies: Reqnroll.PluginTests.");
     }
-    
+
     [Fact]
     public void GetServiceCollection_AutoRegisterBindingsTrue_RegisterBindingsAsScoped()
     {
@@ -165,8 +169,8 @@ public class ServiceCollectionFinderTests
             var serviceCollection = new ServiceCollection();
             serviceCollection.AddSingleton<ITestInterface>(new TestInterface("ValidStartWithAutoRegister"));
         }
-    }   
-    
+    }
+
     private class InvalidStartNull
     {
         [ScenarioDependencies]
@@ -174,8 +178,8 @@ public class ServiceCollectionFinderTests
         {
             return null;
         }
-    }  
-    
+    }
+
     private class InvalidStartWrongType
     {
         [ScenarioDependencies]

--- a/Tests/Reqnroll.PluginTests/Microsoft.Extensions.DependencyInjection/ServiceCollectionFinderTests.cs
+++ b/Tests/Reqnroll.PluginTests/Microsoft.Extensions.DependencyInjection/ServiceCollectionFinderTests.cs
@@ -70,6 +70,20 @@ public class ServiceCollectionFinderTests
 
         // Assert
         act.Should().Throw<InvalidScenarioDependenciesException>().WithMessage("[ScenarioDependencies] should return IServiceCollection but returned System.Collections.Generic.List`1[System.String].");
+    }   
+    
+    [Fact]
+    public void GetServiceCollection_NotFound_ThrowsMissingScenarioDependenciesException()
+    {
+        // Arrange
+        var testRunnerManagerMock = CreateTestRunnerManagerMock(typeof(ServiceCollectionFinderTests));
+        var sut = new ServiceCollectionFinder(testRunnerManagerMock.Object);
+
+        // Act
+        var act = () => sut.GetServiceCollection();
+
+        // Assert
+        act.Should().Throw<MissingScenarioDependenciesException>().WithMessage("No method marked with [ScenarioDependencies] attribute found. It should be a static method. Scanned assemblies: Reqnroll.PluginTests.");
     }
     
     [Fact]
@@ -106,6 +120,11 @@ public class ServiceCollectionFinderTests
     {
         var assemblyMock = new Mock<Assembly>();
         assemblyMock.Setup(m => m.GetTypes()).Returns(types.ToArray());
+        if (types.Length > 0)
+        {
+            var assembly = types[0].Assembly;
+            assemblyMock.Setup(m => m.GetName()).Returns(assembly.GetName());
+        }
 
         var testRunnerManagerMock = new Mock<ITestRunnerManager>();
         testRunnerManagerMock.Setup(m => m.BindingAssemblies).Returns([assemblyMock.Object]);

--- a/Tests/Reqnroll.PluginTests/Microsoft.Extensions.DependencyInjection/ServiceCollectionFinderTests.cs
+++ b/Tests/Reqnroll.PluginTests/Microsoft.Extensions.DependencyInjection/ServiceCollectionFinderTests.cs
@@ -87,7 +87,7 @@ public class ServiceCollectionFinderTests
 
         // Assert
         act.Should().Throw<MissingScenarioDependenciesException>()
-           .WithMessage("No method marked with [ScenarioDependencies] attribute found. It should be a (public or private) static method. Scanned assemblies: Reqnroll.PluginTests.");
+           .WithMessage("No method marked with [ScenarioDependencies] attribute found. It should be a (public or non-public) static method. Scanned assemblies: Reqnroll.PluginTests.");
     }
 
     [Fact]


### PR DESCRIPTION
<!---
Thanks for helping to make Reqnroll better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻

You can delete these comment sections as you process them.
-->

### 🤔 What's changed?

For Reqnroll.Microsoft.Extensions.DependencyInjection improved the message when `[ScenarioDependencies]` can't be found

- Tell it should be `static` (and could be non-public)
- Tell the scanned assemblies
- Don't give a "System.ArgumentNullException : Value cannot be null" when returning the wrong type / void methods

The new messages are (see also unit tests)
- [ScenarioDependencies] should return IServiceCollection but the method doesn't return a value.
- [ScenarioDependencies] should return IServiceCollection but returned null.
- [ScenarioDependencies] should return IServiceCollection but returned System.Collections.Generic.List`1[System.String].
- No method marked with [ScenarioDependencies] attribute found. It should be a (public or non-public) static method. Scanned assemblies: Reqnroll.PluginTests.

Nothing has been changed with the behavior of the code in the happy path. I have considered scanned non-static methods, but because the current code scans all types and all static (public and private methodes) in the assembly until one is found, I don't think that is a good idea for the performance. 

I also fixed the Virtual call in ctor for MissingScenarioDependenciesException. 
![image](https://github.com/user-attachments/assets/22db9769-4a4c-4704-ae66-1470699600e9)


<!-- Describe your changes in detail -->

### ⚡️ What's your motivation? 

<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->

Fixes #474

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)


### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

- Do you also think the change to prevent the virtual call in the ctor is the best option?
- Are the messages clear?

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
  - [ ] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
