### PR TITLE
Human readable test names in mstest rowtests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Improvements:
 
 * Improvement: MsTest simple scenarios (not Scenario Outlines) uses the Scenario Name as the friendly name for the test (#588)
+* Improvement: MsTest Scenario Outlines use the Scenario Name as the friendly name for the test
 
 ## Bug fixes:
 

--- a/Reqnroll.Generator/UnitTestProvider/MsTestV2GeneratorProvider.cs
+++ b/Reqnroll.Generator/UnitTestProvider/MsTestV2GeneratorProvider.cs
@@ -63,6 +63,35 @@ namespace Reqnroll.Generator.UnitTestProvider
                ? new CodeArrayCreateExpression(typeof(string[]), tagExpressions)
                : new CodePrimitiveExpression(null)));
 
+            // GH193 - Adding a human readable display name for Data Rows
+            // This pulls the display name from the TestMethod attribute on the test method
+            // adds the list of argument values
+            // [TestMethod("friendly name")]
+            // [DataRow(argvalue1, argvalue2, DisplayName="friendly name(argvalue1,argvalue2)"]
+
+            // Find the "TestMethod" attribute and retrieve its "DisplayName" property value
+            var testMethodAttr = testMethod.CustomAttributes
+                .OfType<CodeAttributeDeclaration>()
+                .FirstOrDefault(attr => attr.AttributeType.BaseType == TEST_ATTR);
+
+            string testMethodDisplayName = null;
+            if (testMethodAttr != null && testMethodAttr.Arguments.Count >= 1)
+            {
+                var displayNameArg = testMethodAttr.Arguments
+                    .OfType<CodeAttributeArgument>()
+                    .FirstOrDefault();
+                if (displayNameArg != null && displayNameArg.Value is CodePrimitiveExpression expr && expr.Value is string str)
+                {
+                    testMethodDisplayName = str;
+                }
+            }
+            if (string.IsNullOrEmpty(testMethodDisplayName))
+            {
+                testMethodDisplayName = testMethod.Name;
+            }
+            var displayName = $"{testMethodDisplayName}({string.Join(",", arguments)})";
+            var displayNameProp = new CodeAttributeArgument("DisplayName", new CodePrimitiveExpression(displayName));
+            args.Add(displayNameProp);
             CodeDomHelper.AddAttribute(testMethod, ROW_ATTR, args.ToArray());
         }
 

--- a/Tests/Reqnroll.GeneratorTests/UnitTestProvider/MsTestV2GeneratorProviderTests.cs
+++ b/Tests/Reqnroll.GeneratorTests/UnitTestProvider/MsTestV2GeneratorProviderTests.cs
@@ -219,7 +219,7 @@ namespace Reqnroll.GeneratorTests.UnitTestProvider
             var featureGenerator = provider.CreateFeatureGenerator();
 
             // ACT
-            var code = featureGenerator.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace");
+            var code = featureGenerator.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace", out _);
 
             // ASSERT
             var testMethod = code.Class().Members().Single(m => m.Name == "AddItems");


### PR DESCRIPTION

### 🤔 What's changed?

Modified MsTestv2GeneratorProvider so that Scenario Outlines (aka, DataRow tests) are provided with a friendly name based upon the Scenario Name and the list of data value arguments.

### ⚡️ What's your motivation? 

User friendliness

### 🏷️ What kind of change is this?
- :zap: New feature (non-breaking change which adds new behaviour)


### ♻️ Anything particular you want feedback on?

Need further discussion on how it should handle large lists of arguments and argument values that are large. Should they be elided?

### 📋 Checklist:


- [X ] I've changed the behaviour of the code
  - [X ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [X ] Users should know about my change
  - [ X] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
