### PR TITLE
Refactor: Add GeneratorWarnings as output parameter of UnitTestFeatureGenerator.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Improvements:
 
 * Improvement: MsTest simple scenarios (not Scenario Outlines) uses the Scenario Name as the friendly name for the test (#588)
-
+* Refactored UnitTestFeatureGenerator to provide an output parameter that contains warnings (#624)
 ## Bug fixes:
 
 * Fix: Exception in an `AfterFeature` hook causes the next first test failure in the next feature (#597)

--- a/Reqnroll.Generator/Generation/UnitTestFeatureGenerator.cs
+++ b/Reqnroll.Generator/Generation/UnitTestFeatureGenerator.cs
@@ -1,16 +1,17 @@
-using System;
-using System.CodeDom;
-using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
-using System.Linq;
-using System.Reflection;
-using System.Threading.Tasks;
 using Reqnroll.Configuration;
 using Reqnroll.Generator.CodeDom;
 using Reqnroll.Generator.UnitTestConverter;
 using Reqnroll.Generator.UnitTestProvider;
 using Reqnroll.Parser;
 using Reqnroll.Tracing;
+using System;
+using System.CodeDom;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
 
 namespace Reqnroll.Generator.Generation
 {
@@ -42,7 +43,7 @@ namespace Reqnroll.Generator.Generation
 
         public string TestClassNameFormat { get; set; } = "{0}Feature";
 
-        public CodeNamespace GenerateUnitTestFixture(ReqnrollDocument document, string testClassName, string targetNamespace)
+        public CodeNamespace GenerateUnitTestFixture(ReqnrollDocument document, string testClassName, string targetNamespace, out IEnumerable<string> generationWarnings)
         {
             var codeNamespace = CreateNamespace(targetNamespace);
             var feature = document.ReqnrollFeature;
@@ -66,6 +67,7 @@ namespace Reqnroll.Generator.Generation
 
             //before returning the generated code, call the provider's method in case the generated code needs to be customized            
             _testGeneratorProvider.FinalizeTestClass(generationContext);
+            generationWarnings = generationContext.GenerationWarnings;
             return codeNamespace;
         }
 

--- a/Reqnroll.Generator/Interfaces/TestGeneratorResult.cs
+++ b/Reqnroll.Generator/Interfaces/TestGeneratorResult.cs
@@ -26,6 +26,10 @@ namespace Reqnroll.Generator.Interfaces
 
         public bool Success { get { return Errors == null || !Errors.Any(); } }
 
+        /// <summary>
+        /// Warning messages from code generation, if any.
+        /// </summary>
+        public IEnumerable<string> Warnings { get; private set; }
         public TestGeneratorResult(params TestGenerationError[] errors)
             : this((IEnumerable<TestGenerationError>)errors)
         {
@@ -37,12 +41,16 @@ namespace Reqnroll.Generator.Interfaces
             if (errors.Count() == 0) throw new ArgumentException("no errors provided", "errors");
 
             Errors = errors.ToArray();
+            Warnings = new List<string>();
         }
 
-        public TestGeneratorResult(string generatedTestCode, bool isUpToDate)
+        public TestGeneratorResult(string generatedTestCode, bool isUpToDate, IEnumerable<string> warnings)
         {
             IsUpToDate = isUpToDate;
             GeneratedTestCode = generatedTestCode;
+            Warnings = new List<string>();
+            if (warnings != null)
+                Warnings = warnings.ToList();
         }
     }
 }

--- a/Reqnroll.Generator/Interfaces/TestGeneratorResult.cs
+++ b/Reqnroll.Generator/Interfaces/TestGeneratorResult.cs
@@ -41,7 +41,7 @@ namespace Reqnroll.Generator.Interfaces
             if (errors.Count() == 0) throw new ArgumentException("no errors provided", "errors");
 
             Errors = errors.ToArray();
-            Warnings = new List<string>();
+            Warnings = Array.Empty<string>();
         }
 
         public TestGeneratorResult(string generatedTestCode, bool isUpToDate, IEnumerable<string> warnings)

--- a/Reqnroll.Generator/Interfaces/TestGeneratorResult.cs
+++ b/Reqnroll.Generator/Interfaces/TestGeneratorResult.cs
@@ -48,9 +48,7 @@ namespace Reqnroll.Generator.Interfaces
         {
             IsUpToDate = isUpToDate;
             GeneratedTestCode = generatedTestCode;
-            Warnings = new List<string>();
-            if (warnings != null)
-                Warnings = warnings.ToList();
+            Warnings = warnings is null ? Array.Empty<string>() : warnings.ToList();
         }
     }
 }

