### PR TITLE
Guard when calling AfterScenario when TestRunner is already released

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@
 * Fix: xUnit async `[AfterTestRun]` hook might not execute fully (#530)
 * Fix: Scenario, feature and test run finished event is not published when the related "after" hook fails (#560)
 * Fix: Inconsistent hook execution (duble execution, before/after hook skipped, infrastructure errors) when before or after hooks fail (#526)
+* Fix: Guard when calling AfterScenario when TestRunner is already released (#387)
 
-*Contributors of this release (in alphabetical order): @clrudolphi, @gasparnagy* 
+*Contributors of this release (in alphabetical order): @clrudolphi, @gasparnagy, @obligaron* 
 
 # v2.4.0 - 2025-03-06
 

--- a/Reqnroll.Generator/Generation/UnitTestFeatureGenerator.cs
+++ b/Reqnroll.Generator/Generation/UnitTestFeatureGenerator.cs
@@ -385,6 +385,19 @@ namespace Reqnroll.Generator.Generation
 
             var testRunnerField = _scenarioPartHelper.GetTestRunnerExpression();
 
+            // Guard when calling AfterScenario when TestRunner is already released (errors or edge cases in a supported test framework)
+            // if ((testRunner == null))
+            // {
+            //     return;
+            // }
+            var testRunnerNotNullGuard =
+                new CodeConditionStatement(new CodeBinaryOperatorExpression(
+                    testRunnerField,
+                    CodeBinaryOperatorType.IdentityEquality,
+                    new CodePrimitiveExpression(null)),
+                    new CodeMethodReturnStatement());
+            testCleanupMethod.Statements.Add(testRunnerNotNullGuard);
+
             //await testRunner.OnScenarioEndAsync();
             var onScenarioEndCallExpression = new CodeMethodInvokeExpression(
                 testRunnerField,
@@ -393,19 +406,23 @@ namespace Reqnroll.Generator.Generation
             var onScenarioEndCallStatement = new CodeExpressionStatement(onScenarioEndCallExpression);
 
             // "Release" the TestRunner, so that other threads can pick it up
-            // TestRunnerManager.ReleaseTestRunner(testRunner);
+            // global::Reqnroll.TestRunnerManager.ReleaseTestRunner(testRunner);
             var releaseTestRunnerCallStatement = new CodeExpressionStatement(
                 new CodeMethodInvokeExpression(
                     new CodeTypeReferenceExpression(new CodeTypeReference(typeof(TestRunnerManager), CodeTypeReferenceOptions.GlobalReference)),
                     nameof(TestRunnerManager.ReleaseTestRunner),
                     testRunnerField));
 
+            // Unassign TestRunner to make sure it won't be reused if the test framework runs AfterScenario multiple times
+            // testRunner = null;
+            var unasignTestRunnerInstance = new CodeAssignStatement(testRunnerField, new CodePrimitiveExpression(null));
+
             // add ReleaseTestRunner to the finally block of OnScenarioEndAsync 
             testCleanupMethod.Statements.Add(
                 new CodeTryCatchFinallyStatement(
                     [onScenarioEndCallStatement],
                     [],
-                    [releaseTestRunnerCallStatement]
+                    [releaseTestRunnerCallStatement, unasignTestRunnerInstance]
                 ));
         }
 


### PR DESCRIPTION
<!---
Thanks for helping to make Reqnroll better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻

You can delete these comment sections as you process them.
-->

### 🤔 What's changed?

<!-- Describe your changes in detail -->

Checks in generated feature files that `testRunner` is not null in after scenario hooks (IAsyncLifetime.DisposeAsync/TearDown/TestCleanup). If the testRunner field is null return without a exception.

### ⚡️ What's your motivation? 

<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->

Hopefully fixes #387

This PR should fix crashes caused by the test framework entering the after scenario hooks multiple times.
If Reqnroll has incorrect TestRunner management, this PR won't fix it.
See also discussion in #550.

Unfortunately, we don't have a sample project that reproduces #387.

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

Is this the right approach?
Should we add some sort of logging for this (not expected) behavior of the test framework?

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] Users should know about my change
  - [x] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
