### PR TITLE
Fix: Exception in an `AfterFeature` hook causes the next first test failure in the next feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ## Bug fixes:
 
-*Contributors of this release (in alphabetical order):* 
+* Fix: Exception in an `AfterFeature` hook causes the next first test failure in the next feature (#597)
+
+*Contributors of this release (in alphabetical order):* @obligaron
 
 # v2.4.1 - 2025-04-29
 

--- a/Reqnroll.Generator/Generation/UnitTestFeatureGenerator.cs
+++ b/Reqnroll.Generator/Generation/UnitTestFeatureGenerator.cs
@@ -206,6 +206,17 @@ namespace Reqnroll.Generator.Generation
             testClassCleanupMethod.Attributes = MemberAttributes.Public;
             testClassCleanupMethod.Name = GeneratorConstants.TESTCLASS_CLEANUP_NAME;
 
+            // Make sure that OnFeatureEndAsync is called on all associated TestRunners.
+            // await global::Reqnroll.TestRunnerManager.ReleaseFeatureAsync(featureInfo);
+            var releaseFeature = new CodeMethodInvokeExpression(
+                    new CodeTypeReferenceExpression(new CodeTypeReference(typeof(TestRunnerManager), CodeTypeReferenceOptions.GlobalReference)),
+                    nameof(TestRunnerManager.ReleaseFeatureAsync),
+                    new CodeVariableReferenceExpression(GeneratorConstants.FEATUREINFO_FIELD));
+
+            _codeDomHelper.MarkCodeMethodInvokeExpressionAsAwait(releaseFeature);
+
+            testClassCleanupMethod.Statements.Add(releaseFeature);
+
             _codeDomHelper.MarkCodeMemberMethodAsAsync(testClassCleanupMethod);
 
             _testGeneratorProvider.SetTestClassCleanupMethod(generationContext);

--- a/Reqnroll/ITestRunnerManager.cs
+++ b/Reqnroll/ITestRunnerManager.cs
@@ -11,6 +11,7 @@ namespace Reqnroll
         bool IsMultiThreaded { get; }
         ITestRunner GetTestRunner(FeatureInfo featureHint = null);
         void ReleaseTestThreadContext(ITestThreadContext testThreadContext);
+        Task ReleaseFeatureForTestRunnersAsync(FeatureInfo featureInfo);
         void Initialize(Assembly testAssembly);
         Task FireTestRunEndAsync();
         Task FireTestRunStartAsync();


### PR DESCRIPTION
<!---
Thanks for helping to make Reqnroll better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻

You can delete these comment sections as you process them.
-->

### 🤔 What's changed?

When a feature file cleanup (e.g., ClassCleanup) is called, all available test-runners that match the cleaned up feature execute the `AfterFeature` hook.

### ⚡️ What's your motivation? 

<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->

Fixes #597

This ensures that errors in the `AfterFeature' hook are raised as they were before #277 was merged.

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

The error could still occur if another thread grabs the test runner from `_availableTestWorkerContainers` before the test frameworks call the feature file cleanup method.
Perhaps we should have a separate list of available test runners for a feature, and only return the test runner to the global `_availableTestWorkerContainers` when the feature is complete.

I've encountered some cases where the `TestWorkerContainerHint.LastUsedFeatureInfo' and the `TestRunner.FeatureContext.FeatureInfo' don't match. I'm not sure in what cases this might happen.

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] Users should know about my change
  - [x] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
