### PR TITLE
Updated copyright years on Reqnroll Documentation site

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,7 @@ import sys
 
 
 project = 'Reqnroll'
-copyright = '2024, Reqnroll'
+copyright = '2024-2025, Reqnroll'
 author = 'Reqnroll'
 
 


### PR DESCRIPTION

### 🤔 What's changed?

Updated years

### ⚡️ What's your motivation? 

This looks unmaintained, which we clearly aren't!

![image](https://github.com/user-attachments/assets/42c2b200-f8b7-4ed3-a849-dae5531ccb8d)
### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :book: Documentation (improvements without changing code)
