### PR TITLE
MsTest: adds the test method friendly name to the generated TestMethodAttribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # [vNext]
-
+* Improvement: MsTest simple scenarios (not Scenario Outlines) uses the Scenario Name as the friendly name for the test
 ## Improvements:
 
 ## Bug fixes:

--- a/Reqnroll.Generator/UnitTestProvider/MsTestGeneratorProvider.cs
+++ b/Reqnroll.Generator/UnitTestProvider/MsTestGeneratorProvider.cs
@@ -133,7 +133,7 @@ namespace Reqnroll.Generator.UnitTestProvider
 
         public virtual void SetTestMethod(TestClassGenerationContext generationContext, CodeMemberMethod testMethod, string friendlyTestName)
         {
-            CodeDomHelper.AddAttribute(testMethod, TEST_ATTR);
+            CodeDomHelper.AddAttribute(testMethod, TEST_ATTR, friendlyTestName);
             CodeDomHelper.AddAttribute(testMethod, DESCRIPTION_ATTR, friendlyTestName);
 
             //as in mstest, you cannot mark classes with the description attribute, we


### PR DESCRIPTION
... with the result that the friendly name is used by the VS2022 Test Explorer as the name of the test rather than the C# method name.


### 🤔 What's changed?

Changed the MsTestGeneratorProvider SetTestMethod so that the TestMethodAttribute includes the friendly name as the name of the test.

### ⚡️ What's your motivation? 

See thread in #574 

### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)


### 📋 Checklist:


- [X] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [x] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
