### PR TITLE
Corrected naming of the MessageFormatter 

### DIFF
--- a/Reqnroll/Formatters/Message/MessageFormatter.cs
+++ b/Reqnroll/Formatters/Message/MessageFormatter.cs
@@ -11,16 +11,16 @@ using Reqnroll.Formatters.PayloadProcessing;
 using Reqnroll.Formatters.RuntimeSupport;
 using Reqnroll.Utils;
 
-namespace Reqnroll.Formatters.Messages;
+namespace Reqnroll.Formatters.Message;
 
 /// <summary>
 /// Produces a Cucumber Messages output (.ndjson) file.
 /// </summary>
-public class MessagesFormatter : FileWritingFormatterBase
+public class MessageFormatter : FileWritingFormatterBase
 {
     private readonly byte[] _newLineBytes = Encoding.UTF8.GetBytes(Environment.NewLine);
 
-    public MessagesFormatter(IFormattersConfigurationProvider configurationProvider, IFormatterLog logger, IFileSystem fileSystem) : base(configurationProvider, logger, fileSystem, "messages", ".ndjson", "reqnroll_report.ndjson")
+    public MessageFormatter(IFormattersConfigurationProvider configurationProvider, IFormatterLog logger, IFileSystem fileSystem) : base(configurationProvider, logger, fileSystem, "message", ".ndjson", "reqnroll_report.ndjson")
     {
     }
 

--- a/Reqnroll/Infrastructure/DefaultDependencyProvider.cs
+++ b/Reqnroll/Infrastructure/DefaultDependencyProvider.cs
@@ -117,7 +117,7 @@ namespace Reqnroll.Infrastructure
             container.RegisterTypeAs<FileBasedConfigurationResolver, IFormattersConfigurationResolver>("fileBasedResolver");
             container.RegisterTypeAs<EnvironmentConfigurationResolver, IFormattersEnvironmentOverrideConfigurationResolver>();
             container.RegisterTypeAs<FormattersConfigurationProvider, IFormattersConfigurationProvider>();
-            container.RegisterTypeAs<MessageFormatter, ICucumberMessageFormatter>("messages");
+            container.RegisterTypeAs<MessageFormatter, ICucumberMessageFormatter>("message");
             container.RegisterTypeAs<HtmlFormatter, ICucumberMessageFormatter>("html");
             container.RegisterTypeAs<CucumberMessageBroker, ICucumberMessageBroker>();
             container.RegisterTypeAs<CucumberMessagePublisher, ICucumberMessagePublisher>();

--- a/Reqnroll/Infrastructure/DefaultDependencyProvider.cs
+++ b/Reqnroll/Infrastructure/DefaultDependencyProvider.cs
@@ -15,7 +15,7 @@ using Reqnroll.FileAccess;
 using Reqnroll.Formatters;
 using Reqnroll.Formatters.Configuration;
 using Reqnroll.Formatters.Html;
-using Reqnroll.Formatters.Messages;
+using Reqnroll.Formatters.Message;
 using Reqnroll.Formatters.PayloadProcessing.Cucumber;
 using Reqnroll.Formatters.PubSub;
 using Reqnroll.Formatters.RuntimeSupport;
@@ -117,7 +117,7 @@ namespace Reqnroll.Infrastructure
             container.RegisterTypeAs<FileBasedConfigurationResolver, IFormattersConfigurationResolver>("fileBasedResolver");
             container.RegisterTypeAs<EnvironmentConfigurationResolver, IFormattersEnvironmentOverrideConfigurationResolver>();
             container.RegisterTypeAs<FormattersConfigurationProvider, IFormattersConfigurationProvider>();
-            container.RegisterTypeAs<MessagesFormatter, ICucumberMessageFormatter>("messages");
+            container.RegisterTypeAs<MessageFormatter, ICucumberMessageFormatter>("messages");
             container.RegisterTypeAs<HtmlFormatter, ICucumberMessageFormatter>("html");
             container.RegisterTypeAs<CucumberMessageBroker, ICucumberMessageBroker>();
             container.RegisterTypeAs<CucumberMessagePublisher, ICucumberMessagePublisher>();

--- a/Tests/Reqnroll.Formatters.Tests/MessagesCompatibilityTestBase.cs
+++ b/Tests/Reqnroll.Formatters.Tests/MessagesCompatibilityTestBase.cs
@@ -42,7 +42,7 @@ public class MessagesCompatibilityTestBase : SystemTestBase
             ndjsonFileName = Path.Combine(path, ndjsonFileName);
             htmlFileName = Path.Combine(path, htmlFileName);
         }
