### PR TITLE
Introducing the ability to specify REQNROLL_DRY_RUN=true to use the DryRunBindingInvoker when executing tests

### DIFF
--- a/Tests/Reqnroll.RuntimeTests/DryRunStepExecutionTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/DryRunStepExecutionTests.cs
@@ -1,0 +1,85 @@
+﻿using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using Reqnroll.BoDi;
+using Reqnroll.CommonModels;
+using Reqnroll.EnvironmentAccess;
+using Reqnroll.Infrastructure;
+using Xunit;
+
+namespace Reqnroll.RuntimeTests
+{
+    [Binding]
+    public class TrackedStepExecutionBindings
+    {
+        public int StepExecutionCount { get; private set; } = 0;
+
+        [Given("I have some stuff setup")]
+        public virtual void Given()
+        {
+            StepExecutionCount++;
+        }
+    }
+
+    public class DryRunStepExecutionTests : StepExecutionTestsBase
+    {
+        // This is a mock of the IEnvironmentWrapper interface, which is used to access environment variables.
+        private readonly Mock<IEnvironmentWrapper> _environmentWrapperMock = new Mock<IEnvironmentWrapper>();
+
+        // This class is used to provide a custom runtime configuration for the test runner.
+        // Specifically, it overrides the default dependency provider to use the mocked environment wrapper.
+        class DryRunRuntimeConfigurationProvider : DefaultDependencyProvider
+        {
+            private readonly IEnvironmentWrapper _environmentWrapperMock;
+
+            public DryRunRuntimeConfigurationProvider(IEnvironmentWrapper environmentWrapperMock)
+            {
+                _environmentWrapperMock = environmentWrapperMock;
+            }
+
+            public override void RegisterGlobalContainerDefaults(ObjectContainer container)
+            {
+                base.RegisterGlobalContainerDefaults(container);
+                container.RegisterInstanceAs<IEnvironmentWrapper>(_environmentWrapperMock);
+            }
+        }
+
+        [Theory]
+        [InlineData("true")]
+        [InlineData("True")]
+        public async Task ShouldSkipExecutingStepsWhenDryRunEnabled(string value)
+        {
+            _environmentWrapperMock.Setup(e => e.GetEnvironmentVariable(ContainerBuilder.DryRunEnvVarName)).Returns(Result<string>.Success(value));
+
+            var (testRunner, bindingMock) = GetTestRunnerFor<TrackedStepExecutionBindings>(new DryRunRuntimeConfigurationProvider(_environmentWrapperMock.Object));
+            bindingMock.CallBase = true;
+            bindingMock.SetupAllProperties();
+
+            await testRunner.GivenAsync("I have some stuff setup");
+
+            bindingMock.Verify(x => x.Given(), Times.Never, "Step should not be executed in dry run mode.");
+            bindingMock.Object.StepExecutionCount.Should().Be(0, "Step should not be executed in dry run mode.");
+        }
+
+        [Theory]
+        [InlineData("false")]
+        [InlineData("False")]
+        [InlineData("0")]
+        [InlineData("1")]
+        [InlineData((string)null)]
+        public async Task ShouldExecuteStepsWhenDryRunDisabled(string value)
+        {
+            IResult<string> result = value == null ? Result<string>.Failure("Environment variable not set") : Result<string>.Success(value);
+            _environmentWrapperMock.Setup(e => e.GetEnvironmentVariable(ContainerBuilder.DryRunEnvVarName)).Returns(result);
+
+            var (testRunner, bindingMock) = GetTestRunnerFor<TrackedStepExecutionBindings>(new DryRunRuntimeConfigurationProvider(_environmentWrapperMock.Object));
+            bindingMock.CallBase = true;
+            bindingMock.SetupAllProperties();
+
+            await testRunner.GivenAsync("I have some stuff setup");
+
+            bindingMock.Verify(x => x.Given(), Times.Once, "Step should be executed when dry run disabled.");
+            bindingMock.Object.StepExecutionCount.Should().Be(1, "Step should be executed when dry run disabled.");
+        }
+    }
+}

--- a/Tests/Reqnroll.RuntimeTests/StepExecutionTestsBase.cs
+++ b/Tests/Reqnroll.RuntimeTests/StepExecutionTestsBase.cs
@@ -124,12 +124,7 @@ namespace Reqnroll.RuntimeTests
             StepArgumentTypeConverterStub = new Mock<IStepArgumentTypeConverter>();
         }
 
