### PR TITLE
dotnet test - less verbose logging & no-restore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,7 @@ jobs:
 
         # Calculate 'test_params'
         $gitHubActionsLoggerSettings = '"GitHubActions;summary.includePassedTests=true;summary.includeSkippedTests=true;annotations.titleFormat=[@traits.Category] @test;annotations.messageFormat=@error\n@trace"'
-        $testParams = "--verbosity normal --logger $gitHubActionsLoggerSettings -- RunConfiguration.CollectSourceInformation=true RunConfiguration.TreatNoTestsAsError=true"
+        $testParams = "--verbosity minimal --logger $gitHubActionsLoggerSettings -- RunConfiguration.CollectSourceInformation=true RunConfiguration.TreatNoTestsAsError=true"
         Write-Output "test_params=$testParams" >> $env:GITHUB_OUTPUT
         Write-Output "Test Params: $testParams"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,7 @@ jobs:
 
         # Calculate 'test_params'
         $gitHubActionsLoggerSettings = '"GitHubActions;summary.includePassedTests=true;summary.includeSkippedTests=true;annotations.titleFormat=[@traits.Category] @test;annotations.messageFormat=@error\n@trace"'
-        $testParams = "--verbosity quiet --logger $gitHubActionsLoggerSettings -- RunConfiguration.CollectSourceInformation=true RunConfiguration.TreatNoTestsAsError=true"
+        $testParams = "--no-restore --verbosity minimal --logger $gitHubActionsLoggerSettings -- RunConfiguration.CollectSourceInformation=true RunConfiguration.TreatNoTestsAsError=true"
         Write-Output "test_params=$testParams" >> $env:GITHUB_OUTPUT
         Write-Output "Test Params: $testParams"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,7 @@ jobs:
 
         # Calculate 'test_params'
         $gitHubActionsLoggerSettings = '"GitHubActions;summary.includePassedTests=true;summary.includeSkippedTests=true;annotations.titleFormat=[@traits.Category] @test;annotations.messageFormat=@error\n@trace"'
-        $testParams = "--verbosity minimal --logger $gitHubActionsLoggerSettings -- RunConfiguration.CollectSourceInformation=true RunConfiguration.TreatNoTestsAsError=true"
+        $testParams = "--verbosity quiet --logger $gitHubActionsLoggerSettings -- RunConfiguration.CollectSourceInformation=true RunConfiguration.TreatNoTestsAsError=true"
         Write-Output "test_params=$testParams" >> $env:GITHUB_OUTPUT
         Write-Output "Test Params: $testParams"
 


### PR DESCRIPTION
### 🤔 What's changed?

- moved from normal to minimal
- no-restore on dotnet test

this still logs warnings

<img width="1064" height="368" alt="image" src="https://github.com/user-attachments/assets/fc854805-be1c-421d-a6db-02f98861ffc6" />

https://learn.microsoft.com/en-us/visualstudio/msbuild/obtaining-build-logs-with-msbuild?view=vs-2019#verbosity-settings

### ⚡️ What's your motivation? 

logs of 2000+ lines are hard to read 
CI build performance
the restore check is a NOOP, but confusing in logs - I like to check the dotnet rest results, not a NOOP restore
quiet is also an option, but not that much benefit, So minimal is fine

logging:

#### With normal
2500+ lines 
<img width="1445" height="886" alt="image" src="https://github.com/user-attachments/assets/3e358d2c-4b0d-42d5-943c-2ba330375370" />

<img width="1324" height="611" alt="image" src="https://github.com/user-attachments/assets/458c27a2-8c2e-4f0a-a2aa-1ecaedaa945c" />


#### with minimal:
~410 lines, but not really useful

<img width="1523" height="777" alt="image" src="https://github.com/user-attachments/assets/000ba1c2-6bc6-4c1f-9b1d-bcbafe2bc224" />

<img width="973" height="322" alt="image" src="https://github.com/user-attachments/assets/40491860-d6e4-40dc-b9cd-ce8619d3d587" />

at lot of "default config"
<img width="925" height="659" alt="image" src="https://github.com/user-attachments/assets/367a4a9d-adff-468a-afbf-b43f3e74d036" />

#### With quiet
~380 lines
not very different to minimal

<img width="1578" height="589" alt="image" src="https://github.com/user-attachments/assets/8e9fe518-efb1-480d-b803-c4f0a3533618" />

<img width="920" height="582" alt="image" src="https://github.com/user-attachments/assets/4cbad47c-c15c-44b4-9ef7-8956a7043cb4" />


### 🏷️ What kind of change is this?


- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)