--- a/Reqnroll.Generator/TestClassGenerationContext.cs
+++ b/Reqnroll.Generator/TestClassGenerationContext.cs
@@ -28,6 +28,8 @@ namespace Reqnroll.Generator
 
         public IDictionary<string, object> CustomData { get; private set; }
 
+        public ICollection<string> GenerationWarnings { get; private set; }
+
         public TestClassGenerationContext(
             IUnitTestGeneratorProvider unitTestGeneratorProvider,
             ReqnrollDocument document,
@@ -60,6 +62,7 @@ namespace Reqnroll.Generator
             GenerateRowTests = generateRowTests;
 
             CustomData = new Dictionary<string, object>();
+            GenerationWarnings = new List<string>();
         }
     }
 }

--- a/Reqnroll.Generator/TestGenerator.cs
+++ b/Reqnroll.Generator/TestGenerator.cs
@@ -159,7 +159,6 @@ namespace Reqnroll.Generator
             var featureGenerator = featureGeneratorRegistry.CreateGenerator(reqnrollDocument);
 
             var codeNamespace = featureGenerator.GenerateUnitTestFixture(reqnrollDocument, null, targetNamespace, out var generatedWarnings);
-            generationWarnings = generatedWarnings;
             return codeNamespace;
         }
 

--- a/Reqnroll.Generator/TestGenerator.cs
+++ b/Reqnroll.Generator/TestGenerator.cs
@@ -87,12 +87,11 @@ namespace Reqnroll.Generator
 
         protected string GetGeneratedTestCode(FeatureFileInput featureFileInput, out IEnumerable<string> generationWarnings)
         {
-            generationWarnings = new List<string>();
+            generationWarnings = Array.Empty<string>();
             using (var outputWriter = new IndentProcessingWriter(new StringWriter()))
             {
                 var codeProvider = codeDomHelper.CreateCodeDomProvider();
-                var codeNamespace = GenerateTestFileCode(featureFileInput, out IEnumerable<string> generatedWarnings);
-                generationWarnings = generatedWarnings;
+                var codeNamespace = GenerateTestFileCode(featureFileInput, out generationWarnings);
                 if (codeNamespace == null) return "";
 
                 var options = new CodeGeneratorOptions
@@ -144,7 +143,7 @@ namespace Reqnroll.Generator
         
         private CodeNamespace GenerateTestFileCode(FeatureFileInput featureFileInput, out IEnumerable<string> generationWarnings)
         {
-            generationWarnings = new List<string>();
+            generationWarnings = Array.Empty<string>();
             string targetNamespace = GetTargetNamespace(featureFileInput) ?? "Reqnroll.GeneratedTests";
 
             var parser = gherkinParserFactory.Create(reqnrollConfiguration.FeatureLanguage);
@@ -158,7 +157,7 @@ namespace Reqnroll.Generator
 
             var featureGenerator = featureGeneratorRegistry.CreateGenerator(reqnrollDocument);
 
-            var codeNamespace = featureGenerator.GenerateUnitTestFixture(reqnrollDocument, null, targetNamespace, out var generatedWarnings);
+            var codeNamespace = featureGenerator.GenerateUnitTestFixture(reqnrollDocument, null, targetNamespace, out generationWarnings);
             return codeNamespace;
         }
 

--- a/Reqnroll.Generator/TestGenerator.cs
+++ b/Reqnroll.Generator/TestGenerator.cs
@@ -1,6 +1,8 @@
 using System;
 using System.CodeDom;
 using System.CodeDom.Compiler;
+using System.Collections;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -61,18 +63,18 @@ namespace Reqnroll.Generator
             {
                 preliminaryUpToDateCheckResult = testUpToDateChecker.IsUpToDatePreliminary(featureFileInput, generatedTestFullPath, settings.UpToDateCheckingMethod);
                 if (preliminaryUpToDateCheckResult == true)
-                    return new TestGeneratorResult(null, true);
+                    return new TestGeneratorResult(null, true, null);
             }
 
-            string generatedTestCode = GetGeneratedTestCode(featureFileInput);
+            string generatedTestCode = GetGeneratedTestCode(featureFileInput, out IEnumerable<string> generatedWarnings);
             if(string.IsNullOrEmpty(generatedTestCode))
-                return new TestGeneratorResult(null, true);
+                return new TestGeneratorResult(null, true, generatedWarnings);
 
             if (settings.CheckUpToDate && preliminaryUpToDateCheckResult != false)
             {
                 var isUpToDate = testUpToDateChecker.IsUpToDate(featureFileInput, generatedTestFullPath, generatedTestCode, settings.UpToDateCheckingMethod);
                 if (isUpToDate)
-                    return new TestGeneratorResult(null, true);
+                    return new TestGeneratorResult(null, true, generatedWarnings);
             }
 
             if (settings.WriteResultToFile)
@@ -80,16 +82,17 @@ namespace Reqnroll.Generator
                 File.WriteAllText(generatedTestFullPath, generatedTestCode, Encoding.UTF8);
             }
 
-            return new TestGeneratorResult(generatedTestCode, false);
+            return new TestGeneratorResult(generatedTestCode, false, generatedWarnings);
         }
 
