### PR TITLE
Deprecate ScenarioContext.Pending and ScenarioContext.StepIsPending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * The synchronous code invocation API (`IBindingInvoker`) has been deprecated. Please use `IAsyncBindingInvoker` instead.
 * Removed obsolete property `ScenarioInfo.ScenarioAndFeatureTags`. Please use `ScenarioInfo.CombinedTags` instead.
 * Removed obsolete methods on `Reqnroll.Assist.Service` class: `RegisterValueComparer`, `UnregisterValueComparer`, `RegisterValueRetriever`, `UnregisterValueRetriever` use `ValueComparers.Register`, `ValueComparers.Unregister`, `ValueRetrievers.Register`, `ValueRetrievers.Unregister` instead.
+* The methods `ScenarioContext.Pending` and `ScenarioContext.StepIsPending` have been deprecated and going to be removed in v4. Use `throw new PendingStepException()` instead.
 
 *Contributors of this release (in alphabetical order):* @304NotModified, @algirdasN, @clrudolphi, @DrEsteban, @gasparnagy, @loraderon, @obligaron
 

--- a/Reqnroll/ScenarioContext.cs
+++ b/Reqnroll/ScenarioContext.cs
@@ -72,11 +72,13 @@ public class ScenarioContext : ReqnrollContext, IScenarioContext
 
     public ScenarioStepContext StepContext => ScenarioContainer.Resolve<IContextManager>().StepContext;
 
+    [Obsolete("This method has been deprecated and going to be removed in v4. Use 'throw new PendingStepException()' instead.")]
     public void Pending()
     {
         throw new PendingStepException();
     }
 
+    [Obsolete("This method has been deprecated and going to be removed in v4. Use 'throw new PendingStepException()' instead.")]
     public static void StepIsPending()
     {
         throw new PendingStepException();


### PR DESCRIPTION
### 🤔 What's changed?

The methods `ScenarioContext.Pending` and `ScenarioContext.StepIsPending` have been deprecated and going to be removed in v4. Use `throw new PendingStepException()` instead.

This depends on #781, because the old template used these methods.

### ⚡️ What's your motivation? 

Advertise more modern Reqnroll API.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

### 📋 Checklist:

- [x] I've changed the behaviour of the code
- [x] Users should know about my change
  - [x] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
