### PR TITLE
Fix XUnit async AfterTestRun hook issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ## Bug fixes:
 
-*Contributors of this release (in alphabetical order):* 
+* Fix: xUnit async `[AfterTestRun]` hook might not execute fully (#530)
+
+*Contributors of this release (in alphabetical order): @gasparnagy* 
 
 # v2.4.0 - 2025-03-06
 

--- a/Plugins/Reqnroll.xUnit.ReqnrollPlugin/XunitTestAssemblyRunnerWithAssemblyFixture.cs
+++ b/Plugins/Reqnroll.xUnit.ReqnrollPlugin/XunitTestAssemblyRunnerWithAssemblyFixture.cs
@@ -59,7 +59,7 @@ namespace Reqnroll.xUnit.ReqnrollPlugin
                 });
         }
 
-        protected override Task BeforeTestAssemblyFinishedAsync()
+        protected override async Task BeforeTestAssemblyFinishedAsync()
         {
             // Make sure we clean up everybody who is disposable, and use Aggregator.Run to isolate Dispose failures
             foreach (var potentialDisposable in _assemblyFixtureMappings.Values)
@@ -71,16 +71,16 @@ namespace Reqnroll.xUnit.ReqnrollPlugin
 #if NET // IAsyncDisposable supported natively in .NET 5, .NET 6
                 else if (potentialDisposable is IAsyncDisposable asyncDisposable)
                 {
-                    Aggregator.RunAsync(async () => await asyncDisposable.DisposeAsync());
+                    await Aggregator.RunAsync(async () => await asyncDisposable.DisposeAsync());
                 }
 #endif
                 else if (potentialDisposable is IAsyncLifetime asyncLifetime)
                 {
-                    Aggregator.RunAsync(async () => await asyncLifetime.DisposeAsync());
+                    await Aggregator.RunAsync(async () => await asyncLifetime.DisposeAsync());
                 }
             }
 
-            return base.BeforeTestAssemblyFinishedAsync();
+            await base.BeforeTestAssemblyFinishedAsync();
         }
 
         protected override Task<RunSummary> RunTestCollectionWithinParallelAlgorithmAsync(

--- a/Tests/Reqnroll.SystemTests/Generation/GenerationTestBase.cs
+++ b/Tests/Reqnroll.SystemTests/Generation/GenerationTestBase.cs
@@ -249,6 +249,37 @@ public abstract class GenerationTestBase : SystemTestBase
             "AfterTestRun");
         ShouldAllScenariosPass();
     }
+
+    [TestMethod]
+    public void Async_TestRun_Feature_and_Scenario_hooks_are_executed_in_right_order()
+    {
+        var testsInFeatureFile = 3;
+        AddSimpleScenario();
+        AddSimpleScenarioOutline(testsInFeatureFile - 1);
+        AddPassingStepBinding();
+        const string waitCode = "await Task.Delay(TimeSpan.FromMilliseconds(50));";
+        AddHookBinding("BeforeTestRun", code: waitCode, asyncHook: true);
+        AddHookBinding("AfterTestRun", code: waitCode, asyncHook: true);
+        AddHookBinding("BeforeFeature", code: waitCode, asyncHook: true);
+        AddHookBinding("AfterFeature", code: waitCode, asyncHook: true);
+        AddHookBinding("BeforeScenario", code: waitCode, asyncHook: true);
+        AddHookBinding("AfterScenario", code: waitCode, asyncHook: true);
+
+        ExecuteTests();
+
+        _bindingDriver.AssertExecutedHooksEqual(
+            "BeforeTestRun",
+            "BeforeFeature",
+            "BeforeScenario",
+            "AfterScenario",
+            "BeforeScenario",
+            "AfterScenario",
+            "BeforeScenario",
+            "AfterScenario",
+            "AfterFeature",
+            "AfterTestRun");
+        ShouldAllScenariosPass();
+    }
     #endregion
 
     #region Test scenario outlines (nr of examples, params are available in ScenarioContext, allowRowTests=false, examples tags)