-        protected string GetGeneratedTestCode(FeatureFileInput featureFileInput)
+        protected string GetGeneratedTestCode(FeatureFileInput featureFileInput, out IEnumerable<string> generationWarnings)
         {
+            generationWarnings = new List<string>();
             using (var outputWriter = new IndentProcessingWriter(new StringWriter()))
             {
                 var codeProvider = codeDomHelper.CreateCodeDomProvider();
-                var codeNamespace = GenerateTestFileCode(featureFileInput);
-
+                var codeNamespace = GenerateTestFileCode(featureFileInput, out IEnumerable<string> generatedWarnings);
+                generationWarnings = generatedWarnings;
                 if (codeNamespace == null) return "";
 
                 var options = new CodeGeneratorOptions
@@ -139,8 +142,9 @@ namespace Reqnroll.Generator
             return result;
         }
         
-        private CodeNamespace GenerateTestFileCode(FeatureFileInput featureFileInput)
+        private CodeNamespace GenerateTestFileCode(FeatureFileInput featureFileInput, out IEnumerable<string> generationWarnings)
         {
+            generationWarnings = new List<string>();
             string targetNamespace = GetTargetNamespace(featureFileInput) ?? "Reqnroll.GeneratedTests";
 
             var parser = gherkinParserFactory.Create(reqnrollConfiguration.FeatureLanguage);
@@ -154,7 +158,8 @@ namespace Reqnroll.Generator
 
             var featureGenerator = featureGeneratorRegistry.CreateGenerator(reqnrollDocument);
 
-            var codeNamespace = featureGenerator.GenerateUnitTestFixture(reqnrollDocument, null, targetNamespace);
+            var codeNamespace = featureGenerator.GenerateUnitTestFixture(reqnrollDocument, null, targetNamespace, out var generatedWarnings);
+            generationWarnings = generatedWarnings;
             return codeNamespace;
         }
 

--- a/Reqnroll.Generator/UnitTestConverter/IFeatureGenerator.cs
+++ b/Reqnroll.Generator/UnitTestConverter/IFeatureGenerator.cs
@@ -1,10 +1,11 @@
 using System.CodeDom;
+using System.Collections.Generic;
 using Reqnroll.Parser;
 
 namespace Reqnroll.Generator.UnitTestConverter
 {
     public interface IFeatureGenerator
     {
-        CodeNamespace GenerateUnitTestFixture(ReqnrollDocument document, string testClassName, string targetNamespace);
+        CodeNamespace GenerateUnitTestFixture(ReqnrollDocument document, string testClassName, string targetNamespace, out IEnumerable<string> warnings);
     }
 }

--- a/Reqnroll.Tools.MsBuild.Generation/FeatureFileCodeBehindGenerator.cs
+++ b/Reqnroll.Tools.MsBuild.Generation/FeatureFileCodeBehindGenerator.cs
@@ -59,8 +59,6 @@ namespace Reqnroll.Tools.MsBuild.Generation
                 {
                     Log.LogWarning(warning);
                 }
-
-
                 string targetFilePath = _filePathGenerator.GenerateFilePath(
                     projectFolder,
                     outputPath,

--- a/Reqnroll.Tools.MsBuild.Generation/FeatureFileCodeBehindGenerator.cs
+++ b/Reqnroll.Tools.MsBuild.Generation/FeatureFileCodeBehindGenerator.cs
@@ -55,6 +55,12 @@ namespace Reqnroll.Tools.MsBuild.Generation
                     continue;
                 }
 
+                foreach (var warning in generatorResult.Warnings)
+                {
+                    Log.LogWarning(warning);
+                }
+
+
                 string targetFilePath = _filePathGenerator.GenerateFilePath(
                     projectFolder,
                     outputPath,

--- a/Reqnroll.Tools.MsBuild.Generation/TestFileGeneratorResult.cs
+++ b/Reqnroll.Tools.MsBuild.Generation/TestFileGeneratorResult.cs
@@ -19,6 +19,7 @@ namespace Reqnroll.Tools.MsBuild.Generation
             Errors = generatorResult.Errors;
             IsUpToDate = generatorResult.IsUpToDate;
             GeneratedTestCode = generatorResult.GeneratedTestCode;
+            Warnings = generatorResult.Warnings;
         }
 
         /// <summary>
@@ -39,5 +40,7 @@ namespace Reqnroll.Tools.MsBuild.Generation
         public bool Success => Errors == null || !Errors.Any();
 
         public string Filename { get; }
+
+        public IEnumerable<string> Warnings { get; }
     }
 }