-        protected TestRunner GetTestRunnerFor(params Type[] bindingTypes)
-        {
-            return GetTestRunnerFor(null, bindingTypes);
-        }
-
-        protected TestRunner GetTestRunnerFor(Action<IObjectContainer> registerMocks, params Type[] bindingTypes)
+        protected TestRunner GetTestRunnerFor(Action<IObjectContainer> registerMocks, IDefaultDependencyProvider defaultDependencyProvider, params Type[] bindingTypes)
         {
             return TestObjectFactories.CreateTestRunner(
                 container =>
@@ -143,22 +138,23 @@ namespace Reqnroll.RuntimeTests
                         builder.BuildingCompleted();
 
                         registerMocks?.Invoke(container);
-                    });
+                    },
+                defaultDependencyProvider: defaultDependencyProvider);
         }
 
-        protected (TestRunner, Mock<TBinding>) GetTestRunnerFor<TBinding>() where TBinding : class 
+        protected (TestRunner, Mock<TBinding>) GetTestRunnerFor<TBinding>(IDefaultDependencyProvider defaultDependencyProvider = null) where TBinding : class 
         {
-            return GetTestRunnerWithConverterStub<TBinding>(null);
+            return GetTestRunnerWithConverterStub<TBinding>(null, defaultDependencyProvider);
         }
 
         protected (TestRunner, Mock<TBinding>) GetTestRunnerWithConverterStub<TBinding>() where TBinding : class
         {
-            return GetTestRunnerWithConverterStub<TBinding>(c => c.RegisterInstanceAs(StepArgumentTypeConverterStub.Object));
+            return GetTestRunnerWithConverterStub<TBinding>(c => c.RegisterInstanceAs(StepArgumentTypeConverterStub.Object), null);
         }
 