--- a/Tests/Reqnroll.SystemTests/Generation/XUnitGenerationTest.cs
+++ b/Tests/Reqnroll.SystemTests/Generation/XUnitGenerationTest.cs
@@ -24,4 +24,20 @@ public class XUnitGenerationTest : GenerationTestBase
     {
         //nop - xUnit currently does not support method-level parallelization
     }
+
+    [TestMethod]
+    public void AfterTestRun_hook_can_execute_longer_async_actions()
+    {
+        AddSimpleScenario();
+        AddPassingStepBinding();
+        AddHookBinding("AfterTestRun", 
+                       code: "await Task.Delay(TimeSpan.FromMilliseconds(100));",
+                       asyncHook: true);
+
+        ExecuteTests();
+
+        _bindingDriver.AssertExecutedHooksEqual("AfterTestRun");
+        ShouldAllScenariosPass();
+    }
+
 }

--- a/Tests/Reqnroll.SystemTests/Generation/XUnitGenerationTest.cs
+++ b/Tests/Reqnroll.SystemTests/Generation/XUnitGenerationTest.cs
@@ -24,20 +24,4 @@ public class XUnitGenerationTest : GenerationTestBase
     {
         //nop - xUnit currently does not support method-level parallelization
     }
-
-    [TestMethod]
-    public void AfterTestRun_hook_can_execute_longer_async_actions()
-    {
-        AddSimpleScenario();
-        AddPassingStepBinding();
-        AddHookBinding("AfterTestRun", 
-                       code: "await Task.Delay(TimeSpan.FromMilliseconds(100));",
-                       asyncHook: true);
-
-        ExecuteTests();
-
-        _bindingDriver.AssertExecutedHooksEqual("AfterTestRun");
-        ShouldAllScenariosPass();
-    }
-
 }

--- a/Tests/Reqnroll.SystemTests/SystemTestBase.cs
+++ b/Tests/Reqnroll.SystemTests/SystemTestBase.cs
@@ -258,9 +258,9 @@ public abstract class SystemTestBase
         return expectedNrOfTests;
     }
 
-    protected void AddHookBinding(string eventType, string? name = null, string code = "")
+    protected void AddHookBinding(string eventType, string? name = null, string code = "", bool? asyncHook = null)
     {
-        _projectsDriver.AddHookBinding(eventType, name, code: code);
+        _projectsDriver.AddHookBinding(eventType, name, code: code, asyncHook: asyncHook);
     }
 
     protected void AddPassingStepBinding(string scenarioBlock = "StepDefinition", string stepRegex = ".*")

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Driver/ProjectsDriver.cs
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Driver/ProjectsDriver.cs
@@ -51,23 +51,23 @@ namespace Reqnroll.TestProjectGenerator.Driver
             return projectBuilder;
         }
 
-        public void AddHookBinding(string eventType, string name, string hookTypeAttributeTagsString, string methodScopeAttributeTagsString = null, string classScopeAttributeTagsString = null, string code = "", int? order = null)
+        public void AddHookBinding(string eventType, string name, string hookTypeAttributeTagsString, string methodScopeAttributeTagsString = null, string classScopeAttributeTagsString = null, string code = "", bool? asyncHook = null, int? order = null)
         {
             var hookTypeAttributeTags = hookTypeAttributeTagsString?.Split(',').Select(t => t.Trim()).ToArray();
             var methodScopeAttributeTags = methodScopeAttributeTagsString?.Split(',').Select(t => t.Trim()).ToArray();
             var classScopeAttributeTags = classScopeAttributeTagsString?.Split(',').Select(t => t.Trim()).ToArray();
 
-            AddHookBinding(_solutionDriver.DefaultProject, eventType, name, code, order, hookTypeAttributeTags, methodScopeAttributeTags, classScopeAttributeTags);
+            AddHookBinding(_solutionDriver.DefaultProject, eventType, name, code, asyncHook, order, hookTypeAttributeTags, methodScopeAttributeTags, classScopeAttributeTags);
         }
 
