### PR TITLE
Documentation: Add Warning that Feature files must be in UTF-8

### DIFF
--- a/docs/gherkin/feature-files.md
+++ b/docs/gherkin/feature-files.md
@@ -3,6 +3,11 @@
 The feature files are the files that contain the BDD executable specification. 
 
 The feature files are plain text files with the `.feature` extension. You can put feature files in any folders within the Reqnroll project, but the convention is to have a `Features` folder in your project and put the feature files in that folder, optionally in sub-folders.
+```{admonition} Feature Files Should Be Saved in UTF-8
+:class: warning
+
+For proper support of non-ASCII characters in feature files (such as currency symbols and accented characters, feature files must be encoded in UTF-8 (with or without BOM signature). You may wish to add a [*.feature] section to your .editorconfig file with a charset setting to enforce this.
+```
 
 The format of the feature files is called *Gherkin* that is specified and maintained by the [Cucumber](https://cucumber.io/) project. For a full language reference please check the [Cucumber documentation](https://cucumber.io/docs/gherkin/).
 


### PR DESCRIPTION
### 🤔 What's changed?

Add a warning to the feature-files.md documentation page indicating that feature files must be in UTF-8.

### ⚡️ What's your motivation? 

This change is in lieu of PR #765 which attempted to auto-magically detect feature file encoding. Per discussion on that PR, the team is not in favor of making that change and instead prefers a documentation update.

### 🏷️ What kind of change is this?

- :book: Documentation (improvements without changing code)


### ♻️ Anything particular you want feedback on?

Wording, placement in the docs.

### 📋 Checklist:

- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [X] My change requires a change to the documentation.
  - [X] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
