### PR TITLE
Fix namespace clashes caused by empty root namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 * Fix: Exception in an `AfterFeature` hook causes the next first test failure in the next feature (#597)
 * Fix: Disposed ObjectContainer can be accessed through RegisterInstanceAs/RegisterFactoryAs/RegisterTypeAs
+* Fix: Namespace clash in generated files if no RootNamespace is defined in the project file (#633)
 
 *Contributors of this release (in alphabetical order):* @algirdasN, @clrudolphi, @loraderon, @obligaron
 

--- a/Reqnroll.Generator/CodeDom/CodeDomHelper.cs
+++ b/Reqnroll.Generator/CodeDom/CodeDomHelper.cs
@@ -156,16 +156,20 @@ namespace Reqnroll.Generator.CodeDom
             }
         }
 
+        // FIX #633 by forcing all attributes to use the global:: (GLOBAL. for VB) prefix
         public CodeAttributeDeclaration AddAttribute(CodeTypeMember codeTypeMember, string attrType)
         {
-            var codeAttributeDeclaration = new CodeAttributeDeclaration(attrType);
+            var attributeTypeReference = new CodeTypeReference(attrType, CodeTypeReferenceOptions.GlobalReference);
+            var codeAttributeDeclaration = new CodeAttributeDeclaration(attributeTypeReference);
             codeTypeMember.CustomAttributes.Add(codeAttributeDeclaration);
             return codeAttributeDeclaration;
         }
 
         public CodeAttributeDeclaration AddAttribute(CodeTypeMember codeTypeMember, string attrType, params object[] attrValues)
         {
-            var codeAttributeDeclaration = new CodeAttributeDeclaration(attrType,
+            var attributeTypeReference = new CodeTypeReference(attrType, CodeTypeReferenceOptions.GlobalReference);
+
+            var codeAttributeDeclaration = new CodeAttributeDeclaration(attributeTypeReference,
                 attrValues.Select(attrValue => new CodeAttributeArgument(new CodePrimitiveExpression(attrValue))).ToArray());
             codeTypeMember.CustomAttributes.Add(codeAttributeDeclaration);
             return codeAttributeDeclaration;
@@ -173,7 +177,9 @@ namespace Reqnroll.Generator.CodeDom
 
         public CodeAttributeDeclaration AddAttribute(CodeTypeMember codeTypeMember, string attrType, params CodeAttributeArgument[] attrArguments)
         {
-            var codeAttributeDeclaration = new CodeAttributeDeclaration(attrType, attrArguments);
+            var attributeTypeReference = new CodeTypeReference(attrType, CodeTypeReferenceOptions.GlobalReference);
+
+            var codeAttributeDeclaration = new CodeAttributeDeclaration(attributeTypeReference, attrArguments);
             codeTypeMember.CustomAttributes.Add(codeAttributeDeclaration);
             return codeAttributeDeclaration;
         }
@@ -307,6 +313,13 @@ namespace Reqnroll.Generator.CodeDom
             }
             // Global namespaces not yet supported in VB
             return typeName;
+        }
+
+        public string GetGlobalizedName(string itemName)
+        {
+            string prefix = (TargetLanguage == CodeDomProviderLanguage.CSharp) ? "global::" : "Global.";
+
+            return prefix + itemName;
         }
 
         public CodeExpression CreateOptionalArgumentExpression(string parameterName, CodeVariableReferenceExpression valueExpression)

--- a/Reqnroll.Generator/UnitTestProvider/NUnit3TestGeneratorProvider.cs
+++ b/Reqnroll.Generator/UnitTestProvider/NUnit3TestGeneratorProvider.cs
@@ -75,7 +75,7 @@ namespace Reqnroll.Generator.UnitTestProvider
             CodeDomHelper.AddAttribute(generationContext.TestClass, DESCRIPTION_ATTR, featureTitle);
             CodeDomHelper.AddAttribute(generationContext.TestClass, FIXTURELIFECYCLE_ATTR, 
                 new CodeAttributeArgument(
-                    new CodeSnippetExpression($"{LIFECYCLE_CLASS}.{LIFECYCLE_INSTANCEPERTESTCASE}")));
+                    new CodeSnippetExpression(CodeDomHelper.GetGlobalizedName($"{LIFECYCLE_CLASS}.{LIFECYCLE_INSTANCEPERTESTCASE}"))));
         }
 
         public void SetTestClassCategories(TestClassGenerationContext generationContext, IEnumerable<string> featureCategories)
