### PR TITLE
Removed deprecated `<summary>` from NuGet packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * Removed support for end-of-life .NET frameworks (.NET 6, .NET 7, .NET Core) (#706)
 * Allow detecting skipped or pending execution status by the unit test providers (#732)
 * Allow `ScenarioContext`, `FeatureContext` and `TestThreadContext` to be resolved or injected through their interfaces, e.g. `IScenarioContext` (#761)
+* Removed deprecated `<summary>` from NuGet packages (#766)
 
 ## Bug fixes:
 

--- a/Plugins/Reqnroll.Assist.Dynamic/Reqnroll.Assist.Dynamic/Reqnroll.Assist.Dynamic.nuspec
+++ b/Plugins/Reqnroll.Assist.Dynamic/Reqnroll.Assist.Dynamic/Reqnroll.Assist.Dynamic.nuspec
@@ -6,8 +6,10 @@
     <title>Reqnroll.Assist.Dynamic</title>
     <authors>Oleg Koshmeliuk,Marcus Hammarberg, $author$</authors>
     <owners>Oleg Koshmeliuk, Marcus Hammarberg, $owner$</owners>
-    <description>Adds support for dynamic instances and sets from Reqnroll tables.</description>
-    <summary>See documentation at https://github.com/reqnroll/Reqnroll/tree/main/Plugins/Reqnroll.Assist.Dynamic</summary>
+    <description>Adds support for dynamic instances and sets from Reqnroll tables. 
+    
+    See documentation at https://github.com/reqnroll/Reqnroll/tree/main/Plugins/Reqnroll.Assist.Dynamic
+     </description>
     <language>en-US</language>
     <projectUrl>https://www.reqnroll.net</projectUrl>
     <repository type="git" url="https://github.com/reqnroll/Reqnroll.git" branch="$branch$" commit="$commit$" />

--- a/Plugins/Reqnroll.Autofac.ReqnrollPlugin/Reqnroll.Autofac.nuspec
+++ b/Plugins/Reqnroll.Autofac.ReqnrollPlugin/Reqnroll.Autofac.nuspec
@@ -7,7 +7,6 @@
     <authors>Gaspar Nagy, Spec Solutions, $author$</authors>
     <owners>Gaspar Nagy, Spec Solutions, $owner$</owners>
     <description>Reqnroll plugin that enables to use Autofac for resolving test dependencies.</description>
-    <summary>Reqnroll plugin that enables to use Autofac for resolving test dependencies.</summary>
     <language>en-US</language>
     <projectUrl>https://www.reqnroll.net</projectUrl>
     <repository type="git" url="https://github.com/reqnroll/Reqnroll.git" branch="$branch$" commit="$commit$" />

--- a/Plugins/Reqnroll.CustomPlugin/Reqnroll.CustomPlugin.nuspec
+++ b/Plugins/Reqnroll.CustomPlugin/Reqnroll.CustomPlugin.nuspec
@@ -7,7 +7,6 @@
     <authors>$author$</authors>
     <owners>$owner$</owners>
     <description>Package for writing custom generator extensions for Reqnroll.</description>
-    <summary>Package for writing custom generator extensions for Reqnroll.</summary>
     <language>en-US</language>
     <projectUrl>https://www.reqnroll.net</projectUrl>
     <repository type="git" url="https://github.com/reqnroll/Reqnroll.git" branch="$branch$" commit="$commit$" />

--- a/Plugins/Reqnroll.ExternalData/Reqnroll.ExternalData.ReqnrollPlugin/Reqnroll.ExternalData.nuspec
+++ b/Plugins/Reqnroll.ExternalData/Reqnroll.ExternalData.ReqnrollPlugin/Reqnroll.ExternalData.nuspec
@@ -6,7 +6,6 @@
     <authors>$author$</authors>
     <owners>$owner$</owners>
     <description>Package to use external data in Gherkin scenarios</description>
-    <summary>Package to use external data in Gherkin scenarios</summary>
     <language>en-US</language>
     <projectUrl>https://www.reqnroll.net</projectUrl>
     <repository type="git" url="https://github.com/reqnroll/Reqnroll.git" branch="$branch$" commit="$commit$" />

--- a/Plugins/Reqnroll.MSTest.Generator.ReqnrollPlugin/Reqnroll.MSTest.nuspec
+++ b/Plugins/Reqnroll.MSTest.Generator.ReqnrollPlugin/Reqnroll.MSTest.nuspec
@@ -7,7 +7,6 @@
     <authors>$author$</authors>
     <owners>$owner$</owners>
     <description>Package to use Reqnroll for use with MsTest v2. $summary$</description>
-    <summary>Package to use Reqnroll for use with MsTest v2. $summary$</summary>
     <language>en-US</language>
     <projectUrl>https://www.reqnroll.net</projectUrl>
     <repository type="git" url="https://github.com/reqnroll/Reqnroll.git" branch="$branch$" commit="$commit$" />

--- a/Plugins/Reqnroll.Microsoft.Extensions.DependencyInjection.ReqnrollPlugin/Reqnroll.Microsoft.Extensions.DependencyInjection.nuspec
+++ b/Plugins/Reqnroll.Microsoft.Extensions.DependencyInjection.ReqnrollPlugin/Reqnroll.Microsoft.Extensions.DependencyInjection.nuspec
@@ -7,7 +7,6 @@
     <authors>Mark Hoek, Solid Token, Stef Heyenrath, $author$</authors>
     <owners>Mark Hoek, Solid Token, Stef Heyenrath, $owner$</owners>
     <description>Reqnroll plugin that enables to use Microsoft.Extensions.DependencyInjection for resolving test dependencies.</description>
-    <summary>Reqnroll plugin that enables to use Microsoft.Extensions.DependencyInjection for resolving test dependencies.</summary>
     <language>en-US</language>
     <projectUrl>https://www.reqnroll.net</projectUrl>
     <repository type="git" url="https://github.com/reqnroll/Reqnroll.git" branch="$branch$" commit="$commit$" />

--- a/Plugins/Reqnroll.NUnit.Generator.ReqnrollPlugin/Reqnroll.NUnit.nuspec
+++ b/Plugins/Reqnroll.NUnit.Generator.ReqnrollPlugin/Reqnroll.NUnit.nuspec
@@ -7,7 +7,6 @@
     <authors>$author$</authors>
     <owners>$owner$</owners>
     <description>Package to use Reqnroll with NUnit 3.13 and later. $summary$</description>
-    <summary>Package to use Reqnroll with NUnit 3.13 and later. $summary$</summary>
     <language>en-US</language>
     <projectUrl>https://www.reqnroll.net</projectUrl>
     <repository type="git" url="https://github.com/reqnroll/Reqnroll.git" branch="$branch$" commit="$commit$" />

--- a/Plugins/Reqnroll.SpecFlowCompatibility.Generator.ReqnrollPlugin/Reqnroll.SpecFlowCompatibility.nuspec
+++ b/Plugins/Reqnroll.SpecFlowCompatibility.Generator.ReqnrollPlugin/Reqnroll.SpecFlowCompatibility.nuspec
@@ -7,7 +7,6 @@
     <authors>$author$</authors>
     <owners>$owner$</owners>
     <description>Enables SpecFlow compatibility mode for Reqnroll</description>
-    <summary>Enables SpecFlow compatibility mode for Reqnroll</summary>
     <language>en-US</language>
     <projectUrl>https://www.reqnroll.net</projectUrl>
     <repository type="git" url="https://github.com/reqnroll/Reqnroll.git" branch="$branch$" commit="$commit$" />

--- a/Plugins/Reqnroll.TUnit.Generator.ReqnrollPlugin/Reqnroll.TUnit.nuspec
+++ b/Plugins/Reqnroll.TUnit.Generator.ReqnrollPlugin/Reqnroll.TUnit.nuspec
@@ -7,7 +7,6 @@
     <authors>$author$</authors>
     <owners>$owner$</owners>
     <description>Package to use Reqnroll with TUnit 0.25.21 and later. $summary$</description>
-    <summary>Package to use Reqnroll with TUnit 0.25.21 and later. $summary$</summary>
     <language>en-US</language>
     <projectUrl>https://www.reqnroll.net</projectUrl>
     <repository type="git" url="https://github.com/reqnroll/Reqnroll.git" branch="$branch$" commit="$commit$" />

--- a/Plugins/Reqnroll.Verify/Reqnroll.Verify.ReqnrollPlugin/Reqnroll.Verify.nuspec
+++ b/Plugins/Reqnroll.Verify/Reqnroll.Verify.ReqnrollPlugin/Reqnroll.Verify.nuspec
@@ -6,7 +6,6 @@
     <authors>$author$</authors>
     <owners>$owner$</owners>
     <description>Package to use Verify.Xunit with Reqnroll</description>
-    <summary>Package to use Verify.Xunit with Reqnroll</summary>
     <language>en-US</language>
     <projectUrl>https://www.reqnroll.net</projectUrl>
     <repository type="git" url="https://github.com/reqnroll/Reqnroll.git" branch="$branch$" commit="$commit$" />

--- a/Plugins/Reqnroll.Windsor.ReqnrollPlugin/Reqnroll.Windsor.nuspec
+++ b/Plugins/Reqnroll.Windsor.ReqnrollPlugin/Reqnroll.Windsor.nuspec
@@ -7,7 +7,6 @@
     <authors>$author$</authors>
     <owners>Gaspar Nagy, Spec Solutions, $owner$</owners>
     <description>Reqnroll plugin that enables to use Windsor for resolving test dependencies.</description>
-    <summary>Reqnroll plugin that enables to use Windsor for resolving test dependencies.</summary>
     <language>en-US</language>
     <projectUrl>https://www.reqnroll.net</projectUrl>
     <repository type="git" url="https://github.com/reqnroll/Reqnroll.git" branch="$branch$" commit="$commit$" />

--- a/Plugins/Reqnroll.xUnit.Generator.ReqnrollPlugin/Reqnroll.xUnit.nuspec
+++ b/Plugins/Reqnroll.xUnit.Generator.ReqnrollPlugin/Reqnroll.xUnit.nuspec
@@ -7,7 +7,6 @@
     <authors>$author$</authors>
     <owners>$owner$</owners>
     <description>Package to use Reqnroll with xUnit 2.x. Note: this package won't support xUnit 3.x. $summary$</description>
-    <summary>Package to use Reqnroll with xUnit 2.x. Note: this package won't support xUnit 3.x. $summary$</summary>
     <language>en-US</language>
     <projectUrl>https://www.reqnroll.net</projectUrl>
     <repository type="git" url="https://github.com/reqnroll/Reqnroll.git" branch="$branch$" commit="$commit$" />

--- a/Reqnroll.Tools.MsBuild.Generation/Reqnroll.Tools.MsBuild.Generation.nuspec
+++ b/Reqnroll.Tools.MsBuild.Generation/Reqnroll.Tools.MsBuild.Generation.nuspec
@@ -7,7 +7,6 @@
     <authors>$author$</authors>
     <owners>$owner$</owners>
     <description>Package to enable the code-behind file generation during build time http://reqnroll.net/documentation/Generate-Tests-from-MsBuild/</description>
-    <summary>Package to enable the code-behind file generation during build time http://reqnroll.net/documentation/Generate-Tests-from-MsBuild/</summary>
     <language>en-US</language>
     <projectUrl>https://www.reqnroll.net</projectUrl>
     <repository type="git" url="https://github.com/reqnroll/Reqnroll.git" branch="$branch$" commit="$commit$" />


### PR DESCRIPTION
### 🤔 What's changed?

Remove the `<summary>`

Plugins/Reqnroll.Assist.Dynamic/Reqnroll.Assist.Dynamic/Reqnroll.Assist.Dynamic.nuspec: 
Moved content from `<summary>` to `<description>`

### ⚡️ What's your motivation? 

It's deprecated and it's not visible on nuget.org anymore


https://learn.microsoft.com/en-us/nuget/reference/nuspec#summary

<img width="791" height="237" alt="image" src="https://github.com/user-attachments/assets/16d93426-31df-42a5-9524-bdfdcea3059e" />

Also saves some keeping things in-sync / keeping them both up-to-date

Fixes also these warnings when validating packages:

<img width="545" height="131" alt="image" src="https://github.com/user-attachments/assets/e2b987ef-e078-4518-b80c-75377e7f2412" />

I checked the logs that I have fixed all the packages


### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :book: Documentation (improvements without changing code)

  - [x] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

