### PR TITLE
Improved description of xUnit package

### DIFF
--- a/Plugins/Reqnroll.xUnit.Generator.ReqnrollPlugin/Reqnroll.xUnit.nuspec
+++ b/Plugins/Reqnroll.xUnit.Generator.ReqnrollPlugin/Reqnroll.xUnit.nuspec
@@ -6,8 +6,8 @@
     <title>Reqnroll.xUnit</title>
     <authors>$author$</authors>
     <owners>$owner$</owners>
-    <description>Package to use Reqnroll with xUnit 2.4 and later. $summary$</description>
-    <summary>Package to use Reqnroll with xUnit 2.4 and later. $summary$</summary>
+    <description>Package to use Reqnroll with xUnit 2.x. Note: this package won't support xUnit 3.x. $summary$</description>
+    <summary>Package to use Reqnroll with xUnit 2.x. Note: this package won't support xUnit 3.x. $summary$</summary>
     <language>en-US</language>
     <projectUrl>https://www.reqnroll.net</projectUrl>
     <repository type="git" url="https://github.com/reqnroll/Reqnroll.git" branch="$branch$" commit="$commit$" />


### PR DESCRIPTION
### 🤔 What's changed?

Changed the description of the xUnit package

### ⚡️ What's your motivation? 
- The "xUnit 2.4 and later" was confusing, because the dependency of xUnit 2.8.1+
- Made more clear that xUnit 3 isn't supported

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :book: Documentation (improvements without changing code)

