### PR TITLE
Improve tests to make the migration to NSubstitute easier

### DIFF
--- a/Tests/Reqnroll.RuntimeTests/ArgumentHelpers.cs
+++ b/Tests/Reqnroll.RuntimeTests/ArgumentHelpers.cs
@@ -1,0 +1,12 @@
+using Moq;
+using Reqnroll.Bindings.Reflection;
+
+namespace Reqnroll.RuntimeTests;
+
+internal static class ArgumentHelpers
+{
+    public static IBindingType IsBindingType<T>()
+    {
+        return It.Is<IBindingType>(bt => bt.TypeEquals(typeof(T)));
+    }
+}

--- a/Tests/Reqnroll.RuntimeTests/StepArgumentTransformationTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/StepArgumentTransformationTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -84,6 +85,7 @@ namespace Reqnroll.RuntimeTests
         private readonly Mock<IContextManager> contextManagerStub = new Mock<IContextManager>();
         private readonly Mock<IAsyncBindingInvoker> methodBindingInvokerStub = new Mock<IAsyncBindingInvoker>();
         private readonly List<IStepArgumentTransformationBinding> stepTransformations = new List<IStepArgumentTransformationBinding>();
+        private readonly CultureInfo _enUSCulture = new CultureInfo("en-US", false);
 
         public StepArgumentTransformationTests()
         {
@@ -179,7 +181,8 @@ namespace Reqnroll.RuntimeTests
 
             var stepArgumentTypeConverter = CreateStepArgumentTypeConverter();
 
-            var result = await stepArgumentTypeConverter.ConvertAsync("user xyz", typeof(User), new CultureInfo("en-US", false));
+            var runtimeBindingType = new RuntimeBindingType(typeof(User));
+            var result = await stepArgumentTypeConverter.ConvertAsync("user xyz", runtimeBindingType, _enUSCulture);
             result.Should().Be(resultUser);
         }
 
@@ -197,7 +200,8 @@ namespace Reqnroll.RuntimeTests
 
             var stepArgumentTypeConverter = CreateStepArgumentTypeConverter();
 
-            var result = await stepArgumentTypeConverter.ConvertAsync("user xyz", typeof(User), new CultureInfo("en-US", false));
+            var runtimeBindingType = new RuntimeBindingType(typeof(User));
+            var result = await stepArgumentTypeConverter.ConvertAsync("user xyz", runtimeBindingType, _enUSCulture);
             result.Should().Be(resultUser);
         }
 
@@ -215,7 +219,8 @@ namespace Reqnroll.RuntimeTests
 
             var stepArgumentTypeConverter = CreateStepArgumentTypeConverter();
 
-            var result = await stepArgumentTypeConverter.ConvertAsync("user xyz", typeof(User), new CultureInfo("en-US", false));
+            var typeToConvertTo = new RuntimeBindingType(typeof(User));
+            var result = await stepArgumentTypeConverter.ConvertAsync("user xyz", typeToConvertTo, _enUSCulture);
             result.Should().Be(resultUser);
         }
 
@@ -240,8 +245,8 @@ namespace Reqnroll.RuntimeTests
 
             var stepArgumentTypeConverter = CreateStepArgumentTypeConverter();
 
-
-            var result = await stepArgumentTypeConverter.ConvertAsync(table, typeof(IEnumerable<User>), new CultureInfo("en-US", false));
+            var typeToConvertTo = new RuntimeBindingType(typeof(IEnumerable<User>));
+            var result = await stepArgumentTypeConverter.ConvertAsync(table, typeToConvertTo, _enUSCulture);
 
             result.Should().NotBeNull();
             result.Should().Be(resultUsers);

--- a/Tests/Reqnroll.RuntimeTests/StepArgumentTypeConverterTest.cs
+++ b/Tests/Reqnroll.RuntimeTests/StepArgumentTypeConverterTest.cs
@@ -35,28 +35,32 @@ namespace Reqnroll.RuntimeTests
         [Fact]
         public async Task ShouldConvertStringToStringType()
         {
-            var result = await _stepArgumentTypeConverter.ConvertAsync("testValue", typeof(string), _enUSCulture);
+            var typeToConvertTo = new RuntimeBindingType(typeof(string));
+            var result = await _stepArgumentTypeConverter.ConvertAsync("testValue", typeToConvertTo, _enUSCulture);
             result.Should().Be("testValue");
         }
 
         [Fact]
         public async Task ShouldConvertStringToIntType()
         {
-            var result = await _stepArgumentTypeConverter.ConvertAsync("10", typeof(int), _enUSCulture);
+            var typeToConvertTo = new RuntimeBindingType(typeof(int));
+            var result = await _stepArgumentTypeConverter.ConvertAsync("10", typeToConvertTo, _enUSCulture);
             result.Should().Be(10);
         }
 
         [Fact]
         public async Task ShouldConvertStringToDateType()
         {
-            var result = await _stepArgumentTypeConverter.ConvertAsync("2009/10/06", typeof(DateTime), _enUSCulture);
+            var typeToConvertTo = new RuntimeBindingType(typeof(DateTime));
+            var result = await _stepArgumentTypeConverter.ConvertAsync("2009/10/06", typeToConvertTo, _enUSCulture);
             result.Should().Be(new DateTime(2009, 10, 06));
         }
 
         [Fact]
         public async Task ShouldConvertStringToFloatType()
         {
-            var result = await _stepArgumentTypeConverter.ConvertAsync("10.01", typeof(float), _enUSCulture);
+            var typeToConvertTo = new RuntimeBindingType(typeof(float));
+            var result = await _stepArgumentTypeConverter.ConvertAsync("10.01", typeToConvertTo, _enUSCulture);
             result.Should().Be(10.01f);
         }
 
