### PR TITLE
Improve CI/CD perf and ensure all dotnet versions are tested

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,7 @@ jobs:
 
         # Calculate 'test_params'
         $gitHubActionsLoggerSettings = '"GitHubActions;summary.includePassedTests=true;summary.includeSkippedTests=true;annotations.titleFormat=[@traits.Category] @test;annotations.messageFormat=@error\n@trace"'
-        $testParams = "--no-build --verbosity normal -c $productConfig --logger $gitHubActionsLoggerSettings -- RunConfiguration.CollectSourceInformation=true RunConfiguration.TreatNoTestsAsError=true"
+        $testParams = "--verbosity normal --logger $gitHubActionsLoggerSettings -- RunConfiguration.CollectSourceInformation=true RunConfiguration.TreatNoTestsAsError=true"
         Write-Output "test_params=$testParams" >> $env:GITHUB_OUTPUT
         Write-Output "Test Params: $testParams"
 
@@ -189,6 +189,8 @@ jobs:
         dotnet add ./Tests/Reqnroll.PluginTests/Reqnroll.PluginTests.csproj package GitHubActionsTestLogger
         dotnet add ./Tests/Reqnroll.GeneratorTests/Reqnroll.GeneratorTests.csproj package GitHubActionsTestLogger
         dotnet add ./Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator.Tests/Reqnroll.TestProjectGenerator.Tests.csproj package GitHubActionsTestLogger
+        dotnet add ./Tests/Reqnroll.SystemTests/Reqnroll.SystemTests.csproj package GitHubActionsTestLogger
+        dotnet add ./Tests/Reqnroll.Specs/Reqnroll.Specs.csproj package GitHubActionsTestLogger
     - name: Build
       run: dotnet build --no-restore ${{ steps.build_params.outputs.main_build_params }}
     - name: Runtime Tests
@@ -212,6 +214,18 @@ jobs:
         name: packages-v${{ steps.versions.outputs.product_full_version }}
         if-no-files-found: error
         path: "GeneratedNuGetPackages/${{ steps.versions.outputs.product_configuration }}/*.*nupkg"
+    - name: Upload SystemTests
+      uses: actions/upload-artifact@v4
+      with:
+        name: SystemTests
+        if-no-files-found: error
+        path: Tests/Reqnroll.SystemTests/bin/
+    - name: Upload Specs
+      uses: actions/upload-artifact@v4
+      with:
+        name: Specs
+        if-no-files-found: error
+        path: Tests/Reqnroll.Specs/bin/
 
   specs:
     runs-on: ubuntu-latest
@@ -232,16 +246,19 @@ jobs:
       with:
         path: /tmp/RRC
         key: RRC-Specs-${{ runner.os }}-${{ env.ImageVersion }} # Use the runner version as key, so if new dependencies get installed we get a new cache entry
-    - name: Restore dependencies
-      run: dotnet restore
-    - name: Install Test Report Dependencies
-      run: | 
-        dotnet add ./Tests/Reqnroll.Specs/Reqnroll.Specs.csproj package GitHubActionsTestLogger
-    - name: Build
-      run: dotnet build --no-restore ${{ needs.build.outputs.build_params }}
+    - name: Download packages
+      uses: actions/download-artifact@v4
+      with:
+        name: packages-v${{ needs.build.outputs.product_full_version }}
+        path: GeneratedNuGetPackages/${{ needs.build.outputs.product_configuration }}/
+    - name: Download Specs
+      uses: actions/download-artifact@v4
+      with:
+        name: Specs
+        path: Tests/Reqnroll.Specs/bin/
     - name: Specs
       shell: pwsh
