### PR TITLE
Remove workaround for populating skipped step envelope (#737)

### DIFF
--- a/Reqnroll/Formatters/ExecutionTracking/TestStepExecutionTracker.cs
+++ b/Reqnroll/Formatters/ExecutionTracking/TestStepExecutionTracker.cs
@@ -1,4 +1,4 @@
-﻿using Io.Cucumber.Messages.Types;
+using Io.Cucumber.Messages.Types;
 using Reqnroll.Formatters.PayloadProcessing.Cucumber;
 using Reqnroll.Events;
 using System.Threading.Tasks;
@@ -34,9 +34,9 @@ public class TestStepExecutionTracker(TestCaseExecutionTracker parentTracker, IC
             testStepTracker?.ProcessEvent(stepFinishedEvent);
         }
 
-        Exception = stepFinishedEvent.ScenarioContext.TestError;
         StepFinishedAt = stepFinishedEvent.Timestamp;
         Status = stepFinishedEvent.StepContext.Status;
+        Exception = stepFinishedEvent.StepContext.StepError;
 
         await Publisher.PublishAsync(Envelope.Create(MessageFactory.ToTestStepFinished(this)));
     }

--- a/Reqnroll/Infrastructure/TestExecutionEngine.cs
+++ b/Reqnroll/Infrastructure/TestExecutionEngine.cs
@@ -697,6 +697,7 @@ namespace Reqnroll.Infrastructure
         private void UpdateStatusOnStepFailure(ScenarioExecutionStatus stepStatus, Exception exception)
         {
             _contextManager.StepContext.Status = stepStatus;
+            _contextManager.StepContext.StepError = exception;
 
             bool ShouldOverrideScenarioStatus(ScenarioExecutionStatus currentStatus, ScenarioExecutionStatus newStatus)
             {

--- a/Reqnroll/Infrastructure/TestExecutionEngine.cs
+++ b/Reqnroll/Infrastructure/TestExecutionEngine.cs
@@ -630,18 +630,8 @@ namespace Reqnroll.Infrastructure
                     UpdateStatusOnStepFailure(stepStatus, stepException);
 
                 // 8. Publish StepFinishedEvent event
-                //HACK: temporary hack
-                var testErrorBackup = contextManager.ScenarioContext.TestError;
-                if (stepStatus == ScenarioExecutionStatus.Skipped)
-                    contextManager.ScenarioContext.TestError = null; // clear the error to avoid it being propagated to the step finished event
-                //HACK: end
-
                 var stepFinishedEvent = new StepFinishedEvent(contextManager.FeatureContext, contextManager.ScenarioContext, contextManager.StepContext);
                 await _testThreadExecutionEventPublisher.PublishEventAsync(stepFinishedEvent);
-
-                //HACK: temporary hack
-                contextManager.ScenarioContext.TestError = testErrorBackup; // restore the error for further processing
-                //HACK: end
 
                 // 9. Invoke AfterStep hook
                 if (onStepStartHookExecuted)

--- a/Reqnroll/ScenarioStepContext.cs
+++ b/Reqnroll/ScenarioStepContext.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Diagnostics;
 using System.Threading;
 
@@ -8,6 +9,8 @@ namespace Reqnroll
         StepInfo StepInfo { get; }
 
         ScenarioExecutionStatus Status { get; set; }
+        Exception StepError { get; set; }
+
     }
 
     public class ScenarioStepContext : ReqnrollContext, IScenarioStepContext
@@ -45,6 +48,7 @@ namespace Reqnroll
         public StepInfo StepInfo { get; private set; }
 
         public ScenarioExecutionStatus Status { get; set; }
+        public Exception StepError { get; set; }
 
         internal ScenarioStepContext(StepInfo stepInfo)
         {

--- a/Tests/Reqnroll.Formatters.Tests/MessagesCompatibilityTests.cs
+++ b/Tests/Reqnroll.Formatters.Tests/MessagesCompatibilityTests.cs
@@ -20,6 +20,7 @@ public class MessagesCompatibilityTests : MessagesCompatibilityTestBase
     [DataRow("undefined", "Undefined steps")]
     [DataRow("stack-traces", "Stack traces")]
     [DataRow("rules", "Usage of a `Rule`")]
+    [DataRow("skipped", "Skipping scenarios")]
     // These CCK scenario examples produce Cucumber Messages that are materially compliant with the CCK.
     // The messages produced match the CCK expected messages, with exceptions for things
     // that are not material to the CCK spec (such as IDs don't have to be generated in the same order, timestamps don't have to match, etc.)
@@ -77,7 +78,6 @@ public class MessagesCompatibilityTests : MessagesCompatibilityTestBase
     [TestMethod]
     [DataRow("attachments", "Attachments")]
     [DataRow("hooks-named", "Hooks - Named")]
-    [DataRow("skipped", "Skipping scenarios")]
     [DataRow("unknown-parameter-type", "Unknown Parameter Types")]
     // These scenarios are from the CCK, but Reqnroll cannot provide a compliant implementation. This is usually the result of differences in behavior or support of Gherkin features.
     // When these scenarios are run, expect them to fail.

--- a/Tests/Reqnroll.Formatters.Tests/Samples/Resources/skipped/skipped.cs
+++ b/Tests/Reqnroll.Formatters.Tests/Samples/Resources/skipped/skipped.cs
@@ -1,4 +1,4 @@
-﻿using Reqnroll;
+using Reqnroll;
 using Reqnroll.UnitTestProvider;
 using System;
 using System.Collections.Generic;
@@ -16,6 +16,12 @@ namespace CucumberMessages.CompatibilityTests.CCK.skipped
         public Skipped(IUnitTestRuntimeProvider unitTestRuntimeProvider)
         {
             _unitTestRuntimeProvider = unitTestRuntimeProvider;
+        }
+
+        [BeforeScenario("@skip")]
+        public void BeforeScenarioWithSkip()
+        {
+            _unitTestRuntimeProvider.TestIgnore("Skipped before scenario");
         }
 
         [Given("a step that does not skip")]

--- a/Tests/Reqnroll.Formatters.Tests/Samples/Resources/skipped/skipped.feature
+++ b/Tests/Reqnroll.Formatters.Tests/Samples/Resources/skipped/skipped.feature
@@ -6,7 +6,7 @@ Feature: Skipping scenarios
   This can be useful in certain situations e.g. the current environment doesn't have
   the right conditions for running a particular scenario.
 
-  @ignore
+  @skip
   Scenario: Skipping from a Before hook
     Given a step that is skipped
 

--- a/Tests/Reqnroll.RuntimeTests/Formatters/ExecutionTracking/TestStepExecutionTrackerTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/Formatters/ExecutionTracking/TestStepExecutionTrackerTests.cs
@@ -135,6 +135,7 @@ public class TestStepExecutionTrackerTests
 
         var stepContextMock = CreateStepContextWithPickleId("stepPickleId");
         stepContextMock.Setup(sc => sc.Status).Returns(status);
+        stepContextMock.Setup(sc => sc.StepError).Returns(testError);
         var testStepFinished = new TestStepFinished("testCaseStartedId", "testStepId", new TestStepResult(new Duration(0, 0), "", TestStepResultStatus.FAILED, new Io.Cucumber.Messages.Types.Exception(testError.GetType().Name, "", null)), new Timestamp(0,0));
 
         _messageFactoryMock
@@ -142,7 +143,6 @@ public class TestStepExecutionTrackerTests
             .Returns(testStepFinished);
 
         var scenarioContextMock = new Mock<IScenarioContext>();
-        scenarioContextMock.SetupGet(s => s.TestError).Returns(testError);
 
         var stepFinishedEvent = new StepFinishedEvent(null, scenarioContextMock.Object, stepContextMock.Object);
 


### PR DESCRIPTION
### 🤔 What's changed?

This PR addresses #737 by removing the //HACK workaround for populating skipped step envelopes. 
A TestError property has been added to ScenarioStepContext and this is populated when a step throws.
This exception (rather than the Scenario level TestError) is then used to populate the Exception property of the StepFinished envelope.

### ⚡️ What's your motivation? 

Clearer mapping between our context structure and envelope structure.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

In the Cucumber Validation Tests, I have moved the `Skipped` scenario from 'NonCompliant' scenarios section of tests to the mainstream set of tests that are expected to pass. There are two problems that need to be addressed:
- When all scenarios complete with a 'skipped' status, (according to the CCK) the Feature is supposed to be reported as `Success` property of `true`. We report it as a `false`.
- When a Hook throws an `Inconclusive` exception (presumably with the intention of forcing the Scenario to be skipped), the Hook step status should be reported as `SKIPPED` but we report it as `FAILED` (b/c it threw an exception).

Feedback:
- Are either of these problems valid problems?

### 📋 Checklist:

- [X] I've changed the behaviour of the code
  - [X] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
