### PR TITLE
Fix #582 by moving 'using' directives to be generated before the namespace declaration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix: xUnit async `[AfterTestRun]` hook might not execute fully (#530)
 * Fix: Scenario, feature and test run finished event is not published when the related "after" hook fails (#560)
 * Fix: Inconsistent hook execution (duble execution, before/after hook skipped, infrastructure errors) when before or after hooks fail (#526)
+* Fix: Improved test code generation to avoid name collisions with user's Project Name 
 
 *Contributors of this release (in alphabetical order): @clrudolphi, @gasparnagy* 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Fix: xUnit async `[AfterTestRun]` hook might not execute fully (#530)
 * Fix: Scenario, feature and test run finished event is not published when the related "after" hook fails (#560)
 * Fix: Inconsistent hook execution (duble execution, before/after hook skipped, infrastructure errors) when before or after hooks fail (#526)
-* Fix: Improved test code generation to avoid name collisions with user's Project Name 
+* Fix: Improved test code generation to avoid name collisions with user's Project Name (#583)
 
 *Contributors of this release (in alphabetical order): @clrudolphi, @gasparnagy* 
 

--- a/Reqnroll.Generator/Generation/UnitTestFeatureGenerator.cs
+++ b/Reqnroll.Generator/Generation/UnitTestFeatureGenerator.cs
@@ -108,9 +108,6 @@ namespace Reqnroll.Generator.Generation
 
             var codeNamespace = new CodeNamespace(targetNamespace);
 
-            codeNamespace.Imports.Add(new CodeNamespaceImport(GeneratorConstants.REQNROLL_NAMESPACE));
-            codeNamespace.Imports.Add(new CodeNamespaceImport("System"));
-            codeNamespace.Imports.Add(new CodeNamespaceImport("System.Linq"));
             return codeNamespace;
         }
 
@@ -177,7 +174,7 @@ namespace Reqnroll.Generator.Generation
                 new CodeTypeReference(typeof(FeatureInfo), CodeTypeReferenceOptions.GlobalReference), GeneratorConstants.FEATUREINFO_FIELD);
             featureInfoField.Attributes |= MemberAttributes.Static;
             featureInfoField.InitExpression = new CodeObjectCreateExpression(new CodeTypeReference(typeof(FeatureInfo), CodeTypeReferenceOptions.GlobalReference),
-                new CodeObjectCreateExpression(typeof(CultureInfo),
+                new CodeObjectCreateExpression(new CodeTypeReference(typeof(CultureInfo), CodeTypeReferenceOptions.GlobalReference),
                                                new CodePrimitiveExpression(generationContext.Feature.Language)),
                 new CodePrimitiveExpression(generationContext.Document.DocumentLocation?.FeatureFolderPath),
                 new CodePrimitiveExpression(generationContext.Feature.Name),

--- a/Reqnroll.Generator/Generation/UnitTestMethodGenerator.cs
+++ b/Reqnroll.Generator/Generation/UnitTestMethodGenerator.cs
@@ -140,7 +140,7 @@ namespace Reqnroll.Generator.Generation
             var featureTagsExpression = new CodeFieldReferenceExpression(null, GeneratorConstants.FEATURE_TAGS_VARIABLE_NAME);
             if (scenarioDefinitionInFeatureFile.Rule != null && scenarioDefinitionInFeatureFile.Rule.Tags.Any())
             {
-                var tagHelperReference = new CodeTypeReferenceExpression(nameof(TagHelper));
+                var tagHelperReference = new CodeTypeReferenceExpression(new CodeTypeReference(typeof(TagHelper), CodeTypeReferenceOptions.GlobalReference));
                 var ruleTagsExpression = _scenarioPartHelper.GetStringArrayExpression(scenarioDefinitionInFeatureFile.Rule.Tags);
                 inheritedTagsExpression = new CodeMethodInvokeExpression(tagHelperReference, nameof(TagHelper.CombineTags), featureTagsExpression, ruleTagsExpression);
             }
@@ -216,9 +216,9 @@ namespace Reqnroll.Generator.Generation
         private void AddVariableForArguments(CodeMemberMethod testMethod, ParameterSubstitution paramToIdentifier)
         {
             var argumentsExpression = new CodeVariableDeclarationStatement(
-                typeof(OrderedDictionary),
+                new CodeTypeReference(typeof(OrderedDictionary), CodeTypeReferenceOptions.GlobalReference),
                 GeneratorConstants.SCENARIO_ARGUMENTS_VARIABLE_NAME,
-                new CodeObjectCreateExpression(typeof(OrderedDictionary)));
+                new CodeObjectCreateExpression(new CodeTypeReference(typeof(OrderedDictionary), CodeTypeReferenceOptions.GlobalReference)));
 
             testMethod.Statements.Add(argumentsExpression);
 

--- a/Reqnroll.Generator/TestGenerator.cs
+++ b/Reqnroll.Generator/TestGenerator.cs
@@ -98,6 +98,7 @@ namespace Reqnroll.Generator
                                   };
 
                 AddReqnrollHeader(codeProvider, outputWriter);
+                AddFileWideUsingStatements(codeProvider, outputWriter);
                 codeProvider.GenerateCodeFromNamespace(codeNamespace, outputWriter, options);
                 AddReqnrollFooter(codeProvider, outputWriter);
 
@@ -203,6 +204,14 @@ namespace Reqnroll.Generator
                 return path;
 
             return featureFileInput.GetFullPath(projectSettings) + GenerationTargetLanguage.GetExtension(projectSettings.ProjectPlatformSettings.Language);
+        }
+
+        protected void AddFileWideUsingStatements(CodeDomProvider codeProvider,TextWriter outputWriter)
+        {
+            foreach(var statement in codeDomHelper.GetFeatureFilewideUsingStatements())
+            {
+                codeProvider.GenerateCodeFromStatement(statement, outputWriter, null);
+            }
         }
 
         #region Header & Footer


### PR DESCRIPTION
Also made all references to Reqnroll and System types as global:: (there were a few that had been missed earlier).


### 🤔 What's changed?

Modified the code generation such that all references to Reqnroll and System types are now global.
Modified code generation so that the file-wide 'using' statements now appear before the declaration of the namespace for the file. (This addresses the adherence to .NET conventions outlined in #582. )

### ⚡️ What's your motivation? 

Bug fix. Allows user-provided solution names to be used as generated namespace names without collisions with Reqnroll or System types.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

I'm not sure that this works appropriately for VB or F# generation.
### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:


- [X ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [X ] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
