### PR TITLE
Refactor: Enhance handling of Ambiguous Binding Match situations 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Improvements:
 
 * Improvement: MsTest simple scenarios (not Scenario Outlines) uses the Scenario Name as the friendly name for the test (#588)
+* Improvement: Ambiguous binding situations now return the list of Binding Matches that caused the AmbiguousMatchException (#622)
 
 ## Bug fixes:
 

--- a/Reqnroll/Bindings/BindingMatch.cs
+++ b/Reqnroll/Bindings/BindingMatch.cs
@@ -1,3 +1,6 @@
+using Reqnroll.Infrastructure;
+using System.Linq;
+
 namespace Reqnroll.Bindings
 {
     public class BindingMatch
@@ -13,10 +16,10 @@ namespace Reqnroll.Bindings
         public int ScopeMatches { get; private set; }
         public bool IsScoped { get { return ScopeMatches > 0; } }
 
-        public object[] Arguments  { get; private set; }
+        public MatchArgument[] Arguments  { get; private set; }
         public StepContext StepContext { get; private set; }
 
-        public BindingMatch(IStepDefinitionBinding stepBinding, int scopeMatches, object[] arguments, StepContext stepContext)
+        public BindingMatch(IStepDefinitionBinding stepBinding, int scopeMatches, MatchArgument[] arguments, StepContext stepContext)
         {
             StepBinding = stepBinding;
             ScopeMatches = scopeMatches;

--- a/Reqnroll/ErrorHandling/AmbiguousBindingException.cs
+++ b/Reqnroll/ErrorHandling/AmbiguousBindingException.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using Reqnroll.Bindings;
+
+// the exceptions are part of the public API, keep them in Reqnroll namespace
+// ReSharper disable once CheckNamespace
+namespace Reqnroll;
+
+/// <summary>
+/// This subclass is added for support of Cucumber Messages.
+/// When emitting the Cucumber Message that describes an ambiguous matching situation, the Message will contain the list of possible matches.
+/// We use this subclass of BindingException to convey that information.
+/// </summary>
+[Serializable]
+public class AmbiguousBindingException : BindingException
+{
+    public IEnumerable<BindingMatch> Matches { get; private set; }
+
+    public AmbiguousBindingException()
+    {
+    }
+
+    public AmbiguousBindingException(string message) : base(message)
+    {
+    }
+
+    public AmbiguousBindingException(string message, Exception inner) : base(message, inner)
+    {
+    }
+
+    public AmbiguousBindingException(string message, IEnumerable<BindingMatch> matches) : base(message)
+    {
+        Matches = new List<BindingMatch>(matches);
+    }
+
+    protected AmbiguousBindingException(
+        SerializationInfo info,
+        StreamingContext context) : base(info, context)
+    {
+        if (info == null)
+        {
+            throw new ArgumentNullException(nameof(info));
+        }
+
+        Matches = (List<BindingMatch>)info.GetValue("Matches", typeof(List<BindingMatch>));
+    }
+
+    public override void GetObjectData(SerializationInfo info, StreamingContext context)
+    {
+        if (info == null)
+        {
+            throw new ArgumentNullException(nameof(info));
+        }
+
+        base.GetObjectData(info, context);
+        info.AddValue("Matches", Matches);
+    }
+}

--- a/Reqnroll/ErrorHandling/ErrorProvider.cs
+++ b/Reqnroll/ErrorHandling/ErrorProvider.cs
@@ -59,17 +59,19 @@ namespace Reqnroll.ErrorHandling
         public Exception GetAmbiguousMatchError(List<BindingMatch> matches, StepInstance stepInstance)
         {
             string stepDescription = stepFormatter.GetStepDescription(stepInstance);
-            return new BindingException(
-                $"Ambiguous step definitions found for step '{stepDescription}': {string.Join(", ", matches.Select(m => GetMethodText(m.StepBinding.Method)).ToArray())}");
+            return new AmbiguousBindingException(
+                $"Ambiguous step definitions found for step '{stepDescription}': {string.Join(", ", matches.Select(m => GetMethodText(m.StepBinding.Method)).ToArray())}",
+                matches);
         }
 
 
         public Exception GetAmbiguousBecauseParamCheckMatchError(List<BindingMatch> matches, StepInstance stepInstance)
         {
             string stepDescription = stepFormatter.GetStepDescription(stepInstance);
-            return new BindingException(
+            return new AmbiguousBindingException(
                 "Multiple step definitions found, but none of them have matching parameter count and type for step "
-                + $"'{stepDescription}': {string.Join(", ", matches.Select(m => GetMethodText(m.StepBinding.Method)).ToArray())}");
+                + $"'{stepDescription}': {string.Join(", ", matches.Select(m => GetMethodText(m.StepBinding.Method)).ToArray())}",
+                matches);
         }
 
         public Exception GetNoMatchBecauseOfScopeFilterError(List<BindingMatch> matches, StepInstance stepInstance)

--- a/Reqnroll/Infrastructure/MatchArgumentCalculator.cs
+++ b/Reqnroll/Infrastructure/MatchArgumentCalculator.cs
@@ -4,21 +4,33 @@ using System.Text.RegularExpressions;
 
 namespace Reqnroll.Infrastructure
 {
+    // The MatchArgument structure holds information about arguments extracted from a Step match. The StartOffset indicates where in the step text the value of the argument begins in that string.
+    public class MatchArgument
+    {
+        public object Value { get; private set; }
+        public int? StartOffset { get; private set; }
+
+        public MatchArgument(object value, int? startOffset = null)
+        {
+            Value = value;
+            StartOffset = startOffset;
+        }
+    }
     public interface IMatchArgumentCalculator
     {
-        object[] CalculateArguments(Match match, StepInstance stepInstance, IStepDefinitionBinding stepDefinitionBinding);
+        MatchArgument[] CalculateArguments(Match match, StepInstance stepInstance, IStepDefinitionBinding stepDefinitionBinding);
     }
 
     public class MatchArgumentCalculator : IMatchArgumentCalculator
     {
-        public object[] CalculateArguments(Match match, StepInstance stepInstance, IStepDefinitionBinding stepDefinitionBinding)
+        public MatchArgument[] CalculateArguments(Match match, StepInstance stepInstance, IStepDefinitionBinding stepDefinitionBinding)
         {
-            var regexArgs = match.Groups.Cast<Group>().Skip(1).Where(g => g.Success).Select(g => g.Value);
-            var arguments = regexArgs.Cast<object>().ToList();
+            var regexArgs = match.Groups.Cast<Group>().Skip(1).Where(g => g.Success).Select(g => new MatchArgument(g.Value, g.Index));
+            var arguments = regexArgs.ToList();
             if (stepInstance.MultilineTextArgument != null)
-                arguments.Add(stepInstance.MultilineTextArgument);
+                arguments.Add(new MatchArgument(stepInstance.MultilineTextArgument));
             if (stepInstance.TableArgument != null)
-                arguments.Add(stepInstance.TableArgument);
+                arguments.Add(new MatchArgument(stepInstance.TableArgument));
 
             return arguments.ToArray();
         }

--- a/Reqnroll/Infrastructure/StepDefinitionMatchService.cs
+++ b/Reqnroll/Infrastructure/StepDefinitionMatchService.cs
@@ -7,6 +7,7 @@ using System.Text.RegularExpressions;
 using Reqnroll.Bindings;
 using Reqnroll.Bindings.Reflection;
 using Reqnroll.ErrorHandling;
+using Reqnroll.Assist;
 
 namespace Reqnroll.Infrastructure
 {
@@ -75,7 +76,7 @@ namespace Reqnroll.Infrastructure
             if (useScopeMatching && stepDefinitionBinding.IsScoped && stepInstance.StepContext != null && !stepDefinitionBinding.BindingScope.Match(stepInstance.StepContext, out scopeMatches))
                 return BindingMatch.NonMatching;
 
-            var arguments = match == null ? Array.Empty<object>() : _matchArgumentCalculator.CalculateArguments(match, stepInstance, stepDefinitionBinding);
+            var arguments = match == null ? Array.Empty<MatchArgument>() : _matchArgumentCalculator.CalculateArguments(match, stepInstance, stepDefinitionBinding);
 
             if (useParamMatching)
             {
@@ -88,7 +89,7 @@ namespace Reqnroll.Infrastructure
 
                 // Check if regex & extra arguments can be converted to the method parameters
                 //if (arguments.Zip(bindingParameters, (arg, parameter) => CanConvertArg(arg, parameter.Type)).Any(canConvert => !canConvert))
-                if (arguments.Where((arg, argIndex) => !CanConvertArg(arg, bindingParameters[argIndex].Type, bindingCulture)).Any())
+                if (arguments.Where((arg, argIndex) => !CanConvertArg(arg.Value, bindingParameters[argIndex].Type, bindingCulture)).Any())
                     return BindingMatch.NonMatching;
             }
 

--- a/Reqnroll/Infrastructure/TestExecutionEngine.cs
+++ b/Reqnroll/Infrastructure/TestExecutionEngine.cs
@@ -641,7 +641,7 @@ namespace Reqnroll.Infrastructure
 
             for (var i = 0; i < match.Arguments.Length; i++)
             {
-                arguments[i] = await ConvertArg(match.Arguments[i], bindingParameters[i].Type);
+                arguments[i] = await ConvertArg(match.Arguments[i].Value, bindingParameters[i].Type);
             }
 
             return arguments;

--- a/Tests/Reqnroll.RuntimeTests/ErrorProviderTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/ErrorProviderTests.cs
@@ -132,7 +132,7 @@ namespace Reqnroll.RuntimeTests
             var result = GetMatchErrorFunc(errorProvider, bindingMatch, null);
 
             result.Should().NotBeNull();
-            result.Should().BeOfType<BindingException>();
+            result.Should().BeAssignableTo<BindingException>();
             result.Message.Should().Be($"{expectedPrefixMessage} '{stepInstanceDescription}': {methodBindingAssemblyName}:{method1BindingTypeFullName}.{methodName}({parameter1Type}), {methodBindingAssemblyName}:{method2BindingTypeFullName}.{methodName}({parameter1Type})");
         }
 

--- a/Tests/Reqnroll.RuntimeTests/Infrastructure/TestExecutionEngineTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/Infrastructure/TestExecutionEngineTests.cs
@@ -195,7 +195,7 @@ namespace Reqnroll.RuntimeTests.Infrastructure
             List<BindingMatch> candidatingMatches;
             stepDefinitionMatcherStub.Setup(sdm => sdm.GetBestMatch(It.IsAny<StepInstance>(), It.IsAny<CultureInfo>(), out ambiguityReason, out candidatingMatches))
                 .Returns(
-                    new BindingMatch(stepDefStub.Object, 0, new object[0], new StepContext("bla", "foo", new List<string>(), CultureInfo.InvariantCulture)));
+                    new BindingMatch(stepDefStub.Object, 0, new MatchArgument[0], new StepContext("bla", "foo", new List<string>(), CultureInfo.InvariantCulture)));
 
             return stepDefStub;
         }
@@ -213,7 +213,7 @@ namespace Reqnroll.RuntimeTests.Infrastructure
             List<BindingMatch> candidatingMatches;
             stepDefinitionMatcherStub.Setup(sdm => sdm.GetBestMatch(It.IsAny<StepInstance>(), It.IsAny<CultureInfo>(), out ambiguityReason, out candidatingMatches))
                 .Returns(
-                    new BindingMatch(stepDefStub.Object, 0, new object[] { "userName" }, new StepContext("bla", "foo", new List<string>(), CultureInfo.InvariantCulture)));
+                    new BindingMatch(stepDefStub.Object, 0, new MatchArgument[] { new MatchArgument("username", 1) }, new StepContext("bla", "foo", new List<string>(), CultureInfo.InvariantCulture)));
 
             return stepDefStub;
         }


### PR DESCRIPTION

### 🤔 What's changed?
Changes to the binding matching process such that when an ambiguous match is found, the actual found binding matches are returned as part of the AmbiguousBindingMatchException.

### ⚡️ What's your motivation? 

This is in preparation for Cucumber Messages which needs the binding info.


### 🏷️ What kind of change is this?


- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)



### 📋 Checklist:


- [X ] I've changed the behaviour of the code
  - [X ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [x] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
