### PR TITLE
Fix #676: Hooks Executed Twice if Inherited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Fix: Exception in an `AfterFeature` hook causes the next first test failure in the next feature (#597)
 * Fix: Disposed ObjectContainer can be accessed through RegisterInstanceAs/RegisterFactoryAs/RegisterTypeAs
 * Fix: Namespace clash in generated files if no RootNamespace is defined in the project file (#633)
+* Fix: Hook methods in a class hierarchy are mistakenly treated as distinct from each class of the hierarchy and fired multiple times (#676)
 
 *Contributors of this release (in alphabetical order):*  @304NotModified, @algirdasN, @clrudolphi, @DrEsteban, @loraderon, @obligaron
 

--- a/Reqnroll/Bindings/Reflection/BindingMethodEqualityComparer.cs
+++ b/Reqnroll/Bindings/Reflection/BindingMethodEqualityComparer.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Reqnroll.Bindings.Reflection
+{
+    public class BindingMethodEqualityComparer : IEqualityComparer<IBindingMethod>
+    {
+        public bool Equals(IBindingMethod x, IBindingMethod y)
+        {
+            if (ReferenceEquals(x, y))
+                return true;
+            if (x is null || y is null)
+                return false;
+            if (x.GetType() != y.GetType())
+                return false;
+
+            // Special handling for RuntimeBindingMethod
+            if (x is RuntimeBindingMethod rx && y is RuntimeBindingMethod ry)
+            {
+                var miX = rx.MethodInfo;
+                var miY = ry.MethodInfo;
+                if (miX == miY)
+                    return true;
+                if (miX is null || miY is null)
+                    return false;
+                // Consider equal if MetadataToken, Module, and DeclaringType are equal
+                return miX.MetadataToken == miY.MetadataToken &&
+                       Equals(miX.Module, miY.Module) &&
+                       Equals(miX.DeclaringType, miY.DeclaringType);
+            }
+
+            // Fallback to default equality
+            return x.Equals(y);
+        }
+
+        public int GetHashCode(IBindingMethod obj)
+        {
+            if (obj is null)
+                return 0;
+            if (obj is RuntimeBindingMethod rbm && rbm.MethodInfo != null)
+            {
+                // Use MetadataToken and Module for hash code
+                unchecked
+                {
+                    int hash = 17;
+                    hash = hash * 23 + rbm.MethodInfo.MetadataToken.GetHashCode();
+                    hash = hash * 23 + (rbm.MethodInfo.Module?.GetHashCode() ?? 0);
+                    hash = hash * 23 + (rbm.MethodInfo.DeclaringType?.GetHashCode() ?? 0);
+                    return hash;
+                }
+            }
+            return obj.GetHashCode();
+        }
+    }
+}

--- a/Reqnroll/Infrastructure/TestExecutionEngine.cs
+++ b/Reqnroll/Infrastructure/TestExecutionEngine.cs
@@ -351,7 +351,7 @@ namespace Reqnroll.Infrastructure
             // The InvokeHook uses only the Method anyway...
             // The only problem could be if the same method is decorated with hook attributes using different order,
             // but in this case it is anyway impossible to tell the right ordering.
-            var uniqueMatchingHooks = matchingHooks.GroupBy(hookBinding => hookBinding.Method).Select(g => g.First());
+            var uniqueMatchingHooks = matchingHooks.GroupBy(hookBinding => hookBinding.Method, new BindingMethodEqualityComparer()).Select(g => g.First());
             Exception hookException = null;
             try
             {

--- a/Tests/Reqnroll.RuntimeTests/Bindings/BindingMethodEqualityComparerTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/Bindings/BindingMethodEqualityComparerTests.cs
@@ -1,0 +1,133 @@
+using System.Reflection;
+using FluentAssertions;
+using Reqnroll.Bindings.Reflection;
+using Xunit;
+
+namespace Reqnroll.RuntimeTests.Bindings
+{
+    public class BindingMethodEqualityComparerTests
+    {
+        private static IBindingMethod CreateBindingMethod(MethodInfo methodInfo)
+            => new RuntimeBindingMethod(methodInfo);
+
+        [Fact]
+        public void Equals_ShouldReturnTrue_ForSameMethodInfo()
+        {
+            var methodInfo = typeof(SampleClass).GetMethod(nameof(SampleClass.MethodA));
+            var bindingMethod1 = CreateBindingMethod(methodInfo);
+            var bindingMethod2 = CreateBindingMethod(methodInfo);
+            var comparer = new BindingMethodEqualityComparer();
+
+            comparer.Equals(bindingMethod1, bindingMethod2).Should().BeTrue();
+        }
+
+        [Fact]
+        public void Equals_ShouldReturnFalse_ForDifferentMethodInfos()
+        {
+            var methodInfo1 = typeof(SampleClass).GetMethod(nameof(SampleClass.MethodA));
+            var methodInfo2 = typeof(SampleClass).GetMethod(nameof(SampleClass.MethodB));
+            var bindingMethod1 = CreateBindingMethod(methodInfo1);
+            var bindingMethod2 = CreateBindingMethod(methodInfo2);
+            var comparer = new BindingMethodEqualityComparer();
+
+            comparer.Equals(bindingMethod1, bindingMethod2).Should().BeFalse();
+        }
+
+        [Fact]
+        public void Equals_ShouldReturnTrue_ForBaseAndDerivedReflectedMethod()
+        {
+            var baseMethod = typeof(BaseClass).GetMethod(nameof(BaseClass.SharedMethod));
+            var derivedMethod = typeof(DerivedClass).GetMethod(nameof(BaseClass.SharedMethod));
+            var comparer = new BindingMethodEqualityComparer();
+
+            baseMethod.Should().NotBeNull();
+            derivedMethod.Should().NotBeNull();
+            baseMethod.Equals(derivedMethod).Should().BeFalse("MethodInfo.Equals is false for base/derived reflection");
+
+            var bindingMethod1 = CreateBindingMethod(baseMethod);
+            var bindingMethod2 = CreateBindingMethod(derivedMethod);
+
+            comparer.Equals(bindingMethod1, bindingMethod2).Should().BeTrue("comparer should treat base/derived reflected method as equal");
+        }
+
+        [Fact]
+        public void Equals_ShouldReturnFalse_ForOverriddenMethodInDerived()
+        {
+            var baseMethod = typeof(BaseWithVirtual).GetMethod(nameof(BaseWithVirtual.VirtualMethod));
+            var derivedMethod = typeof(DerivedWithOverride).GetMethod(nameof(BaseWithVirtual.VirtualMethod));
+            var comparer = new BindingMethodEqualityComparer();
+
+            baseMethod.Should().NotBeNull();
+            derivedMethod.Should().NotBeNull();
+            baseMethod.Equals(derivedMethod).Should().BeFalse("MethodInfo.Equals is false for base/derived override");
+
+            var bindingMethod1 = CreateBindingMethod(baseMethod);
+            var bindingMethod2 = CreateBindingMethod(derivedMethod);
+
+            comparer.Equals(bindingMethod1, bindingMethod2).Should().BeFalse("comparer should treat base/derived override as not equal");
+        }
+
+        [Fact]
+        public void GetHashCode_ShouldBeEqual_ForEquivalentMethods()
+        {
+            var methodInfo = typeof(SampleClass).GetMethod(nameof(SampleClass.MethodA));
+            var bindingMethod1 = CreateBindingMethod(methodInfo);
+            var bindingMethod2 = CreateBindingMethod(methodInfo);
+            var comparer = new BindingMethodEqualityComparer();
+
+            comparer.GetHashCode(bindingMethod1).Should().Be(comparer.GetHashCode(bindingMethod2));
+        }
+
+        [Fact]
+        public void GetHashCode_ShouldDiffer_ForDifferentMethods()
+        {
+            var methodInfo1 = typeof(SampleClass).GetMethod(nameof(SampleClass.MethodA));
+            var methodInfo2 = typeof(SampleClass).GetMethod(nameof(SampleClass.MethodB));
+            var bindingMethod1 = CreateBindingMethod(methodInfo1);
+            var bindingMethod2 = CreateBindingMethod(methodInfo2);
+            var comparer = new BindingMethodEqualityComparer();
+
+            comparer.GetHashCode(bindingMethod1).Should().NotBe(comparer.GetHashCode(bindingMethod2));
+        }
+
+        [Fact]
+        public void GetHashCode_ShouldBeEqual_ForBaseAndDerivedReflectedMethod()
+        {
+            var baseMethod = typeof(BaseClass).GetMethod(nameof(BaseClass.SharedMethod));
+            var derivedMethod = typeof(DerivedClass).GetMethod(nameof(BaseClass.SharedMethod));
+            var comparer = new BindingMethodEqualityComparer();
+
+            var bindingMethod1 = CreateBindingMethod(baseMethod);
+            var bindingMethod2 = CreateBindingMethod(derivedMethod);
+
+            comparer.GetHashCode(bindingMethod1).Should().Be(comparer.GetHashCode(bindingMethod2));
+        }
+
+        // Helper classes for testing
+        private class SampleClass
+        {
+            public void MethodA() { }
+            public void MethodB() { }
+        }
+
+        private class BaseClass
+        {
+            public void SharedMethod() { }
+        }
+
+        private class DerivedClass : BaseClass
+        {
+            // Inherits SharedMethod as-is
+        }
+
+        private class BaseWithVirtual
+        {
+            public virtual void VirtualMethod() { }
+        }
+
+        private class DerivedWithOverride : BaseWithVirtual
+        {
+            public override void VirtualMethod() { }
+        }
+    }
+}


### PR DESCRIPTION
### 🤔 What's changed?

The `TestExecutionEngine` finds candidate `hookBindings` from the `BindingRegistry` and then groups them by `IBindingMethod` to eliminate duplicates. This change adds a custom `IEqualityComparer<IBindingMethod>` that accounts for the fact that two `IBindingMethods` should be considered the same if they belong to an inheritance hiearchy (all else equivalent except the `ReflectedType`).


### ⚡️ What's your motivation? 

Fixes #676 

### 🏷️ What kind of change is this?


- :bug: Bug fix (non-breaking change which fixes a defect)


### ♻️ Anything particular you want feedback on?

The codebase _already_ has an existing `BindingMethodComparer`, which is used for deduplicating step binding methods. 
***Should these two classes be combined?***

### 📋 Checklist:


- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
