### PR TITLE
Fix: AfterFeature is called as many times as there are scenarios that throw an exception in AfterScenario

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Bug fixes:
 
 * Fix: xUnit async `[AfterTestRun]` hook might not execute fully (#530)
+* Fix: Scenario finished event is not published when the `[AfterScenario]` hook fails (#560)
 
 *Contributors of this release (in alphabetical order): @gasparnagy* 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 ## Bug fixes:
 
 * Fix: xUnit async `[AfterTestRun]` hook might not execute fully (#530)
-* Fix: Scenario finished event is not published when the `[AfterScenario]` hook fails (#560)
+* Fix: Scenario, feature and test run finished event is not published when the related "after" hook fails (#560)
+* Fix: Scenario, feature and test run finished event is not published when the related "after" hook fails (#560)
 
 *Contributors of this release (in alphabetical order): @gasparnagy* 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@
 
 * Fix: xUnit async `[AfterTestRun]` hook might not execute fully (#530)
 * Fix: Scenario, feature and test run finished event is not published when the related "after" hook fails (#560)
-* Fix: Scenario, feature and test run finished event is not published when the related "after" hook fails (#560)
+* Fix: Inconsistent hook execution (duble execution, before/after hook skipped, infrastructure errors) when before or after hooks fail (#526)
 
-*Contributors of this release (in alphabetical order): @gasparnagy* 
+*Contributors of this release (in alphabetical order): @clrudolphi, @gasparnagy* 
 
 # v2.4.0 - 2025-03-06
 

--- a/Plugins/Reqnroll.SpecFlowCompatibility.ReqnrollPlugin/Wrappers/FeatureContext.cs
+++ b/Plugins/Reqnroll.SpecFlowCompatibility.ReqnrollPlugin/Wrappers/FeatureContext.cs
@@ -20,4 +20,8 @@ public class FeatureContext(Reqnroll.FeatureContext originalContext) : IFeatureC
     public CultureInfo BindingCulture => originalContext.BindingCulture;
 
     public IObjectContainer FeatureContainer => originalContext.FeatureContainer;
+
+    public Exception BeforeFeatureHookError => originalContext.BeforeFeatureHookError;
+
+    public bool BeforeFeatureHookFailed => originalContext.BeforeFeatureHookFailed;
 }

--- a/Reqnroll.Generator/Generation/UnitTestFeatureGenerator.cs
+++ b/Reqnroll.Generator/Generation/UnitTestFeatureGenerator.cs
@@ -254,8 +254,10 @@ namespace Reqnroll.Generator.Generation
             _codeDomHelper.MarkCodeMethodInvokeExpressionAsAwait(onFeatureEndAsyncExpression);
 
             // VB does not allow the use of the await keyword in a "finally" clause. Therefore, we have to generate code specific to
-            // the language. The C# code will await OnFeatureStartAsync() while VB will call is sync and assign a variable to the resulting Task.
+            // the language. The C# code will await OnFeatureStartAsync() while VB will call the method synchronously and store the returned Task in a variable.
             // The VB code will then call await on that task after the conclusion of the try/finally block.
+            // This construct in VB might not fully wait for a real async execution of a before feature hook in case there was an exception in the previous after feature hook,
+            // but this affects only very specific and rare cases and only apply for legacy VB usages.
 
             // Dim onFeatureStartTask as Task = Nothing
             if (_codeDomHelper.TargetLanguage == CodeDomProviderLanguage.VB)

--- a/Reqnroll.Generator/Generation/UnitTestFeatureGenerator.cs
+++ b/Reqnroll.Generator/Generation/UnitTestFeatureGenerator.cs
@@ -253,7 +253,7 @@ namespace Reqnroll.Generator.Generation
                 nameof(ITestRunner.OnFeatureEndAsync));
             _codeDomHelper.MarkCodeMethodInvokeExpressionAsAwait(onFeatureEndAsyncExpression);
 
-            // VB does not allow the use of the await keyword in a finally clause. Therefore we have to generate code specific to
+            // VB does not allow the use of the await keyword in a "finally" clause. Therefore, we have to generate code specific to
             // the language. The C# code will await OnFeatureStartAsync() while VB will call is sync and assign a variable to the resulting Task.
             // The VB code will then call await on that task after the conclusion of the try/finally block.
 
@@ -263,8 +263,9 @@ namespace Reqnroll.Generator.Generation
                 testInitializeMethod.Statements.Add(new CodeVariableDeclarationStatement(new CodeTypeReference(typeof(Task)), "onFeatureStartTask", new CodePrimitiveExpression(null)));
             }
             // try {
-            //if (testRunner.FeatureContext != null && !testRunner.FeatureContext.FeatureInfo.Equals(featureInfo))
-            //  await testRunner.OnFeatureEndAsync(); // finish if different
+            //   if (testRunner.FeatureContext != null && !testRunner.FeatureContext.FeatureInfo.Equals(featureInfo))
+            //     await testRunner.OnFeatureEndAsync(); // finish if different
+            // } 
             var conditionallyExecuteOnFeatureEndExpressionStatement =
                 new CodeConditionStatement(
                     new CodeBinaryOperatorExpression(
@@ -284,15 +285,13 @@ namespace Reqnroll.Generator.Generation
                             new CodePrimitiveExpression(false))),
                     new CodeExpressionStatement(
                         onFeatureEndAsyncExpression));
-            // } 
 
-            // Will Generate this for C#:
-            // "Start" the feature if needed
+            // Will generate this for C#:
             // finally {
-            //  if (testRunner.FeatureContext == null) {
-            //      await testRunner.OnFeatureStartAsync(featureInfo);
-            //  }
-            //}
+            //   if (testRunner.FeatureContext == null) { // "Start" the feature if needed
+            //     await testRunner.OnFeatureStartAsync(featureInfo);
+            //   }
+            // }
             CodeStatement onFeatureStartExpression;
             var featureStartMethodInvocation = new CodeMethodInvokeExpression(
                     testRunnerField,
@@ -307,12 +306,12 @@ namespace Reqnroll.Generator.Generation
             // will generate this for VB:
             // Finally
             //   If testRunner.FeatureContext Is Nothing Then
-            //      onFeatureStartTask = testRunner.OnFeatureStartAsync(featureInfo)
+            //     onFeatureStartTask = testRunner.OnFeatureStartAsync(featureInfo)
             //   EndIf
-            //  EndTry
-            //  If onFeatureStartTask IsNot Nothing Then
-            //     Await onFeatureStartTask
-            //  EndIf
+            // EndTry
+            // If onFeatureStartTask IsNot Nothing Then
+            //   Await onFeatureStartTask
+            // EndIf
             {
                 onFeatureStartExpression = new CodeAssignStatement(
                     new CodeVariableReferenceExpression("onFeatureStartTask"),

--- a/Reqnroll/FeatureContext.cs
+++ b/Reqnroll/FeatureContext.cs
@@ -14,6 +14,9 @@ namespace Reqnroll
         CultureInfo BindingCulture { get; }
 
         IObjectContainer FeatureContainer { get; }
+
+        Exception BeforeFeatureHookError { get; }
+        bool BeforeFeatureHookFailed { get; }
     }
 
     public class FeatureContext : ReqnrollContext, IFeatureContext
@@ -66,5 +69,9 @@ namespace Reqnroll
         public CultureInfo BindingCulture { get; }
         public IObjectContainer FeatureContainer { get; }
         internal Stopwatch Stopwatch { get; }
+
+        // these properties are used by the generated code to skip scenario execution of features with a failing before feature hook
+        public Exception BeforeFeatureHookError { get; internal set; }
+        public bool BeforeFeatureHookFailed => BeforeFeatureHookError != null;
     }
 }

--- a/Reqnroll/Infrastructure/TestExecutionEngine.cs
+++ b/Reqnroll/Infrastructure/TestExecutionEngine.cs
@@ -154,7 +154,16 @@ namespace Reqnroll.Infrastructure
 
             // The 'FireEventsAsync' call might throw an exception if the related before feature hook fails,
             // but we can let the exception propagate to the caller.
-            await FireEventsAsync(HookType.BeforeFeature);
+            try
+            {
+                await FireEventsAsync(HookType.BeforeFeature);
+            }
+            catch (Exception e)
+            {
+                // we capture the exception here to be able to skip subsequent scenario execution in the same feature
+                _contextManager.FeatureContext.BeforeFeatureHookError = e;
+                throw;
+            }
         }
 
         public virtual async Task OnFeatureEndAsync()

--- a/Reqnroll/Infrastructure/TestExecutionEngine.cs
+++ b/Reqnroll/Infrastructure/TestExecutionEngine.cs
@@ -239,9 +239,15 @@ namespace Reqnroll.Infrastructure
 
         public virtual async Task OnScenarioEndAsync()
         {
+            // We invoke the before/after feature hooks from test setup, but we initialize the scenario context in the test method.
+            // In case the feature hooks fail, the runner will not run the test method, but the test teardown method will be called.
+            // In this case we don't have an initialized scenario context, so we don't need to call the after scenario hooks.
+            if (_contextManager.ScenarioContext == null)
+                return;
+
             try
             {
-                if (_contextManager.ScenarioContext?.ScenarioExecutionStatus != ScenarioExecutionStatus.Skipped)
+                if (_contextManager.ScenarioContext.ScenarioExecutionStatus != ScenarioExecutionStatus.Skipped)
                 {
                     await FireScenarioEventsAsync(HookType.AfterScenario);
                 }
@@ -394,7 +400,7 @@ namespace Reqnroll.Infrastructure
                     currentContainer = FeatureContext.FeatureContainer;
                     break;
                 default: // scenario scoped hooks
-                    currentContainer = ScenarioContext?.ScenarioContainer;
+                    currentContainer = ScenarioContext.ScenarioContainer;
                     break;
             }
 

--- a/Reqnroll/Infrastructure/TestExecutionEngine.cs
+++ b/Reqnroll/Infrastructure/TestExecutionEngine.cs
@@ -241,7 +241,7 @@ namespace Reqnroll.Infrastructure
         {
             try
             {
-                if (_contextManager.ScenarioContext.ScenarioExecutionStatus != ScenarioExecutionStatus.Skipped)
+                if (_contextManager.ScenarioContext?.ScenarioExecutionStatus != ScenarioExecutionStatus.Skipped)
                 {
                     await FireScenarioEventsAsync(HookType.AfterScenario);
                 }
@@ -394,7 +394,7 @@ namespace Reqnroll.Infrastructure
                     currentContainer = FeatureContext.FeatureContainer;
                     break;
                 default: // scenario scoped hooks
-                    currentContainer = ScenarioContext.ScenarioContainer;
+                    currentContainer = ScenarioContext?.ScenarioContainer;
                     break;
             }
 

--- a/Reqnroll/Infrastructure/TestExecutionEngine.cs
+++ b/Reqnroll/Infrastructure/TestExecutionEngine.cs
@@ -231,10 +231,10 @@ namespace Reqnroll.Infrastructure
                 {
                     await FireScenarioEventsAsync(HookType.AfterScenario);
                 }
-                _testThreadExecutionEventPublisher.PublishEvent(new ScenarioFinishedEvent(FeatureContext, ScenarioContext));
             }
             finally
             {
+                _testThreadExecutionEventPublisher.PublishEvent(new ScenarioFinishedEvent(FeatureContext, ScenarioContext));
                 _contextManager.CleanupScenarioContext();
             }
         }

--- a/Tests/Reqnroll.RuntimeTests/Infrastructure/TestExecutionEngineTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/Infrastructure/TestExecutionEngineTests.cs
@@ -366,31 +366,89 @@ namespace Reqnroll.RuntimeTests.Infrastructure
         }
 
         [Fact]
-        public async Task Should_cleanup_step_context_after_scenario_block_hook_error()
+        public async Task Should_cleanup_step_context_when_before_scenario_block_hook_error()
         {
             var testExecutionEngine = CreateTestExecutionEngine();
             RegisterStepDefinition();
 
             var hookMock = CreateHookMock(beforeScenarioBlockEvents);
             methodBindingInvokerMock.Setup(i => i.InvokeBindingAsync(hookMock.Object, contextManagerStub.Object, null, testTracerStub.Object, It.IsAny<DurationHolder>()))
-                .Throws(new Exception("simulated error"));
+                .Throws(new Exception("simulated before block hook error"));
 
-            try
-            {
-                await testExecutionEngine.StepAsync(StepDefinitionKeyword.Given, null, "foo", null, null);
-
-                Assert.Fail("execution of the step should have failed because of the exeption thrown by the before scenario block hook");
-            }
-            catch (Exception)
-            {
-            }
+            await FluentActions.Awaiting(() => testExecutionEngine.StepAsync(StepDefinitionKeyword.Given, null, "foo", null, null))
+                               .Should().ThrowAsync<Exception>("execution of the step should have failed because of the exception thrown by the before scenario block hook");
 
             methodBindingInvokerMock.Verify(i => i.InvokeBindingAsync(hookMock.Object, contextManagerStub.Object, null, testTracerStub.Object, It.IsAny<DurationHolder>()), Times.Once());
             contextManagerStub.Verify(cm => cm.CleanupStepContext());
+
+            contextManagerStub.Object.ScenarioContext.ScenarioExecutionStatus.Should().Be(ScenarioExecutionStatus.TestError);
+            contextManagerStub.Object.ScenarioContext.TestError?.Message.Should().Be("simulated before block hook error");
         }
 
         [Fact]
-        public async Task Should_not_execute_afterstep_when_step_is_undefined()
+        public async Task Should_cleanup_step_context_when_after_scenario_block_hook_error()
+        {
+            var testExecutionEngine = CreateTestExecutionEngine();
+            RegisterStepDefinition();
+
+            var hookMock = CreateHookMock(afterScenarioBlockEvents);
+            methodBindingInvokerMock.Setup(i => i.InvokeBindingAsync(hookMock.Object, contextManagerStub.Object, null, testTracerStub.Object, It.IsAny<DurationHolder>()))
+                .Throws(new Exception("simulated after block hook error"));
+
+            await testExecutionEngine.StepAsync(StepDefinitionKeyword.Given, null, "foo", null, null);
+            await FluentActions.Awaiting(() => testExecutionEngine.StepAsync(StepDefinitionKeyword.When, null, "bar", null, null))
+                               .Should().ThrowAsync<Exception>("execution of the step should have failed because of the exception thrown by the before scenario block hook");
+
+            methodBindingInvokerMock.Verify(i => i.InvokeBindingAsync(hookMock.Object, contextManagerStub.Object, null, testTracerStub.Object, It.IsAny<DurationHolder>()), Times.Once());
+            contextManagerStub.Verify(cm => cm.CleanupStepContext());
+
+            contextManagerStub.Object.ScenarioContext.ScenarioExecutionStatus.Should().Be(ScenarioExecutionStatus.TestError);
+            contextManagerStub.Object.ScenarioContext.TestError?.Message.Should().Be("simulated after block hook error");
+        }
+
+        [Fact]
+        public async Task Should_cleanup_step_context_when_before_step_hook_error()
+        {
+            var testExecutionEngine = CreateTestExecutionEngine();
+            RegisterStepDefinition();
+
+            var hookMock = CreateHookMock(beforeStepEvents);
+            methodBindingInvokerMock.Setup(i => i.InvokeBindingAsync(hookMock.Object, contextManagerStub.Object, null, testTracerStub.Object, It.IsAny<DurationHolder>()))
+                .Throws(new Exception("simulated before step hook error"));
+
+            reqnrollConfiguration.StopAtFirstError = true;
+            await FluentActions.Awaiting(() => testExecutionEngine.StepAsync(StepDefinitionKeyword.Given, null, "foo", null, null))
+                               .Should().ThrowAsync<Exception>("execution of the step should have failed because of the exception thrown by the before scenario block hook");
+
+            methodBindingInvokerMock.Verify(i => i.InvokeBindingAsync(hookMock.Object, contextManagerStub.Object, null, testTracerStub.Object, It.IsAny<DurationHolder>()), Times.Once());
+            contextManagerStub.Verify(cm => cm.CleanupStepContext());
+
+            contextManagerStub.Object.ScenarioContext.ScenarioExecutionStatus.Should().Be(ScenarioExecutionStatus.TestError);
+            contextManagerStub.Object.ScenarioContext.TestError?.Message.Should().Be("simulated before step hook error");
+        }
+
+        [Fact]
+        public async Task Should_cleanup_step_context_when_after_step_hook_error()
+        {
+            var testExecutionEngine = CreateTestExecutionEngine();
+            RegisterStepDefinition();
+
+            var hookMock = CreateHookMock(afterStepEvents);
+            methodBindingInvokerMock.Setup(i => i.InvokeBindingAsync(hookMock.Object, contextManagerStub.Object, null, testTracerStub.Object, It.IsAny<DurationHolder>()))
+                .Throws(new Exception("simulated after step hook error"));
+
+            await FluentActions.Awaiting(() => testExecutionEngine.StepAsync(StepDefinitionKeyword.Given, null, "foo", null, null))
+                               .Should().ThrowAsync<Exception>("execution of the step should have failed because of the exception thrown by the before scenario block hook");
+
+            methodBindingInvokerMock.Verify(i => i.InvokeBindingAsync(hookMock.Object, contextManagerStub.Object, null, testTracerStub.Object, It.IsAny<DurationHolder>()), Times.Once());
+            contextManagerStub.Verify(cm => cm.CleanupStepContext());
+
+            contextManagerStub.Object.ScenarioContext.ScenarioExecutionStatus.Should().Be(ScenarioExecutionStatus.TestError);
+            contextManagerStub.Object.ScenarioContext.TestError?.Message.Should().Be("simulated after step hook error");
+        }
+
+        [Fact]
+        public async Task Should_not_execute_after_step_when_step_is_undefined()
         {
             var testExecutionEngine = CreateTestExecutionEngine();
             RegisterUndefinedStepDefinition();

--- a/Tests/Reqnroll.RuntimeTests/Infrastructure/TestThreadExecutionEventPublisherTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/Infrastructure/TestThreadExecutionEventPublisherTests.cs
@@ -248,7 +248,7 @@ namespace Reqnroll.RuntimeTests.Infrastructure
         }
 
         [Fact]
-        public async Task Should_publish_testrun_started_event()
+        public async Task Should_publish_test_run_started_event()
         {
             var testExecutionEngine = CreateTestExecutionEngine();
 
@@ -259,7 +259,7 @@ namespace Reqnroll.RuntimeTests.Infrastructure
         }
 
         [Fact]
-        public async Task Should_publish_testrun_finished_event()
+        public async Task Should_publish_test_run_finished_event()
         {
             var testExecutionEngine = CreateTestExecutionEngine();
 

--- a/Tests/Reqnroll.SystemTests/Generation/GenerationTestBase.cs
+++ b/Tests/Reqnroll.SystemTests/Generation/GenerationTestBase.cs
@@ -523,6 +523,9 @@ public abstract class GenerationTestBase : SystemTestBase
         hookLines.Should().HaveElementAt(0, "-> hook: BeforeTestRun", "The BeforeTestRun hook should be the first");
         hookLines.Should().HaveElementAt(hookLines.Count-1, "-> hook: AfterTestRun", "The AfterTestRun hook should be the last");
 
+        // -> hook: Feature 2/Passing scenario 2:BeforeScenario
+        hookLines.Should().NotContainMatch("-> hook: Feature 1/* scenario 1:*Scenario", "Scenarios of features with a failing before feature hook should not be executed.");
+
         _vsTestExecutionDriver.LastTestExecutionResult.Output.Should().NotContain("NullReferenceException");
         _vsTestExecutionDriver.LastTestExecutionResult.Output.Should().NotContain("The previous ScenarioContext was already disposed.");
     }

--- a/Tests/Reqnroll.SystemTests/Generation/GenerationTestBase.cs
+++ b/Tests/Reqnroll.SystemTests/Generation/GenerationTestBase.cs
@@ -5,7 +5,6 @@ using FluentAssertions;
 using System.Text.Json;
 using System.Collections.Generic;
 using Reqnroll.TestProjectGenerator;
-using Reqnroll.TestProjectGenerator.Driver;
 
 namespace Reqnroll.SystemTests.Generation;
 

--- a/Tests/Reqnroll.SystemTests/Generation/GenerationTestBase.cs
+++ b/Tests/Reqnroll.SystemTests/Generation/GenerationTestBase.cs
@@ -505,7 +505,7 @@ public abstract class GenerationTestBase : SystemTestBase
         }
         hookLines.Should().OnlyHaveUniqueItems();
         hookLines.Should().HaveElementAt(0, "-> hook: BeforeTestRun", "The BeforeTestRun hook should be the first");
-        hookLines.Should().HaveElementAt(-1, "-> hook: AfterTestRun", "The AfterTestRun hook should be the last");
+        hookLines.Should().HaveElementAt(hookLines.Count-1, "-> hook: AfterTestRun", "The AfterTestRun hook should be the last");
 
         _vsTestExecutionDriver.LastTestExecutionResult.Output.Should().NotContain("NullReferenceException");
         _vsTestExecutionDriver.LastTestExecutionResult.Output.Should().NotContain("The previous ScenarioContext was already disposed.");

--- a/Tests/Reqnroll.SystemTests/Generation/GenerationTestBase.cs
+++ b/Tests/Reqnroll.SystemTests/Generation/GenerationTestBase.cs
@@ -503,12 +503,12 @@ public abstract class GenerationTestBase : SystemTestBase
 
         ExecuteTests();
 
-        var parallelLogs = _bindingDriver.GetActualLogLines("parallel").ToList();
-        parallelLogs.Should().NotBeEmpty("the scenarios should have parallel logs");
-        //parallelLogs.Should().AllSatisfy(log => log.Should().StartWith("-> parallel: False"));
-
         var hookLines = _bindingDriver.GetActualHookLines().ToList();
         TestContext.WriteLine(string.Join(Environment.NewLine, hookLines.Select((l,i) => $"#{i}: {l}")));
+
+        var parallelLogs = _bindingDriver.GetActualLogLines("parallel").ToList();
+        parallelLogs.Should().NotBeEmpty("the scenarios should have parallel logs");
+        parallelLogs.Should().AllSatisfy(log => log.Should().StartWith("-> parallel: False"));
 
         var featureOrAboveHookLines = hookLines.Where(l => l.Contains("BeforeFeature") || l.Contains("AfterFeature") || l.Contains("BeforeTestRun") || l.Contains("AfterTestRun")).ToList();
         for (int i = 1; i <= 3; i++)

--- a/Tests/Reqnroll.SystemTests/SystemTestBase.cs
+++ b/Tests/Reqnroll.SystemTests/SystemTestBase.cs
@@ -258,9 +258,9 @@ public abstract class SystemTestBase
         return expectedNrOfTests;
     }
 
-    protected void AddHookBinding(string eventType, string? name = null, string code = "", bool? asyncHook = null)
+    protected void AddHookBinding(string eventType, string? name = null, string code = "", bool? asyncHook = null, int? order = null)
     {
-        _projectsDriver.AddHookBinding(eventType, name, code: code, asyncHook: asyncHook);
+        _projectsDriver.AddHookBinding(eventType, name, code: code, asyncHook: asyncHook, order: order);
     }
 
     protected void AddPassingStepBinding(string scenarioBlock = "StepDefinition", string stepRegex = ".*")

--- a/Tests/Reqnroll.SystemTests/SystemTestBase.cs
+++ b/Tests/Reqnroll.SystemTests/SystemTestBase.cs
@@ -247,7 +247,7 @@ public abstract class SystemTestBase
         _vsTestExecutionDriver.LastTestExecutionResult.Warnings.Should().BeEmpty();
     }
 
-    protected int ConfirmAllTestsRan(int? expectedNrOfTestsSpec)
+    protected int ConfirmAllTestsRan(int? expectedNrOfTestsSpec = null)
     {
         if (expectedNrOfTestsSpec == null && _preparedTests == 0)
             throw new ArgumentException($"If {nameof(_preparedTests)} is not set, the {nameof(expectedNrOfTestsSpec)} is mandatory.", nameof(expectedNrOfTestsSpec));

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Driver/BindingsDriver.cs
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Driver/BindingsDriver.cs
@@ -105,7 +105,7 @@ namespace Reqnroll.TestProjectGenerator.Driver
             regex.Matches(content).Count.Should().NotBe(timesExecuted);
         }
 
-        private IEnumerable<string> GetActualHookLines() => GetActualLogLines("hook");
+        public IEnumerable<string> GetActualHookLines() => GetActualLogLines("hook");
 
         public void AssertHooksExecutedInOrder(params string[] methodNames)
         {

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Helpers/FolderCleaner.cs
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Helpers/FolderCleaner.cs
@@ -6,7 +6,7 @@ namespace Reqnroll.TestProjectGenerator.Helpers;
 public class FolderCleaner
 {
     private const int MaxTestRunAgeMinutes = 60;
-    private const int MaxTestRunsToKeep = 10;
+    private const int MaxTestRunsToKeep = 2*8; // allow safely running tests with 8 test processes
 
     private static int _oldFoldersCleaned = 0;
     private readonly Folders _folders;


### PR DESCRIPTION
### 🤔 What's changed?

Made sure that every relevant code after a hook call is in a finally block or somehow else ensured that it runs even in a case of a hook error.

### ⚡️ What's your motivation? 

Fixes #526 

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

This issue was introduced in v2.2.0 with support scenario-level (method-level) parallel execution (#119, #277).

### 📋 Checklist:

- [ ] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] Users should know about my change
  - [ ] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