@@ -68,49 +72,56 @@ namespace Reqnroll.RuntimeTests
         [Fact]
         public async Task ShouldConvertStringToEnumerationType()
         {
-            var result = await _stepArgumentTypeConverter.ConvertAsync("Value1", typeof(TestEnumeration), _enUSCulture);
+            var typeToConvertTo = new RuntimeBindingType(typeof(TestEnumeration));
+            var result = await _stepArgumentTypeConverter.ConvertAsync("Value1", typeToConvertTo, _enUSCulture);
             result.Should().Be(TestEnumeration.Value1);
         }
 
         [Fact]
         public async Task ShouldConvertStringToEnumerationTypeWithDifferingCase()
         {
-            var result = await _stepArgumentTypeConverter.ConvertAsync("vALUE1", typeof(TestEnumeration), _enUSCulture);
+            var typeToConvertTo = new RuntimeBindingType(typeof(TestEnumeration));
+            var result = await _stepArgumentTypeConverter.ConvertAsync("vALUE1", typeToConvertTo, _enUSCulture);
             result.Should().Be(TestEnumeration.Value1);
         }
 
         [Fact]
         public async Task ShouldConvertStringToEnumerationTypeWithWhitespace()
         {
-            var result = await _stepArgumentTypeConverter.ConvertAsync("Value 1", typeof(TestEnumeration), _enUSCulture);
+            var typeToConvertTo = new RuntimeBindingType(typeof(TestEnumeration));
+            var result = await _stepArgumentTypeConverter.ConvertAsync("Value 1", typeToConvertTo, _enUSCulture);
             result.Should().Be(TestEnumeration.Value1);
         }
 
         [Fact]
         public async Task ShouldConvertGuidToGuidType()
         {
-            var result = await _stepArgumentTypeConverter.ConvertAsync("{EF338B79-FD29-488F-8CA7-39C67C2B8874}", typeof (Guid), _enUSCulture);
+            var typeToConvertTo = new RuntimeBindingType(typeof (Guid));
+            var result = await _stepArgumentTypeConverter.ConvertAsync("{EF338B79-FD29-488F-8CA7-39C67C2B8874}", typeToConvertTo, _enUSCulture);
             result.Should().Be(new Guid("{EF338B79-FD29-488F-8CA7-39C67C2B8874}"));           
         }
 
         [Fact]
         public async Task ShouldConvertNullableGuidToGuidType()
         {
-            var result = await _stepArgumentTypeConverter.ConvertAsync("{1081CFD1-F31F-420F-9360-40590ABEF887}", typeof(Guid?), _enUSCulture);
+            var typeToConvertTo = new RuntimeBindingType(typeof(Guid?));
+            var result = await _stepArgumentTypeConverter.ConvertAsync("{1081CFD1-F31F-420F-9360-40590ABEF887}", typeToConvertTo, _enUSCulture);
             result.Should().Be(new Guid("{1081CFD1-F31F-420F-9360-40590ABEF887}"));
         }
 
         [Fact]
         public async Task ShouldConvertNullableGuidWithEmptyValueToNull()
         {
-            var result = await _stepArgumentTypeConverter.ConvertAsync("", typeof(Guid?), _enUSCulture);
+            var typeToConvertTo = new RuntimeBindingType(typeof(Guid?));
+            var result = await _stepArgumentTypeConverter.ConvertAsync("", typeToConvertTo, _enUSCulture);
             result.Should().BeNull();
         }
 
         [Fact]
         public async Task ShouldConvertLooseGuids()
         {
-            var result = await _stepArgumentTypeConverter.ConvertAsync("1", typeof (Guid), _enUSCulture);
+            var typeToConvertTo = new RuntimeBindingType(typeof (Guid));
+            var result = await _stepArgumentTypeConverter.ConvertAsync("1", typeToConvertTo, _enUSCulture);
             result.Should().Be(new Guid("10000000-0000-0000-0000-000000000000"));
         }
         
