### PR TITLE
Remove [Serializable] from exceptions, including serialisation constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Renamed Regex for all step definition attributes to Expression, as it has a cucumber expression or a regular expression (regex) that matches the step text. (Breaking change) (#639)
 * Introduced a new BuildMetadata class to encapsulate CI metadata properties such as ProductName, BuildUrl, BuildNumber, Remote, Revision, Branch, and Tag. These will be used to populate data in Cucumber Messages. (#658)
 * Added ExpressionType option (cucumber/regex) to [Given], [When] and [Then] attributes (#663)
+* Remove [Serializable] from exceptions (#738)
 * Updated Reqnroll project template to add TUnit test framework support and remove EOL .NET versions (6.0, 7.0), added .NET 9.0 support (#701)
 * Removed support for end-of-life .NET frameworks (.NET 6, .NET 7, .NET Core) (#706)
 * Allow detecting skipped or pending execution status by the unit test providers (#732)

--- a/Plugins/Reqnroll.Microsoft.Extensions.DependencyInjection.ReqnrollPlugin/InvalidScenarioDependenciesException.cs
+++ b/Plugins/Reqnroll.Microsoft.Extensions.DependencyInjection.ReqnrollPlugin/InvalidScenarioDependenciesException.cs
@@ -2,7 +2,6 @@
 
 namespace Reqnroll.Microsoft.Extensions.DependencyInjection;
 
-[Serializable]
 public class InvalidScenarioDependenciesException(string reason) : ReqnrollException("[ScenarioDependencies] should return IServiceCollection but " + reason)
 {
     public override string HelpLink { get; set; } = "https://go.reqnroll.net/doc-msdi";

--- a/Plugins/Reqnroll.Microsoft.Extensions.DependencyInjection.ReqnrollPlugin/MissingScenarioDependenciesException.cs
+++ b/Plugins/Reqnroll.Microsoft.Extensions.DependencyInjection.ReqnrollPlugin/MissingScenarioDependenciesException.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 
 namespace Reqnroll.Microsoft.Extensions.DependencyInjection
 {
-    [Serializable]
     public class MissingScenarioDependenciesException : ReqnrollException
     {
         public MissingScenarioDependenciesException()

--- a/Plugins/Reqnroll.xUnit.ReqnrollPlugin/XUnitInconclusiveException.cs
+++ b/Plugins/Reqnroll.xUnit.ReqnrollPlugin/XUnitInconclusiveException.cs
@@ -1,9 +1,7 @@
 using System;
-using System.Runtime.Serialization;
 
 namespace Reqnroll.xUnit.ReqnrollPlugin
 {
-    [Serializable]
     public class XUnitInconclusiveException : Exception
     {
         public XUnitInconclusiveException() : this("The step is inconclusive")
@@ -17,11 +15,5 @@ namespace Reqnroll.xUnit.ReqnrollPlugin
         public XUnitInconclusiveException(string message, Exception inner) : base(message, inner)
         {
         }
-
-        protected XUnitInconclusiveException(
-            SerializationInfo info,
-            StreamingContext context) : base(info, context)
-        {
         }
-    }
 }

--- a/Plugins/Reqnroll.xUnit.ReqnrollPlugin/XUnitPendingStepException.cs
+++ b/Plugins/Reqnroll.xUnit.ReqnrollPlugin/XUnitPendingStepException.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Runtime.Serialization;
 
 // the exceptions are part of the public API, keep them in Reqnroll namespace
 // ReSharper disable once CheckNamespace
@@ -16,10 +15,6 @@ namespace Reqnroll.xUnit.ReqnrollPlugin
         }
 
         public XUnitPendingStepException(string message, Exception inner) : base(message, inner)
-        {
-        }
-
-        protected XUnitPendingStepException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
     }

--- a/Reqnroll.Generator/TestGeneratorException.cs
+++ b/Reqnroll.Generator/TestGeneratorException.cs
@@ -1,9 +1,7 @@
 using System;
-using System.Runtime.Serialization;
 
 namespace Reqnroll.Generator
 {
-    [Serializable]
     public class TestGeneratorException : Exception
     {
         public TestGeneratorException()
@@ -15,12 +13,6 @@ namespace Reqnroll.Generator
         }
 
         public TestGeneratorException(string message, Exception inner) : base(message, inner)
-        {
-        }
-
-        protected TestGeneratorException(
-            SerializationInfo info,
-            StreamingContext context) : base(info, context)
         {
         }
     }

--- a/Reqnroll/BoDi/ObjectContainerException.cs
+++ b/Reqnroll/BoDi/ObjectContainerException.cs
@@ -1,19 +1,11 @@
 ﻿using System;
 using System.Linq;
-using System.Runtime.Serialization;
 
 namespace Reqnroll.BoDi;
 
-[Serializable]
 public class ObjectContainerException : Exception
 {
     public ObjectContainerException(string message, Type[] resolutionPath) : base(GetMessage(message, resolutionPath))
-    {
-    }
-
-    protected ObjectContainerException(
-        SerializationInfo info,
-        StreamingContext context) : base(info, context)
     {
     }
 

--- a/Reqnroll/ErrorHandling/AmbiguousBindingException.cs
+++ b/Reqnroll/ErrorHandling/AmbiguousBindingException.cs
@@ -13,7 +13,7 @@ namespace Reqnroll;
 /// </summary>
 public class AmbiguousBindingException : BindingException
 {
-    public IEnumerable<BindingMatch> Matches { get; private set; }
+    public IEnumerable<BindingMatch> Matches { get; private set; } = [];
 
     public AmbiguousBindingException(string message) : base(message)
     {
@@ -25,6 +25,6 @@ public class AmbiguousBindingException : BindingException
 
     public AmbiguousBindingException(string message, IEnumerable<BindingMatch> matches) : base(message)
     {
-        Matches = new List<BindingMatch>(matches);
+        Matches = [.. matches];
     }
 }

--- a/Reqnroll/ErrorHandling/AmbiguousBindingException.cs
+++ b/Reqnroll/ErrorHandling/AmbiguousBindingException.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Runtime.Serialization;
 using Reqnroll.Bindings;
 
 // the exceptions are part of the public API, keep them in Reqnroll namespace
@@ -12,7 +11,6 @@ namespace Reqnroll;
 /// When emitting the Cucumber Message that describes an ambiguous matching situation, the Message will contain the list of possible matches.
 /// We use this subclass of BindingException to convey that information.
 /// </summary>
-[Serializable]
 public class AmbiguousBindingException : BindingException
 {
     public IEnumerable<BindingMatch> Matches { get; private set; }
@@ -28,28 +26,5 @@ public class AmbiguousBindingException : BindingException
     public AmbiguousBindingException(string message, IEnumerable<BindingMatch> matches) : base(message)
     {
         Matches = new List<BindingMatch>(matches);
-    }
-
-    protected AmbiguousBindingException(
-        SerializationInfo info,
-        StreamingContext context) : base(info, context)
-    {
-        if (info == null)
-        {
-            throw new ArgumentNullException(nameof(info));
-        }
-
-        Matches = (List<BindingMatch>)info.GetValue("Matches", typeof(List<BindingMatch>));
-    }
-
-    public override void GetObjectData(SerializationInfo info, StreamingContext context)
-    {
-        if (info == null)
-        {
-            throw new ArgumentNullException(nameof(info));
-        }
-
-        base.GetObjectData(info, context);
-        info.AddValue("Matches", Matches);
     }
 }

--- a/Reqnroll/ErrorHandling/BindingException.cs
+++ b/Reqnroll/ErrorHandling/BindingException.cs
@@ -1,10 +1,8 @@
 using System;
-using System.Runtime.Serialization;
 
 // the exceptions are part of the public API, keep them in Reqnroll namespace
 namespace Reqnroll
 {
-    [Serializable]
     public class BindingException : ReqnrollException
     {
         public BindingException() : base("Binding error occurred.")
@@ -16,12 +14,6 @@ namespace Reqnroll
         }
 
         public BindingException(string message, Exception inner) : base(message, inner)
-        {
-        }
-
-        protected BindingException(
-            SerializationInfo info,
-            StreamingContext context) : base(info, context)
         {
         }
     }

--- a/Reqnroll/ErrorHandling/ColumnCouldNotBeBoundException.cs
+++ b/Reqnroll/ErrorHandling/ColumnCouldNotBeBoundException.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Collections.Generic;
-using System.Runtime.Serialization;
 
 // the exceptions are part of the public API, keep them in Reqnroll namespace
 namespace Reqnroll
 {
-    [Serializable]
     public class ColumnCouldNotBeBoundException : Exception
     {
         public IList<string> Columns { get; }
@@ -31,11 +29,6 @@ namespace Reqnroll
         public ColumnCouldNotBeBoundException(string message, Exception innerException, IList<string> columns) : base(message, innerException)
         {
             Columns = columns;
-        }
-
-        /// <inheritdoc />
-        protected ColumnCouldNotBeBoundException(SerializationInfo info, StreamingContext context) : base(info, context)
-        {
         }
 
         private static string CreateMessage(IList<string> columns)

--- a/Reqnroll/ErrorHandling/MissingStepDefinitionException.cs
+++ b/Reqnroll/ErrorHandling/MissingStepDefinitionException.cs
@@ -1,21 +1,12 @@
 using System;
-using System.Runtime.Serialization;
 
 // the exceptions are part of the public API, keep them in Reqnroll namespace
 namespace Reqnroll
 {
-    [Serializable]
     public class MissingStepDefinitionException : ReqnrollException
     {
         public MissingStepDefinitionException()
             : base("No matching step definition found for one or more steps.")
-        {
-        }
-
-        protected MissingStepDefinitionException(
-            SerializationInfo info,
-            StreamingContext context)
-            : base(info, context)
         {
         }
     }

--- a/Reqnroll/ErrorHandling/ReqnrollException.cs
+++ b/Reqnroll/ErrorHandling/ReqnrollException.cs
@@ -1,11 +1,9 @@
 using System;
-using System.Runtime.Serialization;
 
 // the exceptions are part of the public API, keep them in Reqnroll namespace
 // ReSharper disable once CheckNamespace
 namespace Reqnroll
 {
-    [Serializable]
     public class ReqnrollException : Exception
     {
         public ReqnrollException()
@@ -17,12 +15,6 @@ namespace Reqnroll
         }
 
         public ReqnrollException(string message, Exception inner) : base(message, inner)
-        {
-        }
-
-        protected ReqnrollException(
-            SerializationInfo info,
-            StreamingContext context) : base(info, context)
         {
         }
     }


### PR DESCRIPTION
### 🤔 What's changed?

- Removed [Serializable] from exceptions, and only from exceptions
- For those types:
  - Removed constructors with SerializationInfo on exceptions - there are no results anymore for the search text "SerializationInfo" in this solution
  -   Removed GetObjectData methods - there are no results anymore for the search text "GetObjectData" in this solution
  -  Removed `using System.Runtime.Serialization`, there is also no result for the search text "System.Runtime.Serialization" in this solution
 
Also improved a null property, see comment of Copilot

### ⚡️ What's your motivation? 

Fixes #736 

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->


- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

