### PR TITLE
Update doc MSTest regarding generator/tags on examples

### DIFF
--- a/docs/integrations/mstest.md
+++ b/docs/integrations/mstest.md
@@ -72,6 +72,37 @@ public class Hooks
 }
 ```
 
+## Tags on Examples Workaround
+The MsTest Generator has an open issue regarding Tags on Examples, see ['issues/4089']( https://github.com/microsoft/testfx/issues/4089) and ['issues/1043'](https://github.com/microsoft/testfx/issues/1043#issuecomment-1942279024)
+
+In short, tags on Examples are *not* send to the test execution. So @Test and @Acceptance are not available for test filtering/reporting/etc.
+``` gherkin
+Scenario: Sample Scenario  
+   Given sample step
+
+[@Test]
+Examples:  
+| User   |  
+| Tester |
+
+[@Acceptance]
+Examples:  
+| User   |  
+| Acc    |
+```
+
+The workaround for now is to add the **generator** to the reqnroll.json. Note that this does impact how tests are shown and named in the Test Explorer:
+``` json
+    {
+      "$schema": "https://schemas.reqnroll.net/reqnroll-config-latest.json",
+      "generator": {"allowRowTests" :  false},
+    
+      "bindingAssemblies": [
+      ]
+    }
+```
+
+
 ## Tags for TestClass Attributes
 
 The MsTest Generator can generate test class attributes from tags specified on a **feature**.

--- a/docs/integrations/mstest.md
+++ b/docs/integrations/mstest.md
@@ -73,9 +73,9 @@ public class Hooks
 ```
 
 ## Tags on Examples - Workaround
-The MsTest Generator MsTest does not support applying tags (categories) to specific entries of parameterized tests, see ['issues/4089']( https://github.com/microsoft/testfx/issues/4089) and ['issues/1043'](https://github.com/microsoft/testfx/issues/1043#issuecomment-1942279024)
+The MsTest Generator MsTest does not support applying tags (categories) to specific entries of parameterized tests, see [issues 4089]( https://github.com/microsoft/testfx/issues/4089) and [issues 1043](https://github.com/microsoft/testfx/issues/1043#issuecomment-1942279024)
 
-In short, tags on Examples are *not* send to the test execution. So @Test and @Acceptance are not available for test filtering/reporting/etc.
+In short, tags on Examples are *not* send to the test execution. So `@Test` and `@Acceptance` are not available for test filtering/reporting/etc.
 ``` gherkin
 Scenario: Sample Scenario  
    Given sample step
@@ -91,7 +91,7 @@ Examples:
 | Acc    |
 ```
 
-The workaround for now is to disable the "row tests". Note that this does impact how tests names are displayed:
+The workaround for now is to disable the _row tests_. Note that this does impact how tests names are displayed:
 ``` json
 {
   "$schema": "https://schemas.reqnroll.net/reqnroll-config-latest.json",

--- a/docs/integrations/mstest.md
+++ b/docs/integrations/mstest.md
@@ -72,34 +72,35 @@ public class Hooks
 }
 ```
 
-## Tags on Examples Workaround
-The MsTest Generator has an open issue regarding Tags on Examples, see ['issues/4089']( https://github.com/microsoft/testfx/issues/4089) and ['issues/1043'](https://github.com/microsoft/testfx/issues/1043#issuecomment-1942279024)
+## Tags on Examples - Workaround
+The MsTest Generator MsTest does not support applying tags (categories) to specific entries of parameterized tests, see ['issues/4089']( https://github.com/microsoft/testfx/issues/4089) and ['issues/1043'](https://github.com/microsoft/testfx/issues/1043#issuecomment-1942279024)
 
 In short, tags on Examples are *not* send to the test execution. So @Test and @Acceptance are not available for test filtering/reporting/etc.
 ``` gherkin
 Scenario: Sample Scenario  
    Given sample step
 
-[@Test]
+@Test
 Examples:  
 | User   |  
 | Tester |
 
-[@Acceptance]
+@Acceptance
 Examples:  
 | User   |  
 | Acc    |
 ```
 
-The workaround for now is to add the **generator** to the reqnroll.json. Note that this does impact how tests are shown and named in the Test Explorer:
+The workaround for now is to disable the "row tests". Note that this does impact how tests names are displayed:
 ``` json
-    {
-      "$schema": "https://schemas.reqnroll.net/reqnroll-config-latest.json",
-      "generator": {"allowRowTests" :  false},
-    
-      "bindingAssemblies": [
-      ]
-    }
+{
+  "$schema": "https://schemas.reqnroll.net/reqnroll-config-latest.json",
+  // add the line below
+  "generator": {"allowRowTests" :  false},
+
+  "bindingAssemblies": [
+  ]
+}
 ```
 
 


### PR DESCRIPTION
### 🤔 What's changed?

Documentation update regadering MSTest.
Add "generator": {"allowRowTests" :  false} to the documentation for MSTest users as a workaround for Examples: not passing on tags.

### ⚡️ What's your motivation? 

Fixes #342 

### 🏷️ What kind of change is this?

- :book: Documentation (improvements without changing code)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:
*no code changed, just docs*

----