-        private (TestRunner, Mock<TBinding>) GetTestRunnerWithConverterStub<TBinding>(Action<IObjectContainer> registerMocks) where TBinding : class
+        private (TestRunner, Mock<TBinding>) GetTestRunnerWithConverterStub<TBinding>(Action<IObjectContainer> registerMocks, IDefaultDependencyProvider defaultDependencyProvider) where TBinding : class
         {
-            TestRunner testRunner = GetTestRunnerFor(registerMocks, typeof(TBinding));
+            TestRunner testRunner = GetTestRunnerFor(registerMocks, defaultDependencyProvider, typeof(TBinding));
 
             var bindingInstance = new Mock<TBinding>();
             testRunner.ScenarioContext.SetBindingInstance(typeof(TBinding), bindingInstance.Object);

--- a/Tests/Reqnroll.RuntimeTests/TestObjectFactories.cs
+++ b/Tests/Reqnroll.RuntimeTests/TestObjectFactories.cs
@@ -8,25 +8,25 @@ namespace Reqnroll.RuntimeTests
 {
     public static class TestObjectFactories
     {
-        internal static TestRunner CreateTestRunner(out IObjectContainer createThreadContainer, Action<IObjectContainer> registerTestThreadMocks = null, Action<IObjectContainer> registerGlobalMocks = null)
+        internal static TestRunner CreateTestRunner(out IObjectContainer createThreadContainer, Action<IObjectContainer> registerTestThreadMocks = null, Action<IObjectContainer> registerGlobalMocks = null, IDefaultDependencyProvider defaultDependencyProvider = null)
         {
-            createThreadContainer = CreateDefaultTestThreadContainer(registerTestThreadMocks: registerTestThreadMocks, registerGlobalMocks: registerGlobalMocks);
+            createThreadContainer = CreateDefaultTestThreadContainer(registerTestThreadMocks: registerTestThreadMocks, registerGlobalMocks: registerGlobalMocks, defaultDependencyProvider: defaultDependencyProvider);
             return (TestRunner)createThreadContainer.Resolve<ITestRunner>();
         }
 
-        internal static TestRunner CreateTestRunner(Action<IObjectContainer> registerTestThreadMocks = null, Action<IObjectContainer> registerGlobalMocks = null)
+        internal static TestRunner CreateTestRunner(Action<IObjectContainer> registerTestThreadMocks = null, Action<IObjectContainer> registerGlobalMocks = null, IDefaultDependencyProvider defaultDependencyProvider = null)
         {
-            return CreateTestRunner(out _, registerTestThreadMocks, registerGlobalMocks);
+            return CreateTestRunner(out _, registerTestThreadMocks, registerGlobalMocks, defaultDependencyProvider);
         }
 
-        internal static IObjectContainer CreateDefaultGlobalContainer(IRuntimeConfigurationProvider configurationProvider = null, Action<IObjectContainer> registerGlobalMocks = null)
+        internal static IObjectContainer CreateDefaultGlobalContainer(IRuntimeConfigurationProvider configurationProvider = null, Action<IObjectContainer> registerGlobalMocks = null, IDefaultDependencyProvider defaultDependencyProvider = null)
         {
-            return CreateDefaultGlobalContainer(configurationProvider, registerGlobalMocks, new RuntimeTestsContainerBuilder());
+            return CreateDefaultGlobalContainer(configurationProvider, registerGlobalMocks, new RuntimeTestsContainerBuilder(defaultDependencyProvider));
         }
 
-        internal static IObjectContainer CreateDefaultTestThreadContainer(IRuntimeConfigurationProvider configurationProvider = null, Action<IObjectContainer> registerGlobalMocks = null, Action<IObjectContainer> registerTestThreadMocks = null)
+        internal static IObjectContainer CreateDefaultTestThreadContainer(IRuntimeConfigurationProvider configurationProvider = null, Action<IObjectContainer> registerGlobalMocks = null, Action<IObjectContainer> registerTestThreadMocks = null, IDefaultDependencyProvider defaultDependencyProvider = null)
         {
-            return CreateDefaultTestThreadContainer(configurationProvider, registerGlobalMocks, registerTestThreadMocks, new RuntimeTestsContainerBuilder());
+            return CreateDefaultTestThreadContainer(configurationProvider, registerGlobalMocks, registerTestThreadMocks, new RuntimeTestsContainerBuilder(defaultDependencyProvider));
         }
 
         internal static IObjectContainer CreateDefaultFeatureContainer(IRuntimeConfigurationProvider configurationHolder, IDefaultDependencyProvider defaultDependencyProvider = null)


### PR DESCRIPTION
### 🤔 What's changed?

Updates Reqnroll to look for an environment variable, `REQNROLL_DRY_RUN`, which causes it to optionally register the DryRunBindingInvoker vs the default one.

For example, if you execute:
`dotnet test -e REQNROLL_DRY_RUN=true .\MyTestProject.csproj`

The test suite will no longer _actually_ invoke the step handlers. However, if you've [configured](https://docs.reqnroll.net/stable/installation/configuration.html#runtime) ["Inconclusive" test results](https://docs.reqnroll.net/stable/execution/test-results.html#test-fails-due-to-step-binding-problems) to be interpreted as a failure, this will effectively allow you to verify that all .feature files are referencing a defined step handler. (For example during PRs.)

### ⚡️ What's your motivation? 

This enables users to run CI verification on their test suite to ensure all .feature files are referencing a defined step handler. Right now the only way to verify this is at test execution runtime, which can be prohibitive for users that have implemented expensive tests using this framework.

### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)

### ♻️ Anything particular you want feedback on?

I couldn't find a particularly obvious place for this check to go. So I ended up rationalizing to myself that it could live in `ContainerBuilder`, following a similar convention that the [BindingProviderService](https://github.com/reqnroll/Reqnroll/blob/df40e0e202ebaed63304ffc2bc19f71972e8b478/Reqnroll/Bindings/Provider/BindingProviderService.cs#L128-L138) follows.

I also opted to have the environment variable check more-or-less hardcoded in the business logic rather than trying to elevate it to an object model like [ReqnrollConfiguration.cs](https://github.com/reqnroll/Reqnroll/blob/df40e0e202ebaed63304ffc2bc19f71972e8b478/Reqnroll/Configuration/ReqnrollConfiguration.cs#L16). (Though the check _does_ use the `IEnvironmentWrapper` abstraction.) It felt like designing this feature use the "normal" configuration system wasn't the most accessible way to utilize this functionality, as opposed to an environment variable, because that would require somehow updating your config JSON only for CI.

That said, I don't feel totally confident in my chosen implementation. I welcome other contributor's opinions on a better place for this to live!

### 📋 Checklist:

- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [ ] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.
