### PR TITLE
docs(installation/Rider): adding file type association optional step

### DIFF
--- a/docs/installation/setup-ide.md
+++ b/docs/installation/setup-ide.md
@@ -89,6 +89,9 @@ The *Reqnroll with Rider* extension cannot work together with the *SpecFlow for 
     </ItemGroup>
     ```
    - This is a work around for a known issue found here [Content Include .feature files in .csproj](https://github.com/reqnroll/Reqnroll.Rider/issues/1)  
-  
 6. Restart Rider.
-
+7. *(optional)*: If your `.feature` files aren't recognized by the plugin:
+    - Right click on a `.feature` file in the explorer then `Associate with File Type...`
+    - Make sure `Open matching files in JetBrains Rider` is selected
+    - Select `Reqnroll file` in the list and click `OK`
+    - This will add a new File name pattern under `Settings -> Editor -> File Types -> Reqnroll file`


### PR DESCRIPTION
### 🤔 What's changed?

Adding an optional step under `Installation -> Setup IDE -> Setup Rider` in case feature files aren't recognized by the plugin

(https://docs.reqnroll.net/latest/installation/setup-ide.html#setup-rider)

### ⚡️ What's your motivation? 

Fixes reqnroll/Reqnroll.Rider#45

I had this issue for quite a while now, I did try to manually create a file type association under `Settings -> Editor -> File Types` in the past but some some reasons it never worked. Maybe I did something wrong or maybe an issue has been fixed in a new Reqnroll or Rider version. I have no idea.

Anyway, I just discovered the Right click -> `Associate with File Type...` in Rider (never noticed it before) and it fixes my issue.
So I thought adding it to the documentation could benefit others.

### 🏷️ What kind of change is this?

- :book: Documentation (improvements without changing code)

### ♻️ Anything particular you want feedback on?

Not sure why I got this issue in my IDE. Seems like I was the only one
Maybe an extra verification that the `.feature` file name pattern is associated to `Reqnroll file` could be added during the plugin installation?
