### PR TITLE
Fixed handling of dynamically skipped scenarios caused by a Hook (#750)

### DIFF
--- a/Reqnroll/Events/ExecutionEvent.cs
+++ b/Reqnroll/Events/ExecutionEvent.cs
@@ -187,12 +187,14 @@ namespace Reqnroll.Events
         public TimeSpan Duration { get; }
         public IContextManager ContextManager { get; private set; }
         public Exception HookException { get; private set; }
+        public ScenarioExecutionStatus HookStatus { get; private set; }
 
-        public HookBindingFinishedEvent(IHookBinding hookBinding, TimeSpan duration, IContextManager contextManager, Exception hookException = null) 
+        public HookBindingFinishedEvent(IHookBinding hookBinding, TimeSpan duration, IContextManager contextManager, ScenarioExecutionStatus hookStatus, Exception hookException = null) 
         {
             HookBinding = hookBinding;
             Duration = duration;
             ContextManager = contextManager;
+            HookStatus = hookStatus;
             HookException = hookException;
         }
     }

--- a/Reqnroll/Formatters/ExecutionTracking/HookStepExecutionTracker.cs
+++ b/Reqnroll/Formatters/ExecutionTracking/HookStepExecutionTracker.cs
@@ -3,14 +3,13 @@ using Reqnroll.Formatters.PayloadProcessing.Cucumber;
 using Reqnroll.Events;
 using System.Threading.Tasks;
 using Reqnroll.Formatters.PubSub;
-using Reqnroll.UnitTestProvider;
 
 namespace Reqnroll.Formatters.ExecutionTracking;
 
 /// <summary>
 /// This class is used to track execution of hook steps.
 /// </summary>
