### PR TITLE
Change ReqnrollOutputHelper to use test output

### DIFF
--- a/Reqnroll/Infrastructure/ReqnrollOutputHelper.cs
+++ b/Reqnroll/Infrastructure/ReqnrollOutputHelper.cs
@@ -19,7 +19,7 @@ namespace Reqnroll.Infrastructure
         public void WriteLine(string message)
         {
             _testThreadExecutionEventPublisher.PublishEvent(new OutputAddedEvent(message));
-            _traceListener.WriteToolOutput(message);
+            _traceListener.WriteTestOutput(message);
         }
 
         public void WriteLine(string format, params object[] args)

--- a/Tests/Reqnroll.Specs/StepDefinitions/ExecutionResultSteps.cs
+++ b/Tests/Reqnroll.Specs/StepDefinitions/ExecutionResultSteps.cs
@@ -115,7 +115,7 @@ namespace Reqnroll.Specs.StepDefinitions
 
             foreach (var testResult in lastTestExecutionResult.LeafTestResults)
             {
-                var contextIdLines = testResult.StdOut.Split(new string[] { Environment.NewLine, "\n" }, StringSplitOptions.RemoveEmptyEntries).Where(s => s.StartsWith("-> Context ID"));
+                var contextIdLines = testResult.StdOut.Split(new string[] { Environment.NewLine, "\n" }, StringSplitOptions.RemoveEmptyEntries).Where(s => s.StartsWith("Context ID"));
 
                 var distinctContextIdLines = contextIdLines.Distinct();
 


### PR DESCRIPTION
### 🤔 What's changed?

Changed ReqnrollOutputHelper to use test output instead of the tool output in `ITraceListener`.

In practice this means that the `->` prefix is not added to this messages.

### ⚡️ What's your motivation? 

The `ITraceListener.WriteToolOutput` was intended to provide information that come from the tool (ie Reqnroll), not from the tests, so this was incorrect.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

How could it happen that we didn't notice this so far...

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [x] Users should know about my change
  - [ ] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
