### PR TITLE
Tags on rules should be generated as test categories (#731)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * Fix: Disposed ObjectContainer can be accessed through RegisterInstanceAs/RegisterFactoryAs/RegisterTypeAs
 * Fix: Namespace clash in generated files if no RootNamespace is defined in the project file (#633)
 * Fixed source link and deterministic compilation for Reqnroll.CustomPlugin package (#719)
+* Fix: Rule Tags are now properly generated as Test Categories (along with Scenario Tags) (#731)(
 
 *Contributors of this release (in alphabetical order):* @304NotModified, @algirdasN, @clrudolphi, @DrEsteban, @loraderon, @obligaron
 

--- a/Reqnroll.Generator/Generation/UnitTestMethodGenerator.cs
+++ b/Reqnroll.Generator/Generation/UnitTestMethodGenerator.cs
@@ -101,7 +101,8 @@ namespace Reqnroll.Generator.Generation
 
         private void GenerateTest(TestClassGenerationContext generationContext, ScenarioDefinitionInFeatureFile scenarioDefinitionInFeatureFile, int pickleIndex)
         {
-            var testMethod = CreateTestMethod(generationContext, scenarioDefinitionInFeatureFile.ScenarioDefinition, null);
+            var ruleTags = scenarioDefinitionInFeatureFile.Rule?.Tags ?? [];
+            var testMethod = CreateTestMethod(generationContext, scenarioDefinitionInFeatureFile.ScenarioDefinition, ruleTags);
             GenerateTestBody(generationContext, scenarioDefinitionInFeatureFile, testMethod, pickleIndex: pickleIndex);
         }
 

--- a/Tests/Reqnroll.GeneratorTests/ParserHelper.cs
+++ b/Tests/Reqnroll.GeneratorTests/ParserHelper.cs
@@ -45,10 +45,25 @@ class ParserHelper
 
         var scenario1 = new ScenarioOutline(GetTags(scenarioOutlineTags), new Location(0), "Scenario Outline", "scenario outline1 title", "", Array.Empty<Step>(),
         [
-            new Examples(GetTags(examplesTags), default, "Examples", "examples name", "", new TableRow(default, [new TableCell(default, "col1")]), Array.Empty<TableRow>())
+            new Examples(GetTags(examplesTags), default, "Examples", "examples name", "", new TableRow(default, [new TableCell(default, "col1")]), new TableRow[]{new TableRow(default, [new TableCell(default, "col1")])})
         ]);
 
         var reqnrollFeature = new ReqnrollFeature(GetTags(tags), new Location(0), "en", "feature", "title", "desc", new StepsContainer[] {scenario1});
+        return new ReqnrollDocument(reqnrollFeature, Array.Empty<Comment>(), CreateDummyReqnrollLocation());
+    }
+
+    public static ReqnrollDocument CreateDocumentWithScenarioOutlineInRule(string[] tags = null, string[] ruleTags = null, string[] scenarioOutlineTags = null, string[] examplesTags = null)
+    {
+        tags ??= [];
+
+        var scenarioOutline = new ScenarioOutline(GetTags(scenarioOutlineTags), new Location(0), "Scenario Outline", "scenario outline1 title", "", Array.Empty<Step>(),
+        [
+            new Examples(GetTags(examplesTags), default, "Examples", "examples name", "", new TableRow(default, [new TableCell(default, "col1")]), new TableRow[]{new TableRow(default, [new TableCell(default, "col1")])})
+        ]);
+
+        var rule1 = new Rule(GetTags(ruleTags), new Location(0), "Rule", "rule1 title", "", new IHasLocation[] { scenarioOutline });
+
+        var reqnrollFeature = new ReqnrollFeature(GetTags(tags), new Location(0), "en", "feature", "title", "desc", new IHasLocation[] { rule1 });
         return new ReqnrollDocument(reqnrollFeature, Array.Empty<Comment>(), CreateDummyReqnrollLocation());
     }
 

--- a/Tests/Reqnroll.GeneratorTests/ParserHelper.cs
+++ b/Tests/Reqnroll.GeneratorTests/ParserHelper.cs
@@ -28,6 +28,17 @@ class ParserHelper
         return new ReqnrollDocument(reqnrollFeature, Array.Empty<Comment>(), CreateDummyReqnrollLocation());
     }
 
+    public static ReqnrollDocument CreateDocumentWithRule(string[] tags = null, string[] ruleTags = null, string[] scenarioTags = null)
+    {
+        tags ??= [];
+
+        var scenario1 = new Scenario(GetTags(scenarioTags), new Location(0), "Scenario", "scenario1 title", "", Array.Empty<Step>(), Array.Empty<Examples>());
+        var rule1 = new Rule(GetTags(ruleTags), new Location(0), "Rule", "rule1 title", "", new IHasLocation[] { scenario1 });
+
+        var reqnrollFeature = new ReqnrollFeature(GetTags(tags), new Location(0), "en", "feature", "title", "desc", new IHasLocation[] { rule1 });
+        return new ReqnrollDocument(reqnrollFeature, Array.Empty<Comment>(), CreateDummyReqnrollLocation());
+    }
+
     public static ReqnrollDocument CreateDocumentWithScenarioOutline(string[] tags = null, string[] scenarioOutlineTags = null, string[] examplesTags = null)
     {
         tags ??= [];

--- a/Tests/Reqnroll.GeneratorTests/UnitTestFeatureGeneratorTests.cs
+++ b/Tests/Reqnroll.GeneratorTests/UnitTestFeatureGeneratorTests.cs
@@ -76,6 +76,28 @@ namespace Reqnroll.GeneratorTests
         }
 
         [Fact]
+        public void Should_pass_scenario_tags_as_test_method_categories_of_scenarioOutline()
+        {
+            var generator = CreateUnitTestFeatureGenerator();
+            List<string> generatedCats = new();
+            UnitTestGeneratorProviderMock.Setup(ug => ug.SetTestMethodCategories(It.IsAny<TestClassGenerationContext>(), It.IsAny<CodeMemberMethod>(), It.IsAny<IEnumerable<string>>()))
+                .Callback((TestClassGenerationContext ctx, CodeMemberMethod _, IEnumerable<string> cats) => recordTestMethodCategories( cats, generatedCats));
+
+            var theFeature = ParserHelper.CreateDocumentWithScenarioOutline(scenarioOutlineTags: new[] { "foo", "bar" });
+
+            GenerateFeature(generator, theFeature);
+
+            generatedCats.Should().Equal(new string[] { "foo", "bar" });
+
+            void recordTestMethodCategories(IEnumerable<string> cats, List<string> generatedCats)
+            {
+                generatedCats.AddRange(cats);
+            }
+
+        }
+
+
+        [Fact]
         public void Should_pass_rule_tags_as_test_method_category()
         {
             var generator = CreateUnitTestFeatureGenerator();
@@ -89,6 +111,28 @@ namespace Reqnroll.GeneratorTests
 
             generatedCats.Should().BeEquivalentTo(new string[] { "rule_tag1", "rule_tag2", "scenarioTag1" });
         }
+
+
+        [Fact]
+        public void Should_pass_rule_tags_as_test_method_category_of_scenario_outline()
+        {
+            var generator = CreateUnitTestFeatureGenerator();
+            List<string> generatedCats = new List<string>();
+            UnitTestGeneratorProviderMock.Setup(ug => ug.SetTestMethodCategories(It.IsAny<TestClassGenerationContext>(), It.IsAny<CodeMemberMethod>(), It.IsAny<IEnumerable<string>>()))
+                .Callback((TestClassGenerationContext ctx, CodeMemberMethod _, IEnumerable<string> cats) => recordTestMethodCategories(cats, generatedCats));
+
+            var theFeature = ParserHelper.CreateDocumentWithScenarioOutlineInRule(ruleTags: new[] { "rule_tag1", "rule_tag2" }, scenarioOutlineTags: new[] { "scenarioTag1" });
+
+            GenerateFeature(generator, theFeature);
+
+            generatedCats.Should().BeEquivalentTo(new List<string> { "rule_tag1", "rule_tag2", "scenarioTag1" });
+
+            void recordTestMethodCategories(IEnumerable<string> cats, List<string> generatedCats)
+            {
+                generatedCats.AddRange(cats);
+            }
+        }
+
 
         [Fact]
         public void Should_not_pass_feature_tags_as_test_method_category()

--- a/Tests/Reqnroll.GeneratorTests/UnitTestFeatureGeneratorTests.cs
+++ b/Tests/Reqnroll.GeneratorTests/UnitTestFeatureGeneratorTests.cs
@@ -76,6 +76,21 @@ namespace Reqnroll.GeneratorTests
         }
 
         [Fact]
+        public void Should_pass_rule_tags_as_test_method_category()
+        {
+            var generator = CreateUnitTestFeatureGenerator();
+            string[] generatedCats = new string[0];
+            UnitTestGeneratorProviderMock.Setup(ug => ug.SetTestMethodCategories(It.IsAny<TestClassGenerationContext>(), It.IsAny<CodeMemberMethod>(), It.IsAny<IEnumerable<string>>()))
+                .Callback((TestClassGenerationContext ctx, CodeMemberMethod _, IEnumerable<string> cats) => generatedCats = cats.ToArray());
+
+            var theFeature = ParserHelper.CreateDocumentWithRule(ruleTags: new[] { "rule_tag1", "rule_tag2" }, scenarioTags: new[] {"scenarioTag1"});
+
+            GenerateFeature(generator, theFeature);
+
+            generatedCats.Should().BeEquivalentTo(new string[] { "rule_tag1", "rule_tag2", "scenarioTag1" });
+        }
+
+        [Fact]
         public void Should_not_pass_feature_tags_as_test_method_category()
         {
             var generator = CreateUnitTestFeatureGenerator();


### PR DESCRIPTION

### 🤔 What's changed?

Modified UnitTestFeatureGenerator to include Rule tags when generating TestCategory attributes.

### ⚡️ What's your motivation? 

This fixes #731 

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)


### 📋 Checklist:

- [X] I've changed the behaviour of the code
  - [X] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [X] Users should know about my change
  - [X] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