-      run: dotnet test ./Tests/Reqnroll.Specs/Reqnroll.Specs.csproj --filter "Category!=quarantaine{{ needs.build.outputs.specs_filter }}" --logger "trx;LogFileName=${{ github.workspace }}/TestResults/specs-results.trx" ${{ needs.build.outputs.test_params }}
+      run: dotnet test ./Tests/Reqnroll.Specs/bin/${{ needs.build.outputs.product_configuration }}/*/Reqnroll.Specs.dll --filter "Category!=quarantaine{{ needs.build.outputs.specs_filter }}" --logger "trx;LogFileName=${{ github.workspace }}/TestResults/specs-results.trx" ${{ needs.build.outputs.test_params }}
     - name: Upload TRX files
       uses: actions/upload-artifact@v4
       if: always()
@@ -273,20 +290,23 @@ jobs:
       with:
         path: ${{ env.REQNROLL_TEST_TEMPFOLDER }}/RRC
         key: RRC-SystemTests-${{ runner.os }}-${{ env.ImageVersion }} # Use the runner version as key, so if new dependencies get installed we get a new cache entry
+    - name: Download packages
+      uses: actions/download-artifact@v4
+      with:
+        name: packages-v${{ needs.build.outputs.product_full_version }}
+        path: GeneratedNuGetPackages/${{ needs.build.outputs.product_configuration }}/
+    - name: Download SystemTests
+      uses: actions/download-artifact@v4
+      with:
+        name: SystemTests
+        path: Tests/Reqnroll.SystemTests/bin/
     - name: .NET Information
       run: |
         dotnet --list-sdks
         dotnet --list-runtimes
-    - name: Restore dependencies
-      run: dotnet restore
-    - name: Install Test Report Dependencies
-      run: | 
-        dotnet add ./Tests/Reqnroll.SystemTests/Reqnroll.SystemTests.csproj package GitHubActionsTestLogger
-    - name: Build
-      run: dotnet build --no-restore ${{ needs.build.outputs.build_params }}
     - name: System Tests
       shell: pwsh
-      run: dotnet test ./Tests/Reqnroll.SystemTests/Reqnroll.SystemTests.csproj --logger "trx;LogFileName=${{ github.workspace }}/TestResults/systemtests-windows-results.trx" ${{ needs.build.outputs.test_params }} 
+      run: dotnet test ./Tests/Reqnroll.SystemTests/bin/${{ needs.build.outputs.product_configuration }}/*/Reqnroll.SystemTests.dll --logger "trx;LogFileName=${{ github.workspace }}/TestResults/systemtests-windows-results.trx" ${{ needs.build.outputs.test_params }} 
     - name: Upload Test Result TRX Files
       uses: actions/upload-artifact@v4
       if: always()
@@ -315,20 +335,23 @@ jobs:
       with:
         path: /tmp/RRC
         key: RRC-SystemTests-${{ runner.os }}-${{ env.ImageVersion }} # Use the runner version as key, so if new dependencies get installed we get a new cache entry
+    - name: Download packages
+      uses: actions/download-artifact@v4
+      with:
+        name: packages-v${{ needs.build.outputs.product_full_version }}
+        path: GeneratedNuGetPackages/${{ needs.build.outputs.product_configuration }}/
+    - name: Download SystemTests
+      uses: actions/download-artifact@v4
+      with:
+        name: SystemTests
+        path: Tests/Reqnroll.SystemTests/bin/
     - name: .NET Information
       run: |
         dotnet --list-sdks
         dotnet --list-runtimes
-    - name: Restore dependencies
-      run: dotnet restore
-    - name: Install Test Report Dependencies
-      run: | 
-        dotnet add ./Tests/Reqnroll.SystemTests/Reqnroll.SystemTests.csproj package GitHubActionsTestLogger
-    - name: Build
-      run: dotnet build --no-restore ${{ needs.build.outputs.build_params }}
     - name: System Tests
       shell: pwsh
