### PR TITLE
Dispose cancellationTokenSource in FormatterBase

### DIFF
--- a/Reqnroll/Formatters/FormatterBase.cs
+++ b/Reqnroll/Formatters/FormatterBase.cs
@@ -182,6 +182,7 @@ public abstract class FormatterBase : ICucumberMessageFormatter, IDisposable
                 {
                     Logger.WriteMessage($"DEBUG: Formatters:PluginBase.Dispose - skipping wait on formatters task {Name}.");
                 }
+                _cancellationTokenSource.Dispose();
             }
             catch (System.Exception e)
             {


### PR DESCRIPTION
<!---
Thanks for helping to make Reqnroll better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻

You can delete these comment sections as you process them.
-->

### 🤔 What's changed?

Dispose cancellationTokenSource in FormatterBase.Dispose()

<!-- Describe your changes in detail -->

### ⚡️ What's your motivation? 

Found this with a SonarQube analysis.
CancellationTokenSource is disposeable and also the docs says we should dispose

<img width="898" height="221" alt="image" src="https://github.com/user-attachments/assets/d1b74677-c255-4517-8c7b-a1b0fe6d78b2" />

https://learn.microsoft.com/en-us/dotnet/api/system.threading.cancellationtokensource?view=net-9.0

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->


- :bug: Bug fix (non-breaking change which fixes a defect)