--- a/Tests/Reqnroll.GeneratorTests/CustomTestGeneratorProviderTest.cs
+++ b/Tests/Reqnroll.GeneratorTests/CustomTestGeneratorProviderTest.cs
@@ -68,7 +68,7 @@ namespace Reqnroll.GeneratorTests
                 
                 var sampleTestGeneratorProvider = new SimpleTestGeneratorProvider(new CodeDomHelper(CodeDomProviderLanguage.CSharp));
                 var converter = CreateUnitTestConverter(sampleTestGeneratorProvider);
-                CodeNamespace code = converter.GenerateUnitTestFixture(feature, "TestClassName", "Target.Namespace");
+                CodeNamespace code = converter.GenerateUnitTestFixture(feature, "TestClassName", "Target.Namespace", out var generationWarnings);
 
                 code.Should().NotBeNull();
                 

--- a/Tests/Reqnroll.GeneratorTests/TestGeneratorTest.cs
+++ b/Tests/Reqnroll.GeneratorTests/TestGeneratorTest.cs
@@ -68,7 +68,7 @@ namespace Reqnroll.GeneratorTests
 
                 var sampleTestGeneratorProvider = new SimpleTestGeneratorProvider(new CodeDomHelper(CodeDomProviderLanguage.CSharp));
                 var converter = CreateUnitTestConverter(sampleTestGeneratorProvider);
-                CodeNamespace code = converter.GenerateUnitTestFixture(feature, null, null);
+                CodeNamespace code = converter.GenerateUnitTestFixture(feature, null, null, out var generationWarnings);
 
                 code.Should().NotBeNull();
                 

--- a/Tests/Reqnroll.GeneratorTests/UnitTestFeatureGeneratorTests.cs
+++ b/Tests/Reqnroll.GeneratorTests/UnitTestFeatureGeneratorTests.cs
@@ -38,7 +38,7 @@ namespace Reqnroll.GeneratorTests
 
         protected void GenerateFeature(IFeatureGenerator generator, ReqnrollDocument document)
         {
-            generator.GenerateUnitTestFixture(document, "dummy", "dummyNS");
+            generator.GenerateUnitTestFixture(document, "dummy", "dummyNS", out var generationWarnings);
         }
     }
 

--- a/Tests/Reqnroll.GeneratorTests/UnitTestProvider/MsTestGeneratorProviderTests.cs
+++ b/Tests/Reqnroll.GeneratorTests/UnitTestProvider/MsTestGeneratorProviderTests.cs
@@ -121,7 +121,7 @@ namespace Reqnroll.GeneratorTests.UnitTestProvider
             var converter = sampleTestGeneratorProvider.CreateUnitTestConverter();
 
             // ACT
