### PR TITLE
Ask for xUnit version in GitHub template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -14,7 +14,8 @@ body:
     options: 
       - MSTest 
       - NUnit
-      - xUnit
+      - xUnit 2
+      - xUnit 3
   validations:
     required: true
 - type: input


### PR DESCRIPTION
Let users select xUnit 2 or 3. 

Feedback requested: or should we mention that xUnit 3 isn't supported yet?