@@ -118,7 +129,8 @@ namespace Reqnroll.RuntimeTests
         public async Task ShouldUseATypeConverterWhenAvailable()
         {
             var originalValue = new DateTimeOffset(2019, 7, 29, 0, 0, 0, TimeSpan.Zero);
-            var result = await _stepArgumentTypeConverter.ConvertAsync(originalValue, typeof (TestClass), _enUSCulture);
+            var typeToConvertTo = new RuntimeBindingType(typeof (TestClass));
+            var result = await _stepArgumentTypeConverter.ConvertAsync(originalValue, typeToConvertTo, _enUSCulture);
             result.Should().BeOfType(typeof(TestClass));
             result.As<TestClass>().Time.Should().Be(originalValue);
         }
@@ -129,8 +141,9 @@ namespace Reqnroll.RuntimeTests
             var method = typeof(TestClass).GetMethod(nameof(TestClass.StringToIntConverter));
             _stepTransformations.Add(new StepArgumentTransformationBinding(@"\d+", new RuntimeBindingMethod(method)));
             _stepTransformations.Add(new StepArgumentTransformationBinding(@".*", new RuntimeBindingMethod(method)));
-            
-            await _stepArgumentTypeConverter.ConvertAsync("1", typeof(int), _enUSCulture);
+
+            var typeToConvertTo = new RuntimeBindingType(typeof(int));
+            await _stepArgumentTypeConverter.ConvertAsync("1", typeToConvertTo, _enUSCulture);
             
             _testTracer.Verify(c => c.TraceWarning(It.IsAny<string>()), Times.Once);
         }
@@ -142,8 +155,9 @@ namespace Reqnroll.RuntimeTests
 
             _stepTransformations.Add(new StepArgumentTransformationBinding(@"\d+", new RuntimeBindingMethod(method)));
             _stepTransformations.Add(new StepArgumentTransformationBinding(@".*", new RuntimeBindingMethod(method), order: 10));
-            
-            await _stepArgumentTypeConverter.ConvertAsync("1", typeof(int), _enUSCulture);
+
+            var typeToConvertTo = new RuntimeBindingType(typeof(int));
+            await _stepArgumentTypeConverter.ConvertAsync("1", typeToConvertTo, _enUSCulture);
             
             _testTracer.Verify(c => c.TraceWarning(It.IsAny<string>()), Times.Never);
         }

--- a/Tests/Reqnroll.RuntimeTests/StepExecutionTestsWithConversionsForTables.cs
+++ b/Tests/Reqnroll.RuntimeTests/StepExecutionTestsWithConversionsForTables.cs
@@ -42,12 +42,9 @@ namespace Reqnroll.RuntimeTests
             Table table = new Table("h1");
             var user = new User();
 
-            // return false unless its a User
-            StepArgumentTypeConverterStub.Setup(LegacyStepArgumentTypeConverterExtensions.GetCanConvertMethodFilter(table, typeof(User))).Returns(true);
-            StepArgumentTypeConverterStub.Setup(LegacyStepArgumentTypeConverterExtensions.GetConvertAsyncMethodFilter(table, typeof(User))).ReturnsAsync(user);
-
-            //bindingInstance.Expect(b => b.SingleTable(user));
-            //MockRepository.ReplayAll();
+            // return false unless it's a User
+            StepArgumentTypeConverterStub.Setup(c => c.CanConvert(table, ArgumentHelpers.IsBindingType<User>(), It.IsAny<CultureInfo>())).Returns(true);
+            StepArgumentTypeConverterStub.Setup(c => c.ConvertAsync(It.Is<object>(s => s.Equals(table)), ArgumentHelpers.IsBindingType<User>(), It.IsAny<CultureInfo>())).ReturnsAsync(user);
 
             await testRunner.GivenAsync("sample step for argument convert with table", null, table);
 
@@ -63,17 +60,12 @@ namespace Reqnroll.RuntimeTests
             Table table = new Table("h1");
             var user = new User();
             var multiLineArg = "multi-line arg";
-            // return false unless its a User
-            StepArgumentTypeConverterStub.Setup(LegacyStepArgumentTypeConverterExtensions.GetCanConvertMethodFilter(table, typeof(User))).Returns(true);            
+            // return false unless it's a User
+            StepArgumentTypeConverterStub.Setup(c => c.CanConvert(table, ArgumentHelpers.IsBindingType<User>(), It.IsAny<CultureInfo>())).Returns(true);            
             StepArgumentTypeConverterStub.Setup(c => c.CanConvert(It.IsAny<object>(), It.IsAny<IBindingType>(), It.IsAny<CultureInfo>())).Returns(false);