-            var code = converter.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace");
+            var code = converter.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace", out var generationWarnings);
 
             // ASSERT
             var descriptionAttributeForFirstScenarioOutline = code.Class().Members().Single(m => m.Name == "SimpleScenarioOutline_Something").CustomAttributes().Single(a => a.Name == TestDescriptionAttributeName);
@@ -139,7 +139,7 @@ namespace Reqnroll.GeneratorTests.UnitTestProvider
             var converter = sampleTestGeneratorProvider.CreateUnitTestConverter();
 
             // ACT
-            var code = converter.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace");
+            var code = converter.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace", out var generationWarnings);
 
             // ASSERT
             var descriptionAttributeForFirstScenarioOutline = code.Class().Members().Single(m => m.Name == "SimpleScenarioOutline_Variant0").CustomAttributes().Single(a => a.Name == TestDescriptionAttributeName);
@@ -157,7 +157,7 @@ namespace Reqnroll.GeneratorTests.UnitTestProvider
             var converter = sampleTestGeneratorProvider.CreateUnitTestConverter();
 
             // ACT
-            var code = converter.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace");
+            var code = converter.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace", out var generationWarnings);
 
             // ASSERT
             var descriptionAttributeForFirstScenarioOutline = code.Class().Members().Single(m => m.Name == "SimpleScenarioOutline_Something").CustomAttributes().Single(a => a.Name == TestDescriptionAttributeName);
@@ -175,7 +175,7 @@ namespace Reqnroll.GeneratorTests.UnitTestProvider
             var converter = sampleTestGeneratorProvider.CreateUnitTestConverter();
 
             // ACT
-            var code = converter.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace");
+            var code = converter.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace", out var generationWarnings);
 
             // ASSERT
             var descriptionAttributeForFirstScenarioOutline = code.Class().Members().Single(m => m.Name == "SimpleScenarioOutline_ExampleSet0_Something").CustomAttributes().Single(a => a.Name == TestDescriptionAttributeName);
@@ -214,7 +214,7 @@ namespace Reqnroll.GeneratorTests.UnitTestProvider
             var featureGenerator = provider.CreateFeatureGenerator(addNonParallelizableMarkerForTags: new[] { "nonparallelizable" });
 
             // ACT
-            var code = featureGenerator.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace");
+            var code = featureGenerator.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace", out var generationWarnings);
 
             // ASSERT
             var attributes = code.Class().CustomAttributes().ToArray();
@@ -235,7 +235,7 @@ namespace Reqnroll.GeneratorTests.UnitTestProvider
             var featureGenerator = provider.CreateFeatureGenerator(addNonParallelizableMarkerForTags: ["nonparallelizable"]);
 
             // ACT
-            var code = featureGenerator.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace");
+            var code = featureGenerator.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace", out var generationWarnings);
 
             // ASSERT
             var attributes = code.Class().CustomAttributes().ToArray();
@@ -252,7 +252,7 @@ namespace Reqnroll.GeneratorTests.UnitTestProvider
             var converter = sampleTestGeneratorProvider.CreateUnitTestConverter();
 
             // ACT
-            var code = converter.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace");
+            var code = converter.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace", out var generationWarnings);
 
             // ASSERT
             var testMethodAttributeForFirstScenario = code.Class().Members().Single(m => m.Name == "SimpleScenario").CustomAttributes().Single(a => a.Name == TestMethodAttributeName);
@@ -264,7 +264,7 @@ namespace Reqnroll.GeneratorTests.UnitTestProvider
             var parser = new ReqnrollGherkinParser(parserCultureInfo ?? new CultureInfo("en-US"));
             using (var reader = new StringReader(documentSource))
             {
-                var document = parser.Parse(reader, null);
+                var document = parser.Parse(reader, new ReqnrollDocumentLocation($"dummy_Reqnroll_Location_for{nameof(MsTestGeneratorProviderTests)}"));
                 document.Should().NotBeNull();
                 return document;
             }

