### PR TITLE
chore: Add documentation about the xUnit parallel modes

### DIFF
--- a/docs/integrations/xunit.md
+++ b/docs/integrations/xunit.md
@@ -1,6 +1,6 @@
 # xUnit
 
-Reqnroll supports xUnit 2.4 or later.  
+Reqnroll supports xUnit v2 2.8 or later. xUnit v3 is currently not supported.
 
 Documentation for xUnit can be found [here](https://xunit.net/#documentation).
 
@@ -17,7 +17,31 @@ For Test Discovery & Execution:
 
 ## Access ITestOutputHelper
 
-The xUnit ITestOutputHelper is registered in the ScenarioContainer. You can get access to simply via getting it via [Context-Injection](../automation/context-injection.md).
+The xUnit `ITestOutputHelper` is registered in the ScenarioContainer. You can get access to simply via getting it via [Context-Injection](../automation/context-injection.md).
+
+## Migrating from SpecFlow
+
+Reqnroll generates Task based async code, which is different from the SpecFlow generated synchronous code.
+This change has a big effect on how xUnit runs the Tests.
+
+xUnit since Version 2.8 has two modes for running tests in parallel: `conservative` (new and default since 2.8) and `aggressive` the default (older and default before 2.8). For more details about both algorithms and their 
+configuration, see the [xUnit Running Tests in Parallel](https://xunit.net/docs/running-tests-in-parallel). 
+Reqnroll.xUnit also supports both modes since Version 2.4.0; on older versions, only the aggressive mode was possible (even with xUnit 2.8 or higher).
+
+TLDR is:
+
+* Conservative mode starts just as many tests, which are configured in max parallel threads.
+* Aggressive mode starts all tests, and lets the Task Scheduler handle the maximum parallel threads. 
+
+Because of the async nature of Reqnroll generated test code, the aggressive mode together with resource
+intensive test (i.e. Browser-based tests) can lead to the impression that more tests are run in parallel then
+configured (more Browsers opened than expected). 
+This is normally a wanted async/await behavior. To fully utilize the available resources.
+
+If you have resource-intensive tests, use the default conservative mode and limit the parallel tests in xUnit.
+But you can opt in the aggressive mode if your tests are lighter on the resources, to optimize the time to finish the tests.
+
+We recommend sticking to the default conservative mode unless you have good reason to use the aggressive mode.
 
 ### Example
 


### PR DESCRIPTION
### 🤔 What's changed?

Added some description about the xUnit parallel algorithm.

The new Conservative is is the default, so if the aggressive mode is not configured, then the user
has now a "expected" behavior. So i described not to switch to conservative mode, but i give
the recommandation to stick to it.

### ⚡️ What's your motivation? 

Having something to point on, when the issue is comming up, because some hat explicit configured the aggressive mode.

### 🏷️ What kind of change is this?

- :book: Documentation (improvements without changing code)

### ♻️ Anything particular you want feedback on?

If you find typos or would like to change a sentence or two, just do it ;)
