### PR TITLE
Sorted the list of plugins to enable deterministic loading of plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # [vNext]
 
 ## Improvements:
+* Added sorting of the list of plugins which is given back during plugin discovery (#519)
 
 ## Bug fixes:
 

--- a/Reqnroll/Plugins/RuntimePluginLocationMerger.cs
+++ b/Reqnroll/Plugins/RuntimePluginLocationMerger.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 
@@ -32,7 +33,13 @@ namespace Reqnroll.Plugins
                 }
             }
 
-            return modifiedList ?? pluginPaths;
+            return SortPluginPaths(modifiedList ?? [.. pluginPaths]);
+        }
+
+        private static IReadOnlyList<string> SortPluginPaths(List<string> pluginPaths)
+        {
+            pluginPaths.Sort((x, y) => string.Compare(Path.GetFileName(x), Path.GetFileName(y), StringComparison.Ordinal));
+            return pluginPaths;
         }
 
         private static List<string> CopyUntilIndex(IReadOnlyList<string> pluginPaths, int index)

--- a/Reqnroll/Plugins/RuntimePluginLocator.cs
+++ b/Reqnroll/Plugins/RuntimePluginLocator.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using Reqnroll.Infrastructure;
 
@@ -46,7 +47,7 @@ namespace Reqnroll.Plugins
                 }
             }
 
-            return _runtimePluginLocationMerger.Merge(allRuntimePlugins);
+            return _runtimePluginLocationMerger.Merge(allRuntimePlugins).OrderBy(plugin => plugin).ToList();
         }
 
         private static IEnumerable<string> SearchPluginsInFolder(string folder)

--- a/Reqnroll/Plugins/RuntimePluginLocator.cs
+++ b/Reqnroll/Plugins/RuntimePluginLocator.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using Reqnroll.Infrastructure;
 
@@ -47,7 +46,7 @@ namespace Reqnroll.Plugins
                 }
             }
 
-            return _runtimePluginLocationMerger.Merge(allRuntimePlugins).OrderBy(plugin => plugin).ToList();
+            return _runtimePluginLocationMerger.Merge(allRuntimePlugins);
         }
 
         private static IEnumerable<string> SearchPluginsInFolder(string folder)

--- a/Tests/Reqnroll.RuntimeTests/Infrastructure/RuntimePluginLocationMergerTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/Infrastructure/RuntimePluginLocationMergerTests.cs
@@ -112,7 +112,6 @@ namespace Reqnroll.RuntimeTests.Infrastructure
             result.Should().HaveCount(2);
         }
 
-
         [SkippableFact]
         public void Merge_DifferendPluginSamePath_BothAreReturned_Unix()
         {
@@ -130,6 +129,68 @@ namespace Reqnroll.RuntimeTests.Infrastructure
             result.Should().Contain("/temp/Plugin.ReqnrollPlugin.dll");
             result.Should().Contain("/temp/AnotherPlugin.ReqnrollPlugin.dll");
             result.Should().HaveCount(2);
+        }
+
+        [SkippableFact]
+        public void Merge_UnsortedListOfPlugins_SortedListIsReturned_Windows()
+        {
+            Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
+
+            //ARRANGE
+            var runtimePluginLocationMerger = new RuntimePluginLocationMerger();
+
+
+            //ACT
+            var result = runtimePluginLocationMerger.Merge(new string[]
+            {
+                "C:\\temp1\\B.ReqnrollPlugin.dll",
+                "C:\\temp2\\D.ReqnrollPlugin.dll",
+                "C:\\temp\\AA.ReqnrollPlugin.dll",
+                "C:\\temp1\\Z.ReqnrollPlugin.dll",
+                "C:\\temp2\\A.ReqnrollPlugin.dll",
+                "C:\\temp\\C.ReqnrollPlugin.dll",
+            });
+
+
+            //ASSERT
+            result.Should().HaveCount(6);
+            result[0].Should().Be("C:\\temp2\\A.ReqnrollPlugin.dll");
+            result[1].Should().Be("C:\\temp\\AA.ReqnrollPlugin.dll");
+            result[2].Should().Be("C:\\temp1\\B.ReqnrollPlugin.dll");
+            result[3].Should().Be("C:\\temp\\C.ReqnrollPlugin.dll");
+            result[4].Should().Be("C:\\temp2\\D.ReqnrollPlugin.dll");
+            result[5].Should().Be("C:\\temp1\\Z.ReqnrollPlugin.dll");
+        }
+
+        [SkippableFact]
+        public void Merge_UnsortedListOfPlugins_SortedListIsReturned_Unix()
+        {
+            Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX));
+
+            //ARRANGE
+            var runtimePluginLocationMerger = new RuntimePluginLocationMerger();
+
+
+            //ACT
+            var result = runtimePluginLocationMerger.Merge(new string[]
+            {
+                "C:\\temp1\\B.ReqnrollPlugin.dll",
+                "C:\\temp2\\D.ReqnrollPlugin.dll",
+                "C:\\temp\\AA.ReqnrollPlugin.dll",
+                "C:\\temp1\\Z.ReqnrollPlugin.dll",
+                "C:\\temp2\\A.ReqnrollPlugin.dll",
+                "C:\\temp\\C.ReqnrollPlugin.dll",
+            });
+
+
+            //ASSERT
+            result.Should().HaveCount(6);
+            result[0].Should().Be("C:\\temp2\\A.ReqnrollPlugin.dll");
+            result[1].Should().Be("C:\\temp\\AA.ReqnrollPlugin.dll");
+            result[2].Should().Be("C:\\temp1\\B.ReqnrollPlugin.dll");
+            result[3].Should().Be("C:\\temp\\C.ReqnrollPlugin.dll");
+            result[4].Should().Be("C:\\temp2\\D.ReqnrollPlugin.dll");
+            result[5].Should().Be("C:\\temp1\\Z.ReqnrollPlugin.dll");
         }
     }
 }


### PR DESCRIPTION
### 🤔 What's changed?

During plugin discovery the list of found plugins is sorted to enable deterministic loading of plugins

### ⚡️ What's your motivation? 

As described in Ideas #502 the problem is that the plugins are discovered by querying files in directories. This behavior is different depending on the underlying filesystem, means:
Window/NFTS: alphanumerical
Linux/ext: "inode" order

This leads to the situation that the loading is different when you locally test with Windows and on the pipeline the tests are running on a linux agent.

This is per se a bit inconsistent, but for us it is a problem as we have a plugin which is overwriting the tracing. We enforce by the plugin-name that our plugin is loaded last, which now only works with NTFS.

### 🏷️ What kind of change is this?

The list of plugins which is given back is sorted alphabetical

### ♻️ Anything particular you want feedback on?


### 📋 Checklist:

- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [X] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
