### PR TITLE
Don't care about already released TestThreadContexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ## Bug fixes:
 
-*Contributors of this release (in alphabetical order):* 
+* Don't crash on already released TestThreadContexts (#550)
+
+*Contributors of this release (in alphabetical order): @304NotModified* 
 
 # v2.4.0 - 2025-03-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Don't crash on already released TestThreadContexts (#550)
 * Fix: xUnit async `[AfterTestRun]` hook might not execute fully (#530)
 
-*Contributors of this release (in alphabetical order):* @304NotModified, @gasparnagy* 
+*Contributors of this release (in alphabetical order): @304NotModified, @gasparnagy* 
 
 # v2.4.0 - 2025-03-06
 

--- a/Reqnroll/TestRunnerManager.cs
+++ b/Reqnroll/TestRunnerManager.cs
@@ -104,7 +104,9 @@ public class TestRunnerManager : ITestRunnerManager
     {
         var testThreadContainer = testThreadContext.TestThreadContainer;
         if (!_usedTestWorkerContainers.TryRemove(testThreadContainer, out var usedContainerHint))
-            throw new InvalidOperationException($"TestThreadContext with id {TestThreadContainerInfo.GetId(testThreadContainer)} was already released");
+        {
+            // Already released   
+        }
         var containerHint = new TestWorkerContainerHint(usedContainerHint?.LastUsedFeatureInfo, Thread.CurrentThread.ManagedThreadId);
         if (!_availableTestWorkerContainers.TryAdd(testThreadContainer, containerHint))
             throw new InvalidOperationException($"TestThreadContext with id {TestThreadContainerInfo.GetId(testThreadContainer)} was released twice");


### PR DESCRIPTION



### 🤔 What's changed?

Ignore this error, as nothing goes wrong after it.

### ⚡️ What's your motivation? 
Fixes https://github.com/reqnroll/Reqnroll/issues/387

Also, there is another "Container was already taken by another thread" comment, see 
https://github.com/reqnroll/Reqnroll/blob/966d1c372bdef843d7a2e3ecd267e07722351d80/Reqnroll/TestRunnerManager.cs#L186


### 🏷️ What kind of change is this?



- :bug: Bug fix (non-breaking change which fixes a defect)


### ♻️ Anything particular you want feedback on?


### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