@@ -95,11 +95,11 @@ namespace Reqnroll.Generator.UnitTestProvider
                                 nameof(ScenarioContext)),
                             nameof(ScenarioContext.ScenarioContainer)),
                         nameof(IObjectContainer.RegisterInstanceAs),
-                        new CodeTypeReference(TESTCONTEXT_TYPE)),
+                        new CodeTypeReference(TESTCONTEXT_TYPE, CodeTypeReferenceOptions.GlobalReference)),
                     GetTestContextExpression()));
         }
 
-        private CodeExpression GetTestContextExpression() => new CodeVariableReferenceExpression(TESTCONTEXT_INSTANCE);
+        private CodeExpression GetTestContextExpression() => new CodeVariableReferenceExpression(CodeDomHelper.GetGlobalizedName(TESTCONTEXT_INSTANCE));
 
         public void SetTestInitializeMethod(TestClassGenerationContext generationContext)
         {

--- a/Reqnroll.Generator/UnitTestProvider/XUnit2TestGeneratorProvider.cs
+++ b/Reqnroll.Generator/UnitTestProvider/XUnit2TestGeneratorProvider.cs
@@ -53,12 +53,14 @@ namespace Reqnroll.Generator.UnitTestProvider
         protected virtual CodeTypeReference CreateFixtureInterface(TestClassGenerationContext generationContext, CodeTypeReference fixtureDataType)
         {
             // Add a field for the ITestOutputHelper
-            generationContext.TestClass.Members.Add(new CodeMemberField(OUTPUT_INTERFACE, OUTPUT_INTERFACE_FIELD_NAME));
+            generationContext.TestClass.Members.Add(new CodeMemberField(new CodeTypeReference(OUTPUT_INTERFACE, CodeTypeReferenceOptions.GlobalReference), OUTPUT_INTERFACE_FIELD_NAME));
 
             // Store the fixture data type for later use in constructor
             generationContext.CustomData.Add(FIXTUREDATA_PARAMETER_NAME, fixtureDataType);
 
-            return new CodeTypeReference(ICLASSFIXTURE_INTERFACE, fixtureDataType);
+            var classFixtureCodeType =  new CodeTypeReference(ICLASSFIXTURE_INTERFACE, fixtureDataType);
+            classFixtureCodeType.Options = CodeTypeReferenceOptions.GlobalReference;
+            return classFixtureCodeType;
         }
 
         protected CodeDomHelper CodeDomHelper { get; set; }
@@ -93,7 +95,7 @@ namespace Reqnroll.Generator.UnitTestProvider
             constructor.Parameters.Add(
                 new CodeParameterDeclarationExpression((CodeTypeReference)generationContext.CustomData[FIXTUREDATA_PARAMETER_NAME], FIXTUREDATA_PARAMETER_NAME));
             constructor.Parameters.Add(
-                new CodeParameterDeclarationExpression(OUTPUT_INTERFACE, OUTPUT_INTERFACE_PARAMETER_NAME));
+                new CodeParameterDeclarationExpression(new CodeTypeReference(OUTPUT_INTERFACE, CodeTypeReferenceOptions.GlobalReference), OUTPUT_INTERFACE_PARAMETER_NAME));
 
             constructor.Statements.Add(
                 new CodeAssignStatement(
@@ -145,7 +147,7 @@ namespace Reqnroll.Generator.UnitTestProvider
             // otherwise the test runner will not be released.
 
             var callDisposeException = new CodeMethodInvokeExpression(
-                new CodeCastExpression(new CodeTypeReference(IASYNCLIFETIME_INTERFACE), new CodeThisReferenceExpression()),
+                new CodeCastExpression(new CodeTypeReference(IASYNCLIFETIME_INTERFACE, CodeTypeReferenceOptions.GlobalReference), new CodeThisReferenceExpression()),
                 "DisposeAsync");
             CodeDomHelper.MarkCodeMethodInvokeExpressionAsAwait(callDisposeException);
 
@@ -215,7 +217,7 @@ namespace Reqnroll.Generator.UnitTestProvider
                                 nameof(ScenarioContext)),
                             nameof(ScenarioContext.ScenarioContainer)),
                         nameof(IObjectContainer.RegisterInstanceAs),