--- a/Tests/Reqnroll.GeneratorTests/UnitTestProvider/MsTestGeneratorProviderTests.cs
+++ b/Tests/Reqnroll.GeneratorTests/UnitTestProvider/MsTestGeneratorProviderTests.cs
@@ -128,6 +128,8 @@ namespace Reqnroll.GeneratorTests.UnitTestProvider
             descriptionAttributeForFirstScenarioOutline.ArgumentValues().First().Should().Be("Simple Scenario Outline: something");
             var descriptionAttributeForSecondScenarioOutline = code.Class().Members().Single(m => m.Name == "SimpleScenarioOutline_SomethingElse").CustomAttributes().Single(a => a.Name == TestDescriptionAttributeName);
             descriptionAttributeForSecondScenarioOutline.ArgumentValues().First().Should().Be("Simple Scenario Outline: something else");
+
+            generationWarnings.Should().BeEmpty();
         }
 
         [Fact]

--- a/Tests/Reqnroll.GeneratorTests/UnitTestProvider/MsTestV2GeneratorProviderTests.cs
+++ b/Tests/Reqnroll.GeneratorTests/UnitTestProvider/MsTestV2GeneratorProviderTests.cs
@@ -31,7 +31,7 @@ namespace Reqnroll.GeneratorTests.UnitTestProvider
             var converter = sampleTestGeneratorProvider.CreateUnitTestConverter();
 
             // ACT
-            var code = converter.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace");
+            var code = converter.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace", out var generationWarnings);
 
             // ASSERT
             code.Class().CustomAttributes().Any(a => a.Name == TestDeploymentItemAttributeName).Should().BeFalse();
@@ -54,7 +54,7 @@ namespace Reqnroll.GeneratorTests.UnitTestProvider
             var converter = sampleTestGeneratorProvider.CreateUnitTestConverter();
 
             // ACT
-            var code = converter.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace");
+            var code = converter.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace", out var generationWarnings);
 
             // ASSERT
             var deploymentItemAttributeForClass = code.Class().CustomAttributes().Single(a => a.Name == TestDeploymentItemAttributeName);
@@ -87,7 +87,7 @@ namespace Reqnroll.GeneratorTests.UnitTestProvider
             var featureGenerator = provider.CreateFeatureGenerator(addNonParallelizableMarkerForTags: new string[] { "nonparallelizable" });
 
             // ACT
-            var code = featureGenerator.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace");
+            var code = featureGenerator.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace", out var generationWarnings);
 
             // ASSERT
             var attributes = code.Class().CustomAttributes().ToArray();
@@ -111,7 +111,7 @@ namespace Reqnroll.GeneratorTests.UnitTestProvider
             var featureGenerator = provider.CreateFeatureGenerator(addNonParallelizableMarkerForTags: new string[] { "nonparallelizable" });
 
             // ACT
-            var code = featureGenerator.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace");
+            var code = featureGenerator.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace", out var generationWarnings);
 
             // ASSERT
             var attributes = code.Class().CustomAttributes().ToArray();
@@ -139,7 +139,7 @@ namespace Reqnroll.GeneratorTests.UnitTestProvider
             var featureGenerator = provider.CreateFeatureGenerator();
 
             // ACT
-            var code = featureGenerator.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace");
+            var code = featureGenerator.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace", out var generationWarnings);
 
             // ASSERT
             var testMethod = code.Class().Members().Single(m => m.Name == "SimpleScenario");
@@ -160,7 +160,7 @@ namespace Reqnroll.GeneratorTests.UnitTestProvider
             var featureGenerator = provider.CreateFeatureGenerator();
 
             // ACT
-            var code = featureGenerator.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace");
+            var code = featureGenerator.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace", out var generationWarnings);
 
             // ASSERT
             var testMethod = code.Class().Members().Single(m => m.Name == "SimpleScenario");
@@ -186,7 +186,7 @@ namespace Reqnroll.GeneratorTests.UnitTestProvider
             var featureGenerator = provider.CreateFeatureGenerator();
 
             // ACT
-            var code = featureGenerator.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace");
+            var code = featureGenerator.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace", out var generationWarnings);
 
             // ASSERT
             var testMethods = code.Class().Members().Where(x => x.CustomAttributes().Any(a => a.Name == TestMethodAttributeName)).ToList();