-        public void AddHookBinding(string eventType, string name = null, string code = "", int? order = null, IList<string> hookTypeAttributeTags = null, IList<string> methodScopeAttributeTags = null, IList<string> classScopeAttributeTags = null)
+        public void AddHookBinding(string eventType, string name = null, string code = "", bool? asyncHook = null, int? order = null, IList<string> hookTypeAttributeTags = null, IList<string> methodScopeAttributeTags = null, IList<string> classScopeAttributeTags = null)
         {
-            AddHookBinding(_solutionDriver.DefaultProject, eventType, name ?? eventType, code, order, hookTypeAttributeTags, methodScopeAttributeTags, classScopeAttributeTags);
+            AddHookBinding(_solutionDriver.DefaultProject, eventType, name ?? eventType, code, asyncHook, order, hookTypeAttributeTags, methodScopeAttributeTags, classScopeAttributeTags);
         }
 
-        private void AddHookBinding(ProjectBuilder project, string eventType, string name, string code = "", int? order = null, IList<string> hookTypeAttributeTags = null, IList<string> methodScopeAttributeTags = null,  IList<string> classScopeAttributeTags = null)
+        private void AddHookBinding(ProjectBuilder project, string eventType, string name, string code = "", bool? asyncHook = null, int? order = null, IList<string> hookTypeAttributeTags = null, IList<string> methodScopeAttributeTags = null,  IList<string> classScopeAttributeTags = null)
         {
-            project.AddHookBinding(eventType, name, code, order, hookTypeAttributeTags, methodScopeAttributeTags, classScopeAttributeTags);
+            project.AddHookBinding(eventType, name, code, asyncHook, order, hookTypeAttributeTags, methodScopeAttributeTags, classScopeAttributeTags);
         }
 
         public void AddFeatureFile(string featureFileContent)

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Factories/BindingsGenerator/BaseBindingsGenerator.cs
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Factories/BindingsGenerator/BaseBindingsGenerator.cs
@@ -6,6 +6,8 @@ namespace Reqnroll.TestProjectGenerator.Factories.BindingsGenerator
 {
     public abstract class BaseBindingsGenerator
     {
+        public const bool DefaultAsyncHook = false;
+
         public abstract ProjectFile GenerateBindingClassFile(string fileContent);
 
         public abstract ProjectFile GenerateStepDefinition(string method);
@@ -22,9 +24,9 @@ namespace Reqnroll.TestProjectGenerator.Factories.BindingsGenerator
             return GenerateStepDefinition(method);
         }
 
-        public ProjectFile GenerateHookBinding(string eventType, string name, string code = null, int? order = null, IList<string> hookTypeAttributeTags = null, IList<string> methodScopeAttributeTags = null, IList<string> classScopeAttributeTags = null)
+        public ProjectFile GenerateHookBinding(string eventType, string name, string code = null, bool? asyncHook = null, int? order = null, IList<string> hookTypeAttributeTags = null, IList<string> methodScopeAttributeTags = null, IList<string> classScopeAttributeTags = null)
         {
-            string hookClass = GetHookBindingClass(eventType, name, code, order, hookTypeAttributeTags, methodScopeAttributeTags, classScopeAttributeTags);
+            string hookClass = GetHookBindingClass(eventType, name, code, asyncHook, order, hookTypeAttributeTags, methodScopeAttributeTags, classScopeAttributeTags);
             return GenerateBindingClassFile(hookClass);
         }
 
@@ -38,6 +40,7 @@ namespace Reqnroll.TestProjectGenerator.Factories.BindingsGenerator
             string hookType,
             string name,
             string code = "",
+            bool? asyncHook = null,
             int? order = null,
             IList<string> hookTypeAttributeTags = null,
             IList<string> methodScopeAttributeTags = null,

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Factories/BindingsGenerator/CSharpBindingsGenerator.cs
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Factories/BindingsGenerator/CSharpBindingsGenerator.cs
@@ -191,6 +191,7 @@ namespace Reqnroll.TestProjectGenerator.Factories.BindingsGenerator
             string hookType,
             string name,
             string code = "",
+            bool? asyncHook = null,
             int? order = null,
             IList<string> hookTypeAttributeTags = null,
             IList<string> methodScopeAttributeTags = null,
@@ -213,7 +214,9 @@ namespace Reqnroll.TestProjectGenerator.Factories.BindingsGenerator
             string scopeClassAttributes = ToScopeTags(classScopeAttributeTags);
             string scopeMethodAttributes = ToScopeTags(methodScopeAttributeTags);
             string staticKeyword = isStatic ? "static" : string.Empty;
-
+            
+            var asyncHookValue = asyncHook ?? DefaultAsyncHook;
+            var returnType = asyncHookValue ? "async Task" : "void";
 
             return $$"""
 
@@ -231,7 +234,7 @@ namespace Reqnroll.TestProjectGenerator.Factories.BindingsGenerator
                      {
                          [{{hookType}}({{hookTypeAttributeTagsString}})]
                          {{scopeMethodAttributes}}
-                         public {{staticKeyword}} void {{name}}()
+                         public {{staticKeyword}} {{returnType}} {{name}}()
                          {
                              {{code}}
                              global::Log.LogHook();

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Factories/BindingsGenerator/FSharpBindingsGenerator.cs
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Factories/BindingsGenerator/FSharpBindingsGenerator.cs
@@ -111,6 +111,7 @@ type internal Log =
             string hookType,
             string name,
             string code = "",
+            bool? asyncHook = null,
             int? order = null,
             IList<string> hookTypeAttributeTags = null,
             IList<string> methodScopeAttributeTags = null,

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Factories/BindingsGenerator/VbBindingsGenerator.cs
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Factories/BindingsGenerator/VbBindingsGenerator.cs
@@ -147,6 +147,7 @@ namespace Reqnroll.TestProjectGenerator.Factories.BindingsGenerator
             string hookType,
             string name,
             string code = "",
+            bool? asyncHook = null,
             int? order = null,
             IList<string> hookTypeAttributeTags = null,
             IList<string> methodScopeAttributeTags = null,

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/ProjectBuilder.cs
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/ProjectBuilder.cs
@@ -113,13 +113,13 @@ namespace Reqnroll.TestProjectGenerator
             _project.AddFile(bindingsGenerator.GenerateLoggingStepDefinition(methodName, attributeName, regex, ParameterType.DocString, "docStringArg"));
         }
 
-        public void AddHookBinding(string eventType, string name, string code = "", int? order = null, IList<string> hookTypeAttributeTags = null, IList<string> methodScopeAttributeTags = null,
+        public void AddHookBinding(string eventType, string name, string code = "", bool? asyncHook = null, int? order = null, IList<string> hookTypeAttributeTags = null, IList<string> methodScopeAttributeTags = null,
             IList<string> classScopeAttributeTags = null)
         {
             EnsureProjectExists();
 
             var bindingsGenerator = _bindingsGeneratorFactory.FromLanguage(_project.ProgrammingLanguage);
-            _project.AddFile(bindingsGenerator.GenerateHookBinding(eventType, name, code, order, hookTypeAttributeTags, methodScopeAttributeTags, classScopeAttributeTags));
+            _project.AddFile(bindingsGenerator.GenerateHookBinding(eventType, name, code, asyncHook, order, hookTypeAttributeTags, methodScopeAttributeTags, classScopeAttributeTags));
         }
 
         public void AddStepBinding(string bindingCode)


### PR DESCRIPTION
### 🤔 What's changed?

Changed XUnit test run hook infrastructure to wait for async hooks

### ⚡️ What's your motivation? 

Fixes #530 

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

How could this issue exist for 3 years (introduced in SpecFlow in 2022)?

### 📋 Checklist:

- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] Users should know about my change
  - [x] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
