### PR TITLE
Add week number to the RRC cache key on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,7 +344,7 @@ jobs:
     - name: Cache Reqnroll Resource Cache (RRC) folder
       uses: actions/cache@v4
       with:
-        path: ${{ env.REQNROLL_TEST_TEMPFOLDER }}/RRC
+        path: /tmp/RRC
         # Use the runner version in the key, so if new dependencies get installed we get a new cache entry
         # Also add week number so that if new tests require new cached templates they should eventually get into the RRC
         key: RRC-SystemTests-${{ runner.os }}-${{ env.ImageVersion }}-W${{ env.WeekNumber }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,15 +273,19 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set Runner ImageVersion to Env
+    - name: Set Runner ImageVersion and Week number to Env
       shell: pwsh
       run: |
         Write-Output "ImageVersion=$env:ImageVersion" >> $env:GITHUB_ENV
-    - name: Cache RRC folder
+        $WeekNumber = Get-Date -UFormat %V
+        Write-Output "WeekNumber=$WeekNumber" >> $env:GITHUB_ENV
+    - name: Cache Reqnroll Resources Cache (RRC) folder
       uses: actions/cache@v4
       with:
         path: ${{ env.REQNROLL_TEST_TEMPFOLDER }}/RRC
-        key: RRC-SystemTests-${{ runner.os }}-${{ env.ImageVersion }} # Use the runner version as key, so if new dependencies get installed we get a new cache entry
+        # Use the runner version in the key, so if new dependencies get installed we get a new cache entry
+        # Also add week number so that if new tests require new cached templates they should eventually get into the RRC
+        key: RRC-SystemTests-${{ runner.os }}-${{ env.ImageVersion }}-W${{ env.WeekNumber }}
     - name: Download packages
       uses: actions/download-artifact@v4
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,6 +292,10 @@ jobs:
       with:
         name: SystemTests
         path: Tests/Reqnroll.SystemTests/bin/
+    - name: .NET Information (before setup-dotnet)
+      run: |
+        dotnet --list-sdks
+        dotnet --list-runtimes
     - name: Setup dotnet
       uses: actions/setup-dotnet@v4
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,7 +264,8 @@ jobs:
     needs: build
     env:
       # D:\ (temporary) drive has better performance then C:\ (remote) drive on the Github Runner, so place all temporary files on D:\, see https://github.com/actions/setup-dotnet/issues/260
-      DOTNET_INSTALL_DIR: D:\dotnet
+      # DOTNET_INSTALL_DIR: D:\dotnet
+      DOTNET_INSTALL_DIR: 'C:\Program Files\dotnet'
       REQNROLL_TEST_TEMPFOLDER: D:\testrundata
       NUGET_PACKAGES: D:\nuget\packages
       # Disable telemetry, because we use many small projects

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,8 +264,7 @@ jobs:
     needs: build
     env:
       # D:\ (temporary) drive has better performance then C:\ (remote) drive on the Github Runner, so place all temporary files on D:\, see https://github.com/actions/setup-dotnet/issues/260
-      # DOTNET_INSTALL_DIR: D:\dotnet
-      DOTNET_INSTALL_DIR: 'C:\Program Files\dotnet'
+      DOTNET_INSTALL_DIR: D:\dotnet
       REQNROLL_TEST_TEMPFOLDER: D:\testrundata
       NUGET_PACKAGES: D:\nuget\packages
       # Disable telemetry, because we use many small projects
@@ -301,7 +300,10 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: | 
+          6.0.x
           7.0.x
+          8.0.x
+          9.0.x
     - name: .NET Information
       run: |
         dotnet --list-sdks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,10 +301,7 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: | 
-          6.0.x
           7.0.x
-          8.0.x
-          9.0.x
     - name: .NET Information
       run: |
         dotnet --list-sdks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,6 +264,7 @@ jobs:
     needs: build
     env:
       # D:\ (temporary) drive has better performance then C:\ (remote) drive on the Github Runner, so place all temporary files on D:\, see https://github.com/actions/setup-dotnet/issues/260
+      # It is faster to install all required .NET versions to D: drive than installing only the missing one to C: drive and use it from there.
       DOTNET_INSTALL_DIR: D:\dotnet
       REQNROLL_TEST_TEMPFOLDER: D:\testrundata
       NUGET_PACKAGES: D:\nuget\packages
@@ -279,7 +280,7 @@ jobs:
         Write-Output "ImageVersion=$env:ImageVersion" >> $env:GITHUB_ENV
         $WeekNumber = Get-Date -UFormat %V
         Write-Output "WeekNumber=$WeekNumber" >> $env:GITHUB_ENV
-    - name: Cache Reqnroll Resources Cache (RRC) folder
+    - name: Cache Reqnroll Resource Cache (RRC) folder
       uses: actions/cache@v4
       with:
         path: ${{ env.REQNROLL_TEST_TEMPFOLDER }}/RRC
@@ -300,7 +301,7 @@ jobs:
       run: |
         dotnet --list-sdks
         dotnet --list-runtimes
-    - name: Setup dotnet
+    - name: Setup required .NET SDKs
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: | 
@@ -353,6 +354,10 @@ jobs:
       with:
         name: SystemTests
         path: Tests/Reqnroll.SystemTests/bin/
+    - name: .NET Information (before setup-dotnet)
+      run: |
+        dotnet --list-sdks
+        dotnet --list-runtimes
     - name: Setup dotnet
       uses: actions/setup-dotnet@v4
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,10 +296,6 @@ jobs:
       with:
         name: SystemTests
         path: Tests/Reqnroll.SystemTests/bin/
-    - name: .NET Information (before setup-dotnet)
-      run: |
-        dotnet --list-sdks
-        dotnet --list-runtimes
     - name: Setup required .NET SDKs
       # It is faster to install all required .NET versions to D: drive than installing only the missing one to C: drive and use it from there.
       uses: actions/setup-dotnet@v4
@@ -358,10 +354,6 @@ jobs:
       with:
         name: SystemTests
         path: Tests/Reqnroll.SystemTests/bin/
-    - name: .NET Information (before setup-dotnet)
-      run: |
-        dotnet --list-sdks
-        dotnet --list-runtimes
     - name: Setup required .NET SDKs
       # The default image contains .NET 8 only, but reusing it would not provide much performance benefit
       uses: actions/setup-dotnet@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,7 +264,6 @@ jobs:
     needs: build
     env:
       # D:\ (temporary) drive has better performance then C:\ (remote) drive on the Github Runner, so place all temporary files on D:\, see https://github.com/actions/setup-dotnet/issues/260
-      # It is faster to install all required .NET versions to D: drive than installing only the missing one to C: drive and use it from there.
       DOTNET_INSTALL_DIR: D:\dotnet
       REQNROLL_TEST_TEMPFOLDER: D:\testrundata
       NUGET_PACKAGES: D:\nuget\packages
@@ -302,6 +301,7 @@ jobs:
         dotnet --list-sdks
         dotnet --list-runtimes
     - name: Setup required .NET SDKs
+      # It is faster to install all required .NET versions to D: drive than installing only the missing one to C: drive and use it from there.
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: | 
@@ -335,15 +335,19 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set Runner ImageVersion to Env
+    - name: Set Runner ImageVersion and Week number to Env
       shell: pwsh
       run: |
         Write-Output "ImageVersion=$env:ImageVersion" >> $env:GITHUB_ENV
-    - name: Cache RRC folder
+        $WeekNumber = Get-Date -UFormat %V
+        Write-Output "WeekNumber=$WeekNumber" >> $env:GITHUB_ENV
+    - name: Cache Reqnroll Resource Cache (RRC) folder
       uses: actions/cache@v4
       with:
-        path: /tmp/RRC
-        key: RRC-SystemTests-${{ runner.os }}-${{ env.ImageVersion }} # Use the runner version as key, so if new dependencies get installed we get a new cache entry
+        path: ${{ env.REQNROLL_TEST_TEMPFOLDER }}/RRC
+        # Use the runner version in the key, so if new dependencies get installed we get a new cache entry
+        # Also add week number so that if new tests require new cached templates they should eventually get into the RRC
+        key: RRC-SystemTests-${{ runner.os }}-${{ env.ImageVersion }}-W${{ env.WeekNumber }}
     - name: Download packages
       uses: actions/download-artifact@v4
       with:
@@ -358,7 +362,8 @@ jobs:
       run: |
         dotnet --list-sdks
         dotnet --list-runtimes
-    - name: Setup dotnet
+    - name: Setup required .NET SDKs
+      # The default image contains .NET 8 only, but reusing it would not provide much performance benefit
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: | 


### PR DESCRIPTION
### 🤔 What's changed?

Added week number to the RRC cache key on CI

### ⚡️ What's your motivation? 

The RRC cache depends on the system tests we create. A proper cache key would be generated based on the different package template combinations we use in tests, but it is not feasible to generate that.

Added a week number instead so that the cache is re-calculated every week once, but effective in all build during that week.

Also added a few comments on the existing CI tasks.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

### 📋 Checklist:

- [x] I've changed the behaviour of the CI

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