-        string formatters = "{\"formatters\" : {\"messages\" : { \"outputFilePath\" : \"" + ndjsonFileName.Replace("\\", "\\\\") + "\" }," +
+        string formatters = "{\"formatters\" : {\"message\" : { \"outputFilePath\" : \"" + ndjsonFileName.Replace("\\", "\\\\") + "\" }," +
                             " \"html\" : { \"outputFilePath\" : \"" + htmlFileName.Replace("\\", "\\\\") + "\" } } }";
 
         _testSuiteInitializationDriver.OverrideCucumberMessagesFormatters = formatters;
@@ -167,7 +167,7 @@ public class MessagesCompatibilityTestBase : SystemTestBase
         };
 
         FormattersConfigurationProvider configurationProvider = new FormattersConfigurationProvider(resolvers, configEnvResolver, new FormattersDisabledOverrideProvider(env));
-        configurationProvider.GetFormatterConfigurationByName("messages").TryGetValue("outputFilePath", out var outputFilePathElement);
+        configurationProvider.GetFormatterConfigurationByName("message").TryGetValue("outputFilePath", out var outputFilePathElement);
 
         var outputFilePath = outputFilePathElement!.ToString();
         if (string.IsNullOrEmpty(outputFilePath))

--- a/Tests/Reqnroll.Formatters.Tests/reqnroll.json
+++ b/Tests/Reqnroll.Formatters.Tests/reqnroll.json
@@ -4,7 +4,7 @@
   "bindingAssemblies": [
   ],
   "formatters": {
-    "messages": {
+    "message": {
       "outputFilePath": "[BaseDirectory]/CucumberMessages/reqnroll_report.ndjson"
     }
   }

--- a/Tests/Reqnroll.Formatters.Tests/reqnrollConfigurationWithExternalAssembly.json
+++ b/Tests/Reqnroll.Formatters.Tests/reqnrollConfigurationWithExternalAssembly.json
@@ -7,7 +7,7 @@
     }
   ],
   "formatters": {
-    "messages": {
+    "message": {
       "outputFilePath": "[BaseDirectory]/CucumberMessages/reqnroll_report.ndjson"
     }
   }

--- a/Tests/Reqnroll.Formatters.Tests/reqnroll_withBothFormatters.json
+++ b/Tests/Reqnroll.Formatters.Tests/reqnroll_withBothFormatters.json
@@ -4,7 +4,7 @@
   "bindingAssemblies": [
   ],
   "formatters": {
-    "messages": {
+    "message": {
       "outputFilePath": "[BaseDirectory]/CucumberMessages/reqnroll_report.ndjson"
     },
     "html": {

--- a/Tests/Reqnroll.RuntimeTests/Formatters/Configuration/EnvironmentConfigurationResolverTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/Formatters/Configuration/EnvironmentConfigurationResolverTests.cs
@@ -63,7 +63,7 @@ public class EnvironmentConfigurationResolverTests
         var json = """
                    {"formatters": {
                        "html": { "outputFilePath": "forHtml" }, 
-                       "messages": { "outputFilePath": "forMessages" } 
+                       "message": { "outputFilePath": "forMessages" } 
                        }
                    }
                    """;
@@ -77,7 +77,7 @@ public class EnvironmentConfigurationResolverTests
         // Assert
         Assert.Equal(2, result.Count);
         var first = result["html"];
-        var second = result["messages"];
+        var second = result["message"];
         Assert.Equal("forHtml", first["outputFilePath"]);
         Assert.Equal("forMessages", second["outputFilePath"]);
     }


### PR DESCRIPTION


### 🤔 What's changed?

Corrected naming of the MessageFormatter to match the form of the word as used by the Cucumber ecosystem.

### ⚡️ What's your motivation? 

To stay aligned with the Cucumber project.

### 🏷️ What kind of change is this?


- :bug: Bug fix (non-breaking change which fixes a defect)


### 📋 Checklist:


- [X] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