-            StepArgumentTypeConverterStub.Setup(LegacyStepArgumentTypeConverterExtensions.GetConvertAsyncMethodFilter(multiLineArg, typeof(string))).ReturnsAsync(multiLineArg);
-            StepArgumentTypeConverterStub.Setup(LegacyStepArgumentTypeConverterExtensions.GetConvertAsyncMethodFilter(table, typeof(User))).ReturnsAsync(user);
+            StepArgumentTypeConverterStub.Setup(c => c.ConvertAsync(multiLineArg, ArgumentHelpers.IsBindingType<string>(), It.IsAny<CultureInfo>())).ReturnsAsync(multiLineArg);
+            StepArgumentTypeConverterStub.Setup(c => c.ConvertAsync(It.Is<object>(s => s.Equals(table)), ArgumentHelpers.IsBindingType<User>(), It.IsAny<CultureInfo>())).ReturnsAsync(user);
             
-
-            
-            //bindingInstance.Expect(b => b.MultilineArgumentAndTable(multiLineArg, user));
-            //MockRepository.ReplayAll();
-
             await testRunner.GivenAsync("sample step for argument convert with multiline argument and table", multiLineArg, table);
 
             GetLastTestStatus().Should().Be(ScenarioExecutionStatus.OK);
@@ -89,17 +81,13 @@ namespace Reqnroll.RuntimeTests
             string argumentValue = "argument";
             var user = new User();
             var multiLineArg = "multi-line arg";
-            // return false unless its a User
+            // return false unless it's a User
             // must also stub CanConvert & Convert for the string argument as we've introduced a parameter
-            StepArgumentTypeConverterStub.Setup(LegacyStepArgumentTypeConverterExtensions.GetCanConvertMethodFilter(table, typeof(User))).Returns(true);
+            StepArgumentTypeConverterStub.Setup(c => c.CanConvert(table, ArgumentHelpers.IsBindingType<User>(), It.IsAny<CultureInfo>())).Returns(true);
             StepArgumentTypeConverterStub.Setup(c => c.CanConvert(It.IsAny<object>(), It.IsAny<IBindingType>(), It.IsAny<CultureInfo>())).Returns(false);
-            StepArgumentTypeConverterStub.Setup(LegacyStepArgumentTypeConverterExtensions.GetConvertAsyncMethodFilter(table, typeof(User))).ReturnsAsync(user);
-            StepArgumentTypeConverterStub.Setup(LegacyStepArgumentTypeConverterExtensions.GetConvertAsyncMethodFilter(argumentValue, typeof(string))).ReturnsAsync(argumentValue);
-            StepArgumentTypeConverterStub.Setup(LegacyStepArgumentTypeConverterExtensions.GetConvertAsyncMethodFilter(multiLineArg, typeof(string))).ReturnsAsync(multiLineArg);
-
-            
-            //bindingInstance.Expect(b => b.ParameterMultilineArgumentAndTable(argumentValue, multiLineArg, user));
-            //MockRepository.ReplayAll();
+            StepArgumentTypeConverterStub.Setup(c => c.ConvertAsync(It.Is<object>(s => s.Equals(table)), ArgumentHelpers.IsBindingType<User>(), It.IsAny<CultureInfo>())).ReturnsAsync(user);
+            StepArgumentTypeConverterStub.Setup(c => c.ConvertAsync(argumentValue, ArgumentHelpers.IsBindingType<string>(), It.IsAny<CultureInfo>())).ReturnsAsync(argumentValue);
+            StepArgumentTypeConverterStub.Setup(c => c.ConvertAsync(multiLineArg, ArgumentHelpers.IsBindingType<string>(), It.IsAny<CultureInfo>())).ReturnsAsync(multiLineArg);
 
             await testRunner.GivenAsync("sample step for argument convert with parameter, multiline argument and table: argument", multiLineArg, table);
 


### PR DESCRIPTION

### 🤔 What's changed?

Refactored the tests, but don't changed the behavior of the tests.

- Remove LegacyStepArgumentTypeConverterExtensions - it's a strange pattern and makes tests hard to understand
   -  e.g. `StepArgumentTypeConverterStub.Setup(LegacyStepArgumentTypeConverterExtensions.GetCanConvertMethodFilter` is unclear/vague
   - It was sometimes unclear which method we were mocking/assertion (because of the extension)
- Add ArgumentHelpers to avoid to much duplication in the tests and make the tests more readable. 
- Removed dead test code (commented out in the touched files)
- Remove some unused vars in the touched files
- Fixed some spelling in comments

Note, I used Resharper for most actions, e.g. inline method, inline variable etc. 

### ⚡️ What's your motivation? 
The POC with the migration to NSubstitute  
https://github.com/reqnroll/Reqnroll/pull/497 showed use that some parts where difficult to migration. 

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bank: Refactoring in tests

### ♻️ Anything particular you want feedback on?

Do we add these changes to the changelog? 
### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->


  - [ ] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
