### PR TITLE
Include original exception in when throwing a BindingException

### DIFF
--- a/Reqnroll/ErrorHandling/ErrorProvider.cs
+++ b/Reqnroll/ErrorHandling/ErrorProvider.cs
@@ -47,7 +47,7 @@ namespace Reqnroll.ErrorHandling
 
         public Exception GetCallError(IBindingMethod method, Exception ex)
         {
-            return new BindingException($"Error calling binding method '{GetMethodText(method)}': {ex.Message}");
+            return new BindingException($"Error calling binding method '{GetMethodText(method)}': {ex.Message}", ex);
         }
 
         public Exception GetParameterCountError(BindingMatch match, int expectedParameterCount)

--- a/Tests/Reqnroll.RuntimeTests/ErrorProviderTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/ErrorProviderTests.cs
@@ -74,6 +74,7 @@ namespace Reqnroll.RuntimeTests
             result.Should().NotBeNull();
             result.Should().BeOfType<BindingException>();
             result.Message.Should().Be($"Error calling binding method '{methodBindingAssemblyName}:{methodBindingTypeFullName}.{methodName}({parameter1Type}, {parameter2Type})': {expectedExceptionMessage}");
+            result.InnerException.Should().BeSameAs(exceptionStub.Object);
         }
 
         [Fact]


### PR DESCRIPTION
### 🤔 What's changed?

Include original exception in when throwing a BindingException

### ⚡️ What's your motivation? 

Imrprove error message and don't hide the stack when an error occurs. It should help #471 (But I think the catch ArgumentException should still be reworked)

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

