### PR TITLE
Cucumber parameter types docs

### DIFF
--- a/Tests/Reqnroll.RuntimeTests/Bindings/CucumberExpressions/CucumberExpressionStepDefinitionBindingBuilderTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/Bindings/CucumberExpressions/CucumberExpressionStepDefinitionBindingBuilderTests.cs
@@ -1,9 +1,11 @@
-using System;
-using System.Reflection;
+using CucumberExpressions;
 using FluentAssertions;
 using Reqnroll.Bindings;
 using Reqnroll.Bindings.CucumberExpressions;
 using Reqnroll.Bindings.Reflection;
+using System;
+using System.Linq;
+using System.Reflection;
 using Xunit;
 
 namespace Reqnroll.RuntimeTests.Bindings.CucumberExpressions;
@@ -46,9 +48,9 @@ public class CucumberExpressionStepDefinitionBindingBuilderTests
         var sut = CreateSut("I have {int} cucumbers in my belly");
 
         var result = sut.BuildSingle();
-
         result.ExpressionType.Should().Be(StepDefinitionExpressionTypes.CucumberExpression);
         result.Regex?.ToString().Should().Be(@"^I have (-?\d+) cucumbers in my belly$");
+        result.Expression.Should().BeOfType<ReqnrollCucumberExpression>().Which.ParameterTypes.FirstOrDefault()?.ParameterType.Should().Be(typeof(int));
     }
 
     [Fact]
@@ -57,11 +59,12 @@ public class CucumberExpressionStepDefinitionBindingBuilderTests
         var sut = CreateSut("I have eaten cucumbers on {DateTime}");
 
         var result = sut.BuildSingle();
-
+        
         result.ExpressionType.Should().Be(StepDefinitionExpressionTypes.CucumberExpression);
         result.Regex?.ToString().Should().Be(@"^I have eaten cucumbers on (.*)$");
+        result.Expression.Should().BeOfType<ReqnrollCucumberExpression>().Which.ParameterTypes.FirstOrDefault()?.ParameterType.Should().Be(typeof(DateTime));
     }
-
+    
     [Fact]
     public void Should_build_from_expression_with_string_param()
     {

--- a/docs/automation/cucumber-expressions.md
+++ b/docs/automation/cucumber-expressions.md
@@ -22,14 +22,20 @@ To match for a simple text, just use the text as cucumber expression.
 
 ### Parameters
 
-Parameters can be defined using the `{parameter-type}` syntax. Where `parameter-type` can be any of the following:
+Parameters can be defined using the `{parameter-type}` syntax. The typing name is case sensitive. Where `parameter-type` can be any of the following:
 
-* A short name for some simple built-in types: `{int}`, `{long}`, `{byte}`, `{float}`, `{double}`, `{decimal}`
+* A short name for some simple built-in types: `{int}`, `{long}`, `{byte}`, `{float}`, `{double}`, `{decimal}`, `{DateTime}`
 * `string` (`{string}`) that matches to quoted text wrapped with either `"` or `'`. E.g., `[Given("a user {string}")]` matches to `Given a user "Marvin"` or `Given a user 'Zaphod Beeblebrox'`.
 * `word` (`{word}`) that matches to a single word without quotes. E.g., `[Given("a user {word}")]` matches to `Given a user Marvin`.
 * Empty (`{}`) that matches to anything (like `(.*)` with regex).
 * A type name without namespace that is supported by Reqnroll as a parameter type (types with built-in support, enum types and types with [custom argument conversions](step-argument-conversions)). E.g. `[When("I have {CustomColor} cucumbers in my belly")]` matches to `When I have green cucumbers in my belly` if `CustomColor` is an enum with `Green` as a value.
 * A custom type name you have specified int the `[StepArgumentTransformation]` attribute. E.g., With `[StepArgumentTransformation("v(.*)", Name = "my_version")]`, you can define a step as `[When("I download the release {my_version} of the application")]` that matches to `When I download the release v1.2.3 of the application`.
+
+#### Not supported
+Not supported (yet):
+* `{TimeSpan}`
+* `{TimeOnly}`
+* `{DateOnly}`
 
 ### Optionals, alternatives
 


### PR DESCRIPTION

### 🤔 What's changed?

Made more clear what is (not) supported for the parameter types with cucumber expressions

### ⚡️ What's your motivation? 

It was unclear if it was case sensitive and if {datetime}, {dateonly}, {timespan} and {timeonly} are working

### 🏷️ What kind of change is this?


- :book: Documentation (improvements without changing code)


### ♻️ Anything particular you want feedback on?

I test this with the CucumberExpressionStepDefinitionBindingBuilderTests. Not 100% if this was a good reverse engineer approach. 

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