-      run: dotnet test ./Tests/Reqnroll.SystemTests/Reqnroll.SystemTests.csproj --filter "TestCategory!=MsBuild&TestCategory!=Net481" --logger "trx;LogFileName=${{ github.workspace }}/TestResults/systemtests-linux-results.trx"  ${{ needs.build.outputs.test_params }} 
+      run: dotnet test ./Tests/Reqnroll.SystemTests/bin/${{ needs.build.outputs.product_configuration }}/*/Reqnroll.SystemTests.dll --filter "TestCategory!=MsBuild&TestCategory!=Net481" --logger "trx;LogFileName=${{ github.workspace }}/TestResults/systemtests-linux-results.trx"  ${{ needs.build.outputs.test_params }} 
     - name: Upload Test Result TRX Files
       uses: actions/upload-artifact@v4
       if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,6 +292,14 @@ jobs:
       with:
         name: SystemTests
         path: Tests/Reqnroll.SystemTests/bin/
+    - name: Setup dotnet
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: | 
+          6.0.x
+          7.0.x
+          8.0.x
+          9.0.x
     - name: .NET Information
       run: |
         dotnet --list-sdks
@@ -337,13 +345,21 @@ jobs:
       with:
         name: SystemTests
         path: Tests/Reqnroll.SystemTests/bin/
+    - name: Setup dotnet
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: | 
+          6.0.x
+          7.0.x
+          8.0.x
+          9.0.x
     - name: .NET Information
       run: |
         dotnet --list-sdks
         dotnet --list-runtimes
     - name: System Tests
       shell: pwsh
-      run: dotnet test ./Tests/Reqnroll.SystemTests/bin/${{ needs.build.outputs.product_configuration }}/*/Reqnroll.SystemTests.dll --filter "TestCategory!=MsBuild&TestCategory!=Net481" --logger "trx;LogFileName=${{ github.workspace }}/TestResults/systemtests-linux-results.trx"  ${{ needs.build.outputs.test_params }} 
+      run: dotnet test ./Tests/Reqnroll.SystemTests/bin/${{ needs.build.outputs.product_configuration }}/*/Reqnroll.SystemTests.dll --filter "TestCategory!=MsBuild&TestCategory!=NetFramework" --logger "trx;LogFileName=${{ github.workspace }}/TestResults/systemtests-linux-results.trx"  ${{ needs.build.outputs.test_params }} 
     - name: Upload Test Result TRX Files
       uses: actions/upload-artifact@v4
       if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,6 +240,11 @@ jobs:
   system-tests-windows:
     runs-on: windows-latest
     needs: build
+    env:
+      # D:\ (temporary) drive has better performance then C:\ (remote) drive on the Github Runner, so place all temporary files on D:\, see https://github.com/actions/setup-dotnet/issues/260
+      DOTNET_INSTALL_DIR: D:\dotnet
+      REQNROLL_TEST_TEMPFOLDER: D:\testrundata
+      NUGET_PACKAGES: D:\nuget\packages
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,10 @@ jobs:
   specs:
     runs-on: ubuntu-latest
     needs: build
+    env:
+      # Disable telemetry, because we use many small projects
+      DOTNET_CLI_TELEMETRY_OPTOUT: 1
+      REQNROLL_TELEMETRY_ENABLED: 0
 
     steps:
     - uses: actions/checkout@v4
@@ -245,6 +249,9 @@ jobs:
       DOTNET_INSTALL_DIR: D:\dotnet
       REQNROLL_TEST_TEMPFOLDER: D:\testrundata
       NUGET_PACKAGES: D:\nuget\packages
+      # Disable telemetry, because we use many small projects
+      DOTNET_CLI_TELEMETRY_OPTOUT: 1
+      REQNROLL_TELEMETRY_ENABLED: 0
 
     steps:
     - uses: actions/checkout@v4
@@ -274,6 +281,10 @@ jobs:
   system-tests-linux:
     runs-on: ubuntu-latest
     needs: build
+    env:
+      # Disable telemetry, because we use many small projects
+      DOTNET_CLI_TELEMETRY_OPTOUT: 1
+      REQNROLL_TELEMETRY_ENABLED: 0
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,6 +223,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: Set Runner ImageVersion to Env
+      shell: pwsh
+      run: |
+        Write-Output "ImageVersion=$env:ImageVersion" >> $env:GITHUB_ENV
+    - name: Cache RRC folder
+      uses: actions/cache@v4
+      with:
+        path: /tmp/RRC
+        key: RRC-Specs-${{ runner.os }}-${{ env.ImageVersion }} # Use the runner version as key, so if new dependencies get installed we get a new cache entry
     - name: Restore dependencies
       run: dotnet restore
     - name: Install Test Report Dependencies
@@ -255,6 +264,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: Set Runner ImageVersion to Env
+      shell: pwsh
+      run: |
+        Write-Output "ImageVersion=$env:ImageVersion" >> $env:GITHUB_ENV
+    - name: Cache RRC folder
+      uses: actions/cache@v4
+      with:
+        path: ${{ env.REQNROLL_TEST_TEMPFOLDER }}/RRC
+        key: RRC-SystemTests-${{ runner.os }}-${{ env.ImageVersion }} # Use the runner version as key, so if new dependencies get installed we get a new cache entry
     - name: .NET Information
       run: |
         dotnet --list-sdks
@@ -288,6 +306,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: Set Runner ImageVersion to Env
+      shell: pwsh
+      run: |
+        Write-Output "ImageVersion=$env:ImageVersion" >> $env:GITHUB_ENV
+    - name: Cache RRC folder
+      uses: actions/cache@v4
+      with:
+        path: /tmp/RRC
+        key: RRC-SystemTests-${{ runner.os }}-${{ env.ImageVersion }} # Use the runner version as key, so if new dependencies get installed we get a new cache entry
     - name: .NET Information
       run: |
         dotnet --list-sdks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,14 +183,6 @@ jobs:
         [System.IO.File]::WriteAllText("CHANGELOG.md", $content)
     - name: Restore dependencies
       run: dotnet restore
-    - name: Install Test Report Dependencies
-      run: | 
-        dotnet add ./Tests/Reqnroll.RuntimeTests/Reqnroll.RuntimeTests.csproj package GitHubActionsTestLogger
-        dotnet add ./Tests/Reqnroll.PluginTests/Reqnroll.PluginTests.csproj package GitHubActionsTestLogger
-        dotnet add ./Tests/Reqnroll.GeneratorTests/Reqnroll.GeneratorTests.csproj package GitHubActionsTestLogger
-        dotnet add ./Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator.Tests/Reqnroll.TestProjectGenerator.Tests.csproj package GitHubActionsTestLogger
-        dotnet add ./Tests/Reqnroll.SystemTests/Reqnroll.SystemTests.csproj package GitHubActionsTestLogger
-        dotnet add ./Tests/Reqnroll.Specs/Reqnroll.Specs.csproj package GitHubActionsTestLogger
     - name: Build
       run: dotnet build --no-restore ${{ steps.build_params.outputs.main_build_params }}
     - name: Runtime Tests

--- a/Tests/Reqnroll.GeneratorTests/Reqnroll.GeneratorTests.csproj
+++ b/Tests/Reqnroll.GeneratorTests/Reqnroll.GeneratorTests.csproj
@@ -26,6 +26,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" Condition="'$(REQNROLL_TEST_PIPELINEMODE)' == 'true'">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Build.Framework" Version="17.11.4" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.11.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />

--- a/Tests/Reqnroll.PluginTests/Reqnroll.PluginTests.csproj
+++ b/Tests/Reqnroll.PluginTests/Reqnroll.PluginTests.csproj
@@ -22,6 +22,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" Condition="'$(REQNROLL_TEST_PIPELINEMODE)' == 'true'">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Moq" Version="4.20.70" />

--- a/Tests/Reqnroll.RuntimeTests/Reqnroll.RuntimeTests.csproj
+++ b/Tests/Reqnroll.RuntimeTests/Reqnroll.RuntimeTests.csproj
@@ -22,6 +22,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" Condition="'$(REQNROLL_TEST_PIPELINEMODE)' == 'true'">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Moq" Version="4.20.70" />

--- a/Tests/Reqnroll.Specs/Reqnroll.Specs.csproj
+++ b/Tests/Reqnroll.Specs/Reqnroll.Specs.csproj
@@ -38,6 +38,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" Condition="'$(REQNROLL_TEST_PIPELINEMODE)' == 'true'">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="MSBuild.AdditionalTasks" Version="*" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Moq" Version="4.20.72" />

--- a/Tests/Reqnroll.SystemTests/Portability/PortabilityTestBase.cs
+++ b/Tests/Reqnroll.SystemTests/Portability/PortabilityTestBase.cs
@@ -42,6 +42,8 @@ public abstract class PortabilityTestBase : SystemTestBase
         {
             if (!new ConfigurationDriver().PipelineMode)
                 Assert.Inconclusive(ex.ToString());
+            else
+                throw;
         }
     }
 

--- a/Tests/Reqnroll.SystemTests/Reqnroll.SystemTests.csproj
+++ b/Tests/Reqnroll.SystemTests/Reqnroll.SystemTests.csproj
@@ -13,6 +13,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" Condition="'$(REQNROLL_TEST_PIPELINEMODE)' == 'true'">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.5.2" />
     <PackageReference Include="MSTest.TestFramework" Version="3.5.2" />

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator.Tests/Reqnroll.TestProjectGenerator.Tests.csproj
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator.Tests/Reqnroll.TestProjectGenerator.Tests.csproj
@@ -5,6 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" Condition="'$(REQNROLL_TEST_PIPELINEMODE)' == 'true'">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/CacheAndCopyCommandBuilder.cs
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Dotnet/CacheAndCopyCommandBuilder.cs
@@ -35,7 +35,7 @@ public class CacheAndCopyCommandBuilder : CommandBuilder
         }
 
         var sdkSpecifier = _sdk == null ? "" : $"_{_sdk.Version}";
-        return Path.Combine(Path.GetTempPath(), "RRC", $"RRC{sdkSpecifier}_{argsCleaned}{suffix}", directoryName);
+        return Path.Combine(new ConfigurationDriver().TempFolderPath, "RRC", $"RRC{sdkSpecifier}_{argsCleaned}{suffix}", directoryName);
     }
 
     public override CommandResult Execute(Func<Exception, Exception> exceptionFunction)


### PR DESCRIPTION
<!---
Thanks for helping to make Reqnroll better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻

You can delete these comment sections as you process them.
-->

### 🤔 What's changed?

<!-- Describe your changes in detail -->

- RRC cache folder can now also be changed (by changing `REQNROLL_TEST_TEMPFOLDER`)
- Windows: Installed and temporary files are now located on drive D: (test temp folder, dotnet installation, nuget). For background, see https://github.com/actions/setup-dotnet/issues/260
- Opt out of telemetry (Reqnroll and Dotnet) to improve compilation speed (hurts a lot when calling dotnet build etc. for our many generated test projects)
- Cache RRC folder between runs
- For Spec and SystemTest, we reuse the build test assemblies from the "build" job. This avoids recompiling our own nuget and test assemblies (and ensures that we test the nuget packages we have in the artifacts on all platforms).
- Add `GitHubActionsTestLogger` explicitly in csproj (with condition) to improve compilation speed (avoids calling dotnet add package)
- Fix bug where we didn't test all supported dotnet frameworks on CI/CD

### ⚡️ What's your motivation? 

<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->

The CI/CD pipeline takes sometimes more then 15 minutes with this changes the max seen time is around 11 minutes.
The average execution time got down from around 14 min to 10 min.

While investigating the performance of the CI/CD pipeline, I discovered that we don't test all DotNet versions. This didn't show up in the test results because the `DotNetSdkNotInstalledException` was not rethrown (both fixed in last commit).

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

I tried to put each step into its own commit, so that if we want to undo just one optimization, we can easily do so later.
Is this a desirable approach?

With this PR, the performance of the `system-tests-windows' job and the `specs' job are similar. So if we want to further improve CI/CD, we would need to improve both jobs (by splitting them or some other optimization).

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
