### PR TITLE
Fix for 690 to properly add the default extension

### DIFF
--- a/Reqnroll/Formatters/FileWritingFormatterBase.cs
+++ b/Reqnroll/Formatters/FileWritingFormatterBase.cs
@@ -51,7 +51,7 @@ public abstract class FileWritingFormatterBase : FormatterBase
         if (fileName.IsNullOrEmpty())
             fileName = _defaultFileName;
 
-        if (!fileName.EndsWith(_defaultFileExtension, StringComparison.OrdinalIgnoreCase))
+        if (Path.GetExtension(fileName).IsNullOrEmpty())
         {
             fileName += _defaultFileExtension;
         }

--- a/Tests/Reqnroll.RuntimeTests/Formatters/PubSub/FileWriterBaseTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/Formatters/PubSub/FileWriterBaseTests.cs
@@ -152,6 +152,46 @@ public class FileWritingFormatterBaseTests
         Assert.NotNull(_sut.LastOutputPath);
         Assert.Equal($".{sp}aFileName.txt", _sut.LastOutputPath);
     }
+
+    [Fact]
+    public async Task LaunchFileSink_Should_Apply_Default_Extension_When_Filename_Has_No_Extension()
+    {
+        // Arrange
+        var sp = Path.DirectorySeparatorChar;
+        _configurationMock.Setup(c => c.Enabled).Returns(true);
+        _configurationMock.Setup(c => c.GetFormatterConfigurationByName("testPlugin"))
+            .Returns(new Dictionary<string, object> { { "outputFilePath", "myoutput" } });
+        _fileSystemMock.Setup(fs => fs.DirectoryExists(It.IsAny<string>())).Returns(true);
+
+        // Act
+        _sut.LaunchSink(_brokerMock.Object);
+        await _sut.CloseAsync();
+
+        // Assert
+        Assert.NotNull(_sut.LastOutputPath);
+        Assert.EndsWith($".{sp}myoutput.txt", _sut.LastOutputPath);
+    }
+
+    [Fact]
+    public async Task LaunchFileSink_Should_Not_Apply_Default_Extension_When_Filename_Has_Extension()
+    {
+        // Arrange
+        var sp = Path.DirectorySeparatorChar;
+        _configurationMock.Setup(c => c.Enabled).Returns(true);
+        _configurationMock.Setup(c => c.GetFormatterConfigurationByName("testPlugin"))
+            .Returns(new Dictionary<string, object> { { "outputFilePath", "myoutput.log" } });
+        _fileSystemMock.Setup(fs => fs.DirectoryExists(It.IsAny<string>())).Returns(true);
+
+        // Act
+        _sut.LaunchSink(_brokerMock.Object);
+        await _sut.CloseAsync();
+
+        // Assert
+        Assert.NotNull(_sut.LastOutputPath);
+        Assert.EndsWith($".{sp}myoutput.log", _sut.LastOutputPath);
+        Assert.DoesNotContain(".txt", _sut.LastOutputPath.Replace(".txt", "", StringComparison.OrdinalIgnoreCase));
+    }
+
     [Fact]
     public async Task PublishAsync_Should_Write_Envelopes()
     {


### PR DESCRIPTION
### 🤔 What's changed?

Fix for #690  to properly add the default extension when none given and not overwrite one already present.


### 🏷️ What kind of change is this?


- :bug: Bug fix (non-breaking change which fixes a defect)




### 📋 Checklist:



- [X] I've changed the behaviour of the code
  - [X] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
