### PR TITLE
Fix: Disposed ObjectContainer can be accessed through RegisterInstanceAs/RegisterFactoryAs/RegisterTypeAs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## Bug fixes:
 
 * Fix: Exception in an `AfterFeature` hook causes the next first test failure in the next feature (#597)
+* Fix: Disposed ObjectContainer can be accessed through RegisterInstanceAs/RegisterFactoryAs/RegisterTypeAs
 
 *Contributors of this release (in alphabetical order):* @clrudolphi, @obligaron
 

--- a/Reqnroll/BoDi/ObjectContainer.cs
+++ b/Reqnroll/BoDi/ObjectContainer.cs
@@ -153,8 +153,6 @@ public class ObjectContainer : IObjectContainer
             return result;
         }
 
-
-
         protected override object ResolvePerDependency(ObjectContainer container, RegistrationKey keyToResolve, ResolutionList resolutionPath)
         {
             var typeToConstruct = GetTypeToConstruct(keyToResolve);
@@ -440,6 +438,8 @@ public class ObjectContainer : IObjectContainer
 
     private IStrategyRegistration RegisterTypeAsInternal(Type implementationType, Type interfaceType, string name)
     {
+        AssertNotDisposed();
+
         var registrationKey = new RegistrationKey(interfaceType, name);
         AssertNotResolved(registrationKey);
 
@@ -454,6 +454,9 @@ public class ObjectContainer : IObjectContainer
     {
         if (instance == null)
             throw new ArgumentNullException(nameof(instance));
+
+        AssertNotDisposed();
+
         var registrationKey = new RegistrationKey(interfaceType, name);
         AssertNotResolved(registrationKey);
 
@@ -491,6 +494,8 @@ public class ObjectContainer : IObjectContainer
     {
         if (factoryDelegate == null) throw new ArgumentNullException(nameof(factoryDelegate));
         if (interfaceType == null) throw new ArgumentNullException(nameof(interfaceType));
+
+        AssertNotDisposed();
 
         var registrationKey = new RegistrationKey(interfaceType, name);
         AssertNotResolved(registrationKey);
@@ -741,6 +746,9 @@ public class ObjectContainer : IObjectContainer
 
     public void Dispose()
     {
+        if (_isDisposed)
+            return;
+
         _isDisposed = true;
 
         foreach (var obj in _objectPool.Values.OfType<IDisposable>().Where(o => !ReferenceEquals(o, this)))

--- a/Tests/Reqnroll.RuntimeTests/BoDi/DisposeTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/BoDi/DisposeTests.cs
@@ -16,12 +16,42 @@ namespace Reqnroll.RuntimeTests.BoDi
         }
 
         [Fact]
-        public void ContainerShouldThrowExceptionWhenDisposed()
+        public void ContainerShouldThrowExceptionWhenDisposedAndCallingResolve()
         {
             var container = new ObjectContainer();
             container.Dispose();
 
             Action act = () => container.Resolve<IObjectContainer>();
+            act.Should().ThrowExactly<ObjectContainerException>("Object container disposed");
+        }
+
+        [Fact]
+        public void ContainerShouldThrowExceptionWhenDisposedAndCallingRegisterInstanceAs()
+        {
+            var container = new ObjectContainer();
+            container.Dispose();
+
+            Action act = () => container.RegisterInstanceAs<IDisposableClass>(new DisposableClass1());
+            act.Should().ThrowExactly<ObjectContainerException>("Object container disposed");
+        }
+
+        [Fact]
+        public void ContainerShouldThrowExceptionWhenDisposedAndCallingRegisterFactoryAs()
+        {
+            var container = new ObjectContainer();
+            container.Dispose();
+
+            Action act = () => container.RegisterFactoryAs<IDisposableClass>(() => new DisposableClass1());
+            act.Should().ThrowExactly<ObjectContainerException>("Object container disposed");
+        }
+
+        [Fact]
+        public void ContainerShouldThrowExceptionWhenDisposedAndCallingRegisterTypeAs()
+        {
+            var container = new ObjectContainer();
+            container.Dispose();
+
+            Action act = () => container.RegisterTypeAs<IDisposableClass>(typeof(DisposableClass1));
             act.Should().ThrowExactly<ObjectContainerException>("Object container disposed");
         }
 


### PR DESCRIPTION
<!---
Thanks for helping to make Reqnroll better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻

You can delete these comment sections as you process them.
-->

### 🤔 What's changed?

<!-- Describe your changes in detail -->

Throws a exception if `RegisterInstanceAs` or `RegisterFactoryAs` is called on a disposed ObjectContainer instance.

### ⚡️ What's your motivation? 

<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->

Fix a possible loophole where it's possible for `ObjectContainer.Dispose()` to throw an exception:

- Add a disposable instance to an `ObjectContainer' instance with a reference to the `ObjectContainer.
- Dispose `ObjectContainer
- Call the `RegisterInstanceAs' or `RegisterFactoryAs' method of the `ObjectContainer' in your instance.Dispose() method.
- See exception

Could be a possible cause of #589.

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] Users should know about my change
  - [x] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
