### PR TITLE
Fix for #718: Unicode characters in feature files not always handled correctly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,8 @@
 * Fix: Disposed ObjectContainer can be accessed through RegisterInstanceAs/RegisterFactoryAs/RegisterTypeAs
 * Fix: Namespace clash in generated files if no RootNamespace is defined in the project file (#633)
 * Fixed source link and deterministic compilation for Reqnroll.CustomPlugin package (#719)
-* Fix: Rule Tags are now properly generated as Test Categories (along with Scenario Tags) (#731)(
+* Fix: Rule Tags are now properly generated as Test Categories (along with Scenario Tags) (#731)
+* Fix: Unicode characters in Feature Files not always handled properly (#718)
 
 ## Deprecations:
 

--- a/Reqnroll.Generator/FeatureFileInputExtensions.cs
+++ b/Reqnroll.Generator/FeatureFileInputExtensions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using Reqnroll.Generator.Interfaces;
+using UtfUnknown;
 
 namespace Reqnroll.Generator
 {
@@ -12,11 +13,18 @@ namespace Reqnroll.Generator
             if (featureFileInput == null) throw new ArgumentNullException("featureFileInput");
 
             if (featureFileInput.FeatureFileContent != null)
+            {
                 return new StringReader(featureFileInput.FeatureFileContent);
+            }
 
             Debug.Assert(projectSettings != null);
-
-            return new StreamReader(Path.Combine(projectSettings.ProjectFolder, featureFileInput.ProjectRelativePath));
+            var filePath = Path.Combine(projectSettings.ProjectFolder, featureFileInput.ProjectRelativePath);
+            DetectionResult charsetResult = CharsetDetector.DetectFromFile(filePath);
+            if (charsetResult != null)
+            {
+                return new StreamReader(filePath, charsetResult.Detected.Encoding);
+            }
+            return new StreamReader(filePath);
         }
 
         public static string GetFullPath(this FeatureFileInput featureFileInput, ProjectSettings projectSettings)

--- a/Reqnroll.Generator/Reqnroll.Generator.csproj
+++ b/Reqnroll.Generator/Reqnroll.Generator.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.CodeDom" Version="8.0.0" />
+    <PackageReference Include="UTF.Unknown" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION

### 🤔 What's changed?

Feature File Code Generation attempts to detect the file encoding and use the detected encoding when reading the feature file for the parser.

## ⚡️ What's your motivation? 

Fix #718 

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)


### ♻️ Anything particular you want feedback on?

Not sure how or where to add tests for this. Any suggestions?

### 📋 Checklist:

- [X] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [X] Users should know about my change
  - [X] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