-                        new CodeTypeReference(OUTPUT_INTERFACE)),
+                        new CodeTypeReference(OUTPUT_INTERFACE, CodeTypeReferenceOptions.GlobalReference)),
                     new CodeVariableReferenceExpression(OUTPUT_INTERFACE_FIELD_NAME)));
         }
 
@@ -270,7 +272,7 @@ namespace Reqnroll.Generator.UnitTestProvider
 
             // Task IAsyncLifetime.InitializeAsync() { <fixtureSetupMethod>(); }
             var initializeMethod = new CodeMemberMethod();
-            initializeMethod.PrivateImplementationType = new CodeTypeReference(IASYNCLIFETIME_INTERFACE);
+            initializeMethod.PrivateImplementationType = new CodeTypeReference(IASYNCLIFETIME_INTERFACE, CodeTypeReferenceOptions.GlobalReference);
             initializeMethod.Name = "InitializeAsync";
 
             CodeDomHelper.MarkCodeMemberMethodAsAsync(initializeMethod);
@@ -292,7 +294,7 @@ namespace Reqnroll.Generator.UnitTestProvider
 
             generationContext.TestClassCleanupMethod.Attributes |= MemberAttributes.Static;
 
-            var iasyncLifetimeInterface = new CodeTypeReference(IASYNCLIFETIME_INTERFACE);
+            var iasyncLifetimeInterface = new CodeTypeReference(IASYNCLIFETIME_INTERFACE, CodeTypeReferenceOptions.GlobalReference);
 
             // have to add the explicit object base class because of VB.NET
             _currentFixtureDataTypeDeclaration.BaseTypes.Add(typeof(object));
@@ -349,7 +351,7 @@ namespace Reqnroll.Generator.UnitTestProvider
 
             var initializeMethod = new CodeMemberMethod();
             initializeMethod.Attributes = MemberAttributes.Public;
-            initializeMethod.PrivateImplementationType = new CodeTypeReference(IASYNCLIFETIME_INTERFACE);
+            initializeMethod.PrivateImplementationType = new CodeTypeReference(IASYNCLIFETIME_INTERFACE, CodeTypeReferenceOptions.GlobalReference);
             initializeMethod.Name = "InitializeAsync";
 
             CodeDomHelper.MarkCodeMemberMethodAsAsync(initializeMethod);
@@ -363,7 +365,7 @@ namespace Reqnroll.Generator.UnitTestProvider
         {
             // xUnit supports test tear down through the IAsyncLifetime interface
 
-            var iasyncLifetimeInterface = new CodeTypeReference(IASYNCLIFETIME_INTERFACE);
+            var iasyncLifetimeInterface = new CodeTypeReference(IASYNCLIFETIME_INTERFACE, CodeTypeReferenceOptions.GlobalReference);
 
             generationContext.TestClass.BaseTypes.Add(iasyncLifetimeInterface);
 


### PR DESCRIPTION

### 🤔 What's changed?

The NUnit and xUnit plugins are changed to always refer to their test framework types via the "global::" prefix ("Global." in VB).

### ⚡️ What's your motivation? 

This fixes issue #633 in which a project file that includes a `<RootNamespace>` element but leaves it empty causes namespace collisions.

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [x ] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.