@@ -222,7 +222,7 @@ namespace Reqnroll.GeneratorTests.UnitTestProvider
             var featureGenerator = provider.CreateFeatureGenerator();
 
             // ACT
-            var code = featureGenerator.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace");
+            var code = featureGenerator.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace", out var generationWarnings);
 
             // ASSERT
             var testMethods = code.Class().Members().Where(x => x.CustomAttributes().Any(a => a.Name == TestMethodAttributeName)).ToList();
@@ -237,7 +237,7 @@ namespace Reqnroll.GeneratorTests.UnitTestProvider
             var parser = new ReqnrollGherkinParser(parserCultureInfo ?? new CultureInfo("en-US"));
             using (var reader = new StringReader(documentSource))
             {
-                var document = parser.Parse(reader, null);
+                var document = parser.Parse(reader, new ReqnrollDocumentLocation($"dummy_Location_for_{nameof(MsTestV2GeneratorProviderTests)}"));
                 document.Should().NotBeNull();
                 return document;
             }

--- a/Tests/Reqnroll.GeneratorTests/UnitTestProvider/NUnit3GeneratorProviderTests.cs
+++ b/Tests/Reqnroll.GeneratorTests/UnitTestProvider/NUnit3GeneratorProviderTests.cs
@@ -68,7 +68,7 @@ namespace Reqnroll.GeneratorTests.UnitTestProvider
             var converter = sampleTestGeneratorProvider.CreateUnitTestConverter();
 
             // ACT
-            var code = converter.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace");
+            var code = converter.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace", out var generationWarnings);
 
             // ASSERT
             var testMethod = code.Class().Members().Single(m => m.Name == "SimpleScenarioOutline");
@@ -109,7 +109,7 @@ namespace Reqnroll.GeneratorTests.UnitTestProvider
             var converter = sampleTestGeneratorProvider.CreateUnitTestConverter();
 
             // ACT
-            var code = converter.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace");
+            var code = converter.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace", out var generationWarnings);
 
             // ASSERT
             var testMethod = code.Class().Members().Single(m => m.Name == "SimpleScenarioOutline");
@@ -156,7 +156,7 @@ namespace Reqnroll.GeneratorTests.UnitTestProvider
             var converter = sampleTestGeneratorProvider.CreateUnitTestConverter();
 
             // ACT
-            var code = converter.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace");
+            var code = converter.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace", out var generationWarnings);
 
             // ASSERT
             var testMethod = code.Class().Members().Single(m => m.Name == "SimpleScenarioOutline");
@@ -201,7 +201,7 @@ namespace Reqnroll.GeneratorTests.UnitTestProvider
             var converter = sampleTestGeneratorProvider.CreateUnitTestConverter();
 
             // ACT
-            var code = converter.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace");
+            var code = converter.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace", out var generationWarnings);
 
             // ASSERT
             var testMethod = code.Class().Members().Single(m => m.Name == "SimpleScenarioOutline");
@@ -268,7 +268,7 @@ namespace Reqnroll.GeneratorTests.UnitTestProvider
 
                 var featureGenerator = CreateFeatureGenerator(parallelCode, addNonParallelizableMarkerForTags);
 
-                code = featureGenerator.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace");
+                code = featureGenerator.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace", out var generationWarnings);
             }
 
             return code;
@@ -295,7 +295,7 @@ namespace Reqnroll.GeneratorTests.UnitTestProvider
             var parser = new ReqnrollGherkinParser(parserCultureInfo ?? new CultureInfo("en-US"));
             using (var reader = new StringReader(documentSource))
             {
-                var document = parser.Parse(reader, null);
+                var document = parser.Parse(reader, new ReqnrollDocumentLocation($"dummy_ReqnrollLocation_for_{nameof(NUnit3GeneratorProviderTests)}"));
                 document.Should().NotBeNull();
                 return document;
             }