-public class HookStepExecutionTracker(TestCaseExecutionTracker parentTracker, ICucumberMessageFactory messageFactory, IMessagePublisher publisher, IUnitTestRuntimeProvider unitTestRuntimeProvider) : 
+public class HookStepExecutionTracker(TestCaseExecutionTracker parentTracker, ICucumberMessageFactory messageFactory, IMessagePublisher publisher) : 
     StepExecutionTrackerBase(parentTracker, messageFactory, publisher)
 {
     public async Task ProcessEvent(HookBindingStartedEvent hookBindingStartedEvent)
@@ -33,7 +32,7 @@ public class HookStepExecutionTracker(TestCaseExecutionTracker parentTracker, IC
     {
         StepFinishedAt = hookFinishedEvent.Timestamp;
         Exception = hookFinishedEvent.HookException;
-        Status = Exception == null ? ScenarioExecutionStatus.OK : unitTestRuntimeProvider.DetectExecutionStatus(Exception) ?? ScenarioExecutionStatus.TestError;
+        Status = Exception == null ? ScenarioExecutionStatus.OK : ScenarioExecutionStatus.TestError;
 
         await Publisher.PublishAsync(Envelope.Create(MessageFactory.ToTestStepFinished(this)));
     }

--- a/Reqnroll/Formatters/ExecutionTracking/HookStepExecutionTracker.cs
+++ b/Reqnroll/Formatters/ExecutionTracking/HookStepExecutionTracker.cs
@@ -3,13 +3,14 @@ using Reqnroll.Formatters.PayloadProcessing.Cucumber;
 using Reqnroll.Events;
 using System.Threading.Tasks;
 using Reqnroll.Formatters.PubSub;
+using Reqnroll.UnitTestProvider;
 
 namespace Reqnroll.Formatters.ExecutionTracking;
 
 /// <summary>
 /// This class is used to track execution of hook steps.
 /// </summary>
-public class HookStepExecutionTracker(TestCaseExecutionTracker parentTracker, ICucumberMessageFactory messageFactory, IMessagePublisher publisher) : 
+public class HookStepExecutionTracker(TestCaseExecutionTracker parentTracker, ICucumberMessageFactory messageFactory, IMessagePublisher publisher, IUnitTestRuntimeProvider unitTestRuntimeProvider) : 
     StepExecutionTrackerBase(parentTracker, messageFactory, publisher)
 {
     public async Task ProcessEvent(HookBindingStartedEvent hookBindingStartedEvent)
@@ -32,7 +33,7 @@ public class HookStepExecutionTracker(TestCaseExecutionTracker parentTracker, IC
     {
         StepFinishedAt = hookFinishedEvent.Timestamp;
         Exception = hookFinishedEvent.HookException;
-        Status = Exception == null ? ScenarioExecutionStatus.OK : ScenarioExecutionStatus.TestError;
+        Status = Exception == null ? ScenarioExecutionStatus.OK : unitTestRuntimeProvider.DetectExecutionStatus(Exception) ?? ScenarioExecutionStatus.TestError;
 
         await Publisher.PublishAsync(Envelope.Create(MessageFactory.ToTestStepFinished(this)));
     }

--- a/Reqnroll/Formatters/ExecutionTracking/HookStepExecutionTracker.cs
+++ b/Reqnroll/Formatters/ExecutionTracking/HookStepExecutionTracker.cs
@@ -32,7 +32,7 @@ public class HookStepExecutionTracker(TestCaseExecutionTracker parentTracker, IC
     {
         StepFinishedAt = hookFinishedEvent.Timestamp;
         Exception = hookFinishedEvent.HookException;
-        Status = Exception == null ? ScenarioExecutionStatus.OK : ScenarioExecutionStatus.TestError;
+        Status = hookFinishedEvent.HookStatus;
 
         await Publisher.PublishAsync(Envelope.Create(MessageFactory.ToTestStepFinished(this)));
     }

--- a/Reqnroll/Formatters/ExecutionTracking/StepTrackerFactory.cs
+++ b/Reqnroll/Formatters/ExecutionTracking/StepTrackerFactory.cs
@@ -1,9 +1,10 @@
-﻿using Reqnroll.Formatters.PayloadProcessing.Cucumber;
+using Reqnroll.Formatters.PayloadProcessing.Cucumber;
 using Reqnroll.Formatters.PubSub;
+using Reqnroll.UnitTestProvider;
 
 namespace Reqnroll.Formatters.ExecutionTracking;
 
-public class StepTrackerFactory(ICucumberMessageFactory messageFactory, IMessagePublisher publisher) : IStepTrackerFactory
+public class StepTrackerFactory(ICucumberMessageFactory messageFactory, IMessagePublisher publisher, IUnitTestRuntimeProvider unitTestRuntimeProvider) : IStepTrackerFactory
 {
     public TestStepExecutionTracker CreateTestStepExecutionTracker(TestCaseExecutionTracker parentTracker, IMessagePublisher picklePublisher = null)
     {
@@ -11,7 +12,7 @@ public class StepTrackerFactory(ICucumberMessageFactory messageFactory, IMessage
     }
     public HookStepExecutionTracker CreateHookStepExecutionTracker(TestCaseExecutionTracker parentTracker, IMessagePublisher picklePublisher = null)
     {
-        return new HookStepExecutionTracker(parentTracker, messageFactory, picklePublisher ?? publisher);
+        return new HookStepExecutionTracker(parentTracker, messageFactory, picklePublisher ?? publisher, unitTestRuntimeProvider);
     }
     public AttachmentTracker CreateAttachmentTracker(string testRunStartedId, string testCaseStartedId, string testCaseStepId, string testRunHookStartedId, IMessagePublisher picklePublisher = null)
     {

--- a/Reqnroll/Formatters/ExecutionTracking/StepTrackerFactory.cs
+++ b/Reqnroll/Formatters/ExecutionTracking/StepTrackerFactory.cs
@@ -1,10 +1,9 @@
-using Reqnroll.Formatters.PayloadProcessing.Cucumber;
+﻿using Reqnroll.Formatters.PayloadProcessing.Cucumber;
 using Reqnroll.Formatters.PubSub;
-using Reqnroll.UnitTestProvider;
 
 namespace Reqnroll.Formatters.ExecutionTracking;
 
-public class StepTrackerFactory(ICucumberMessageFactory messageFactory, IMessagePublisher publisher, IUnitTestRuntimeProvider unitTestRuntimeProvider) : IStepTrackerFactory
+public class StepTrackerFactory(ICucumberMessageFactory messageFactory, IMessagePublisher publisher) : IStepTrackerFactory
 {
     public TestStepExecutionTracker CreateTestStepExecutionTracker(TestCaseExecutionTracker parentTracker, IMessagePublisher picklePublisher = null)
     {
@@ -12,7 +11,7 @@ public class StepTrackerFactory(ICucumberMessageFactory messageFactory, IMessage
     }
     public HookStepExecutionTracker CreateHookStepExecutionTracker(TestCaseExecutionTracker parentTracker, IMessagePublisher picklePublisher = null)
     {
-        return new HookStepExecutionTracker(parentTracker, messageFactory, picklePublisher ?? publisher, unitTestRuntimeProvider);
+        return new HookStepExecutionTracker(parentTracker, messageFactory, picklePublisher ?? publisher);
     }
     public AttachmentTracker CreateAttachmentTracker(string testRunStartedId, string testCaseStartedId, string testCaseStepId, string testRunHookStartedId, IMessagePublisher picklePublisher = null)
     {

--- a/Reqnroll/Infrastructure/TestExecutionEngine.cs
+++ b/Reqnroll/Infrastructure/TestExecutionEngine.cs
@@ -406,7 +406,8 @@ namespace Reqnroll.Infrastructure
             }
             finally
             {
-                await _testThreadExecutionEventPublisher.PublishEventAsync(new HookBindingFinishedEvent(hookBinding, durationHolder.Duration, _contextManager, exceptionThrown));
+                var hookStatus = exceptionThrown == null ? ScenarioExecutionStatus.OK : GetStatusFromException(exceptionThrown);
+                await _testThreadExecutionEventPublisher.PublishEventAsync(new HookBindingFinishedEvent(hookBinding, durationHolder.Duration, _contextManager, hookStatus, exceptionThrown));
             }
         }
 

--- a/Tests/Reqnroll.Formatters.Tests/MessagesCompatibilityTests.cs
+++ b/Tests/Reqnroll.Formatters.Tests/MessagesCompatibilityTests.cs
@@ -20,7 +20,6 @@ public class MessagesCompatibilityTests : MessagesCompatibilityTestBase
     [DataRow("undefined", "Undefined steps")]
     [DataRow("stack-traces", "Stack traces")]
     [DataRow("rules", "Usage of a `Rule`")]
-    [DataRow("skipped", "Skipping scenarios")]
     // These CCK scenario examples produce Cucumber Messages that are materially compliant with the CCK.
     // The messages produced match the CCK expected messages, with exceptions for things
     // that are not material to the CCK spec (such as IDs don't have to be generated in the same order, timestamps don't have to match, etc.)
@@ -79,6 +78,7 @@ public class MessagesCompatibilityTests : MessagesCompatibilityTestBase
     [DataRow("attachments", "Attachments")]
     [DataRow("hooks-named", "Hooks - Named")]
     [DataRow("unknown-parameter-type", "Unknown Parameter Types")]
+    [DataRow("skipped", "Skipping scenarios")]
     // These scenarios are from the CCK, but Reqnroll cannot provide a compliant implementation. This is usually the result of differences in behavior or support of Gherkin features.
     // When these scenarios are run, expect them to fail.
     public void NonCompliantCCKScenarios(string testName, string featureNameText)

--- a/Tests/Reqnroll.Formatters.Tests/MessagesCompatibilityTests.cs
+++ b/Tests/Reqnroll.Formatters.Tests/MessagesCompatibilityTests.cs
@@ -20,6 +20,7 @@ public class MessagesCompatibilityTests : MessagesCompatibilityTestBase
     [DataRow("undefined", "Undefined steps")]
     [DataRow("stack-traces", "Stack traces")]
     [DataRow("rules", "Usage of a `Rule`")]
+    [DataRow("skipped", "Skipping scenarios")]
     // These CCK scenario examples produce Cucumber Messages that are materially compliant with the CCK.
     // The messages produced match the CCK expected messages, with exceptions for things
     // that are not material to the CCK spec (such as IDs don't have to be generated in the same order, timestamps don't have to match, etc.)
@@ -78,7 +79,6 @@ public class MessagesCompatibilityTests : MessagesCompatibilityTestBase
     [DataRow("attachments", "Attachments")]
     [DataRow("hooks-named", "Hooks - Named")]
     [DataRow("unknown-parameter-type", "Unknown Parameter Types")]
-    [DataRow("skipped", "Skipping scenarios")]
     // These scenarios are from the CCK, but Reqnroll cannot provide a compliant implementation. This is usually the result of differences in behavior or support of Gherkin features.
     // When these scenarios are run, expect them to fail.
     public void NonCompliantCCKScenarios(string testName, string featureNameText)

--- a/Tests/Reqnroll.RuntimeTests/Formatters/ExecutionTracking/FeatureExecutionTrackerTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/Formatters/ExecutionTracking/FeatureExecutionTrackerTests.cs
@@ -408,7 +408,7 @@ public class FeatureExecutionTrackerTests
         var contextManagerMock = new Mock<IContextManager>();
         contextManagerMock.Setup(cm => cm.ScenarioContext).Returns(new ScenarioContext(null, scenarioInfoDummy, null, testOjbResolverMock.Object));
 
-        var hookBindingFinished = new HookBindingFinishedEvent(null, new TimeSpan(), contextManagerMock.Object);
+        var hookBindingFinished = new HookBindingFinishedEvent(null, new TimeSpan(), contextManagerMock.Object, ScenarioExecutionStatus.OK);
 
         // Act
         await sut.ProcessEvent(hookBindingFinished);

--- a/Tests/Reqnroll.RuntimeTests/Formatters/ExecutionTracking/HookStepExecutionTrackerTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/Formatters/ExecutionTracking/HookStepExecutionTrackerTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+﻿using FluentAssertions;
 using Gherkin.CucumberMessages;
 using Io.Cucumber.Messages.Types;
 using Moq;
@@ -15,7 +15,6 @@ using System.Globalization;
 using Xunit;
 using Reqnroll.Formatters.PubSub;
 using System.Threading.Tasks;
-using Reqnroll.UnitTestProvider;
 
 namespace Reqnroll.RuntimeTests.Formatters.ExecutionTracking;
 
@@ -28,7 +27,6 @@ public class HookStepExecutionTrackerTests
     private readonly TestCaseTracker _testCaseTracker;
     private readonly Mock<IIdGenerator> _idGeneratorMock;
     private readonly Mock<IMessagePublisher> _publisherMock;
-    private readonly Mock<IUnitTestRuntimeProvider> _unitTestRuntimeProviderMock;   
     private HookStepExecutionTracker _hookStepExecutionTracker;
     private FeatureInfo _featureInfoStub;
     private FeatureContext _featureContextStub;
@@ -66,7 +64,6 @@ public class HookStepExecutionTrackerTests
         _testCaseTrackerMock = new Mock<IPickleExecutionTracker>();
         _testCaseTracker = new TestCaseTracker("testCaseId", "testCasePickleId", _testCaseTrackerMock.Object);
         _idGeneratorMock = new Mock<IIdGenerator>();
-        _unitTestRuntimeProviderMock = new Mock<IUnitTestRuntimeProvider>();
         _stepDefinitionsByBinding = new ConcurrentDictionary<IBinding, string>();
         _objectContainerStub = new ObjectContainer();
 
@@ -82,8 +79,7 @@ public class HookStepExecutionTrackerTests
         _hookStepExecutionTracker = new HookStepExecutionTracker(
             CreateTestCaseExecutionRecord(),
             _messageFactoryMock.Object,
-            _publisherMock.Object,
-            _unitTestRuntimeProviderMock.Object
+            _publisherMock.Object
         );
     }
 
@@ -185,8 +181,7 @@ public class HookStepExecutionTrackerTests
         _hookStepExecutionTracker = new HookStepExecutionTracker(
             CreateTestCaseExecutionRecord(1),
             _messageFactoryMock.Object,
-            _publisherMock.Object,
-            _unitTestRuntimeProviderMock.Object
+            _publisherMock.Object
         );
             
         // Pre-existing definition that should be found
@@ -261,42 +256,6 @@ public class HookStepExecutionTrackerTests
         _hookStepExecutionTracker.Exception.Should().Be(exception);
         _hookStepExecutionTracker.Status.Should().Be(ScenarioExecutionStatus.TestError); // Error status
     }
-
-    private class SkipException : System.Exception
-    {
-        public SkipException(string message) : base(message) { }
-    }
-    [Fact]
-    public async Task HookStepTracker_ProcessEvent_HookBindingFinishedEvent_WithSkipException_SetsStatusToSkipped()
-    {
-        // Arrange
-        var hookBindingMock = new Mock<IHookBinding>();
-        var exception = new SkipException("Test skip exception");
-        _unitTestRuntimeProviderMock.Setup(utp => utp.DetectExecutionStatus(It.IsAny<SkipException>())).Returns(ScenarioExecutionStatus.Skipped);
-        var hookBindingFinishedEvent = new HookBindingFinishedEvent(
-            hookBindingMock.Object,
-            new TimeSpan(1),
-            _mockContextManager.Object,
-            exception
-        );
-        var hookId = "hook123";
-        var testStepId = "step456";
-        var testStepFinished = new TestStepFinished("testCaseStartedId", testStepId, new TestStepResult(new Duration(0, 0), "", TestStepResultStatus.SKIPPED, null), new Timestamp(0, 1));
-
-        _messageFactoryMock
-            .Setup(f => f.ToTestStepFinished(It.IsAny<HookStepExecutionTracker>()))
-            .Returns(testStepFinished);
-
-        _stepDefinitionsByBinding[hookBindingFinishedEvent.HookBinding] = hookId;
-
-        // Act
-        await _hookStepExecutionTracker.ProcessEvent(hookBindingFinishedEvent);
-
-        // Assert
-        _hookStepExecutionTracker.Exception.Should().Be(exception);
-        _hookStepExecutionTracker.Status.Should().Be(ScenarioExecutionStatus.Skipped); // Error status
-    }
-
 
     // Helper method to create a dummy HookStepTracker without mocking
     private HookStepTracker CreateDummyHookStepDefinition(string hookId)

--- a/Tests/Reqnroll.RuntimeTests/Formatters/ExecutionTracking/PickleExecutionTrackerTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/Formatters/ExecutionTracking/PickleExecutionTrackerTests.cs
@@ -19,6 +19,7 @@ using Xunit;
 using HookType = Reqnroll.Bindings.HookType;
 using Reqnroll.Formatters.PubSub;
 using System.Threading.Tasks;
+using Reqnroll.UnitTestProvider;
 
 namespace Reqnroll.RuntimeTests.Formatters.ExecutionTracking;
 
@@ -27,6 +28,7 @@ public class PickleExecutionTrackerTests
     private readonly Mock<IIdGenerator> _mockIdGenerator;
     private readonly Mock<ICucumberMessageFactory> _mockMessageFactory;
     private readonly Mock<IMessagePublisher> _mockPublisher;
+    private readonly Mock<IUnitTestRuntimeProvider> _mockUnitTestRuntimeProvider;
     private readonly ITestCaseExecutionTrackerFactory _stubTestCaseExecutionTrackerFactory;
     private FeatureInfo _featureInfoStub;
     private FeatureContext _featureContextStub;
@@ -45,8 +47,9 @@ public class PickleExecutionTrackerTests
         _mockIdGenerator.Setup(x => x.GetNewId()).Returns("test-id");
         _mockPublisher = new Mock<IMessagePublisher>();
         _mockMessageFactory = new Mock<ICucumberMessageFactory>();
+        _mockUnitTestRuntimeProvider = new Mock<IUnitTestRuntimeProvider>();
 
-        IStepTrackerFactory stepTrackerFactory = new StepTrackerFactory(_mockMessageFactory.Object, _mockPublisher.Object);
+        IStepTrackerFactory stepTrackerFactory = new StepTrackerFactory(_mockMessageFactory.Object, _mockPublisher.Object, _mockUnitTestRuntimeProvider.Object);
         _stubTestCaseExecutionTrackerFactory = new TestCaseExecutionTrackerFactory(_mockIdGenerator.Object, _mockMessageFactory.Object, _mockPublisher.Object, stepTrackerFactory);
 
         SetupMockContexts();

--- a/Tests/Reqnroll.RuntimeTests/Formatters/ExecutionTracking/PickleExecutionTrackerTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/Formatters/ExecutionTracking/PickleExecutionTrackerTests.cs
@@ -258,7 +258,7 @@ public class PickleExecutionTrackerTests
         _mockHookBinding.Setup(h => h.HookType).Returns(HookType.BeforeScenario);
 
         var hookStartedEvent = new HookBindingStartedEvent(_mockHookBinding.Object, _mockContextManager.Object);
-        var hookFinishedEvent = new HookBindingFinishedEvent(_mockHookBinding.Object, new TimeSpan(1), _mockContextManager.Object);
+        var hookFinishedEvent = new HookBindingFinishedEvent(_mockHookBinding.Object, new TimeSpan(1), _mockContextManager.Object, ScenarioExecutionStatus.OK);
 
         // Initial setup
         await tracker.ProcessEvent(scenarioStartedEvent);
@@ -285,7 +285,7 @@ public class PickleExecutionTrackerTests
         _mockHookBinding.Setup(h => h.HookType).Returns(HookType.BeforeTestRun);
 
         var hookStartedEvent = new HookBindingStartedEvent(_mockHookBinding.Object, _mockContextManager.Object);
-        var hookFinishedEvent = new HookBindingFinishedEvent(_mockHookBinding.Object, new TimeSpan(1), _mockContextManager.Object);
+        var hookFinishedEvent = new HookBindingFinishedEvent(_mockHookBinding.Object, new TimeSpan(1), _mockContextManager.Object, ScenarioExecutionStatus.OK);
 
         // Initial setup
         await tracker.ProcessEvent(scenarioStartedEvent);

--- a/Tests/Reqnroll.RuntimeTests/Formatters/ExecutionTracking/PickleExecutionTrackerTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/Formatters/ExecutionTracking/PickleExecutionTrackerTests.cs
@@ -19,7 +19,6 @@ using Xunit;
 using HookType = Reqnroll.Bindings.HookType;
 using Reqnroll.Formatters.PubSub;
 using System.Threading.Tasks;
-using Reqnroll.UnitTestProvider;
 
 namespace Reqnroll.RuntimeTests.Formatters.ExecutionTracking;
 
@@ -28,7 +27,6 @@ public class PickleExecutionTrackerTests
     private readonly Mock<IIdGenerator> _mockIdGenerator;
     private readonly Mock<ICucumberMessageFactory> _mockMessageFactory;
     private readonly Mock<IMessagePublisher> _mockPublisher;
-    private readonly Mock<IUnitTestRuntimeProvider> _mockUnitTestRuntimeProvider;
     private readonly ITestCaseExecutionTrackerFactory _stubTestCaseExecutionTrackerFactory;
     private FeatureInfo _featureInfoStub;
     private FeatureContext _featureContextStub;
@@ -47,9 +45,8 @@ public class PickleExecutionTrackerTests
         _mockIdGenerator.Setup(x => x.GetNewId()).Returns("test-id");
         _mockPublisher = new Mock<IMessagePublisher>();
         _mockMessageFactory = new Mock<ICucumberMessageFactory>();
-        _mockUnitTestRuntimeProvider = new Mock<IUnitTestRuntimeProvider>();
 
-        IStepTrackerFactory stepTrackerFactory = new StepTrackerFactory(_mockMessageFactory.Object, _mockPublisher.Object, _mockUnitTestRuntimeProvider.Object);
+        IStepTrackerFactory stepTrackerFactory = new StepTrackerFactory(_mockMessageFactory.Object, _mockPublisher.Object);
         _stubTestCaseExecutionTrackerFactory = new TestCaseExecutionTrackerFactory(_mockIdGenerator.Object, _mockMessageFactory.Object, _mockPublisher.Object, stepTrackerFactory);
 
         SetupMockContexts();

--- a/Tests/Reqnroll.RuntimeTests/Formatters/PubSub/FormatterPublisherTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/Formatters/PubSub/FormatterPublisherTests.cs
@@ -510,7 +510,7 @@ public class FormatterPublisherTests
 
         var hookTracker = new TestRunHookExecutionTracker("2", "0", "1", messageFactory, _brokerMock.Object);
         _sut.TestRunHookTrackers.TryAdd(hookBindingMock.Object, hookTracker);
-        var hookBindingFinished = new HookBindingFinishedEvent(hookBindingMock.Object, dur, cmMock.Object);
+        var hookBindingFinished = new HookBindingFinishedEvent(hookBindingMock.Object, dur, cmMock.Object, ScenarioExecutionStatus.OK);
 
         // Act
         await _sut.OnEventAsync(hookBindingFinished);
@@ -556,7 +556,7 @@ public class FormatterPublisherTests
         var executionEvent = eventType switch
         {
             var t when t == typeof(HookBindingStartedEvent) => (IExecutionEvent)Activator.CreateInstance(eventType, hookBindingMock.Object, cmMock.Object),
-            var t when t == typeof(HookBindingFinishedEvent) => (IExecutionEvent)Activator.CreateInstance(eventType, hookBindingMock.Object, dur, cmMock.Object, null),
+            var t when t == typeof(HookBindingFinishedEvent) => (IExecutionEvent)Activator.CreateInstance(eventType, hookBindingMock.Object, dur, cmMock.Object, ScenarioExecutionStatus.OK, null),
             _ => throw new NotSupportedException()
         };
 


### PR DESCRIPTION

<!---
Thanks for helping to make Reqnroll better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻

You can delete these comment sections as you process them.
-->

### 🤔 What's changed?

A Hook step is now shown as Skipped when it throws an exception from a unit test provider that indicates that the test should be skipped. (instead of indicating TestError)

The 'Skipped' CCK scenario now passes!

### ⚡️ What's your motivation? 

Fixes #750 
Compliance with the CCK

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)


### ♻️ Anything particular you want feedback on?


### 📋 Checklist:


- [X] I've changed the behaviour of the code
  - [X] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