--- a/Tests/Reqnroll.GeneratorTests/UnitTestProvider/XUnit2TestGeneratorProviderTests.cs
+++ b/Tests/Reqnroll.GeneratorTests/UnitTestProvider/XUnit2TestGeneratorProviderTests.cs
@@ -51,7 +51,7 @@ namespace Reqnroll.GeneratorTests.UnitTestProvider
             var converter = sampleTestGeneratorProvider.CreateUnitTestConverter();
 
             // ACT
-            var code = converter.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace");
+            var code = converter.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace", out var generationWarnings);
 
             // ASSERT
             var inlineDataAttributes = code.Class()
@@ -98,7 +98,7 @@ namespace Reqnroll.GeneratorTests.UnitTestProvider
             var converter = sampleTestGeneratorProvider.CreateUnitTestConverter();
 
             // ACT
-            var code = converter.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace");
+            var code = converter.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace", out var generationWarnings);
 
             // ASSERT
             var inlineDataAttributes = code.Class()
@@ -149,7 +149,7 @@ namespace Reqnroll.GeneratorTests.UnitTestProvider
             var converter = sampleTestGeneratorProvider.CreateUnitTestConverter();
 
             // ACT
-            var code = converter.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace");
+            var code = converter.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace", out var generationWarnings);
 
             // ASSERT
             var inlineDataAttributes = code.Class()
@@ -326,7 +326,7 @@ namespace Reqnroll.GeneratorTests.UnitTestProvider
             var converter = provider.CreateUnitTestConverter();
 
             // ACT
-            var code = converter.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace");
+            var code = converter.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace", out var generationWarnings);
 
             code.Should().NotBeNull();
 
@@ -352,7 +352,7 @@ namespace Reqnroll.GeneratorTests.UnitTestProvider
             var converter = provider.CreateUnitTestConverter();
 
             // ACT
-            var code = converter.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace");
+            var code = converter.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace", out var generationWarnings);
 
             // ASSERT
             code.Should().NotBeNull();
@@ -370,7 +370,7 @@ namespace Reqnroll.GeneratorTests.UnitTestProvider
             var converter = provider.CreateUnitTestConverter();
 
             // ACT
-            var code = converter.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace");
+            var code = converter.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace", out var generationWarnings);
 
             // ASSERT
             code.Should().NotBeNull();
@@ -417,7 +417,7 @@ namespace Reqnroll.GeneratorTests.UnitTestProvider
             var featureGenerator = provider.CreateFeatureGenerator(addNonParallelizableMarkerForTags: new string[] { "nonparallelizable" });
 
             // ACT
-            var code = featureGenerator.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace");
+            var code = featureGenerator.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace", out var generationWarnings);
 
             // ASSERT
             var attributes = code.Class().CustomAttributes().ToArray();
@@ -441,7 +441,7 @@ namespace Reqnroll.GeneratorTests.UnitTestProvider
             var featureGenerator = provider.CreateFeatureGenerator(addNonParallelizableMarkerForTags: new string[] { "nonparallelizable" });
 
             // ACT
-            var code = featureGenerator.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace");
+            var code = featureGenerator.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace", out var generationWarnings);
 
             // ASSERT
             var attributes = code.Class().CustomAttributes().ToArray();
@@ -453,7 +453,7 @@ namespace Reqnroll.GeneratorTests.UnitTestProvider
             var parser = new ReqnrollGherkinParser(parserCultureInfo ?? new CultureInfo("en-US"));
             using (var reader = new StringReader(documentSource))
             {
-                var document = parser.Parse(reader, null);
+                var document = parser.Parse(reader, new ReqnrollDocumentLocation($"dummy_ReqnrollLocation_for_{nameof(XUnit2TestGeneratorProviderTests)}"));
                 document.Should().NotBeNull();
                 return document;
             }


### PR DESCRIPTION
### 🤔 What's changed?

The UnitTestFeatureGenerator's GenerateUnitTestFixture method now has an out parameter that is a collection of warnings that the generator has created. These would contain notices about problems that did not cause the generator to fail, but that the resulting Feature Test class may not be fully functional.

### ⚡️ What's your motivation? 

In preparation for Cucumber Messages, this was added to allow the generator to signal that there was a problem in processing the Gherkin feature file that may impact Reqnroll's ability to emit Messages.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)


### 📋 Checklist:


- [X] I've changed the behaviour of the code
  - [X] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [x] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
