### PR TITLE
Experimental PR to partially fix #785 Error CS8103

### DIFF
--- a/Reqnroll.Generator/Interfaces/GenerationSettings.cs
+++ b/Reqnroll.Generator/Interfaces/GenerationSettings.cs
@@ -18,4 +18,6 @@ public class GenerationSettings
     /// disabled by default.
     /// </summary>
     public bool WriteResultToFile { get; set; } = false;
+
+    public bool FeatureFilesEmbedded { get; set; } = false;
 }

--- a/Reqnroll.Generator/Interfaces/ProjectSettings.cs
+++ b/Reqnroll.Generator/Interfaces/ProjectSettings.cs
@@ -27,4 +27,12 @@ public class ProjectSettings
     /// The reference of the unparsed Reqnroll configuration of the project. Mandatory.
     /// </summary>
     public ReqnrollConfigurationHolder ConfigurationHolder { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets a value indicating whether feature files will be embedded as resources in the output assembly. Optional.
+    /// </summary>
+    /// <remarks>When set to <see langword="true"/>, feature files will be included in the compiled assembly
+    /// as embedded resources by the build system. This flag informs the code-behind generator to expect that, but it is 
+    /// not the responsibility of the generator to perform the embedding.</remarks>
+    public bool FeatureFilesEmbedded { get; set; }
 }

--- a/Reqnroll.Generator/TestClassGenerationContext.cs
+++ b/Reqnroll.Generator/TestClassGenerationContext.cs
@@ -29,6 +29,7 @@ namespace Reqnroll.Generator
         public IDictionary<string, object> CustomData { get; private set; }
 
         public ICollection<string> GenerationWarnings { get; private set; }
+        public bool FeatureFilesEmbedded { get; private set; }
 
         public TestClassGenerationContext(
             IUnitTestGeneratorProvider unitTestGeneratorProvider,
@@ -44,7 +45,8 @@ namespace Reqnroll.Generator
             CodeMemberMethod scenarioStartMethod,
             CodeMemberMethod scenarioCleanupMethod,
             CodeMemberMethod featureBackgroundMethod,
-            bool generateRowTests)
+            bool generateRowTests,
+            bool featureFilesEmbedded = false)
         {
             UnitTestGeneratorProvider = unitTestGeneratorProvider;
             Document = document;
@@ -60,6 +62,7 @@ namespace Reqnroll.Generator
             ScenarioCleanupMethod = scenarioCleanupMethod;
             FeatureBackgroundMethod = featureBackgroundMethod;
             GenerateRowTests = generateRowTests;
+            FeatureFilesEmbedded = featureFilesEmbedded;
 
             CustomData = new Dictionary<string, object>();
             GenerationWarnings = new List<string>();

--- a/Reqnroll.Generator/TestGenerator.cs
+++ b/Reqnroll.Generator/TestGenerator.cs
@@ -62,7 +62,7 @@ public class TestGenerator : ErrorHandlingTestGenerator, ITestGenerator
                 return new TestGeneratorResult(null, true, null);
         }
 
-        string generatedTestCode = GetGeneratedTestCode(featureFileInput, out IEnumerable<string> generatedWarnings);
+        string generatedTestCode = GetGeneratedTestCode(featureFileInput, out IEnumerable<string> generatedWarnings, settings.FeatureFilesEmbedded);
         if(string.IsNullOrEmpty(generatedTestCode))
             return new TestGeneratorResult(null, true, generatedWarnings);
 
@@ -81,13 +81,13 @@ public class TestGenerator : ErrorHandlingTestGenerator, ITestGenerator
         return new TestGeneratorResult(generatedTestCode, false, generatedWarnings);
     }
 
-    protected string GetGeneratedTestCode(FeatureFileInput featureFileInput, out IEnumerable<string> generationWarnings)
+    protected string GetGeneratedTestCode(FeatureFileInput featureFileInput, out IEnumerable<string> generationWarnings, bool featureFilesEmbedded = false)
     {
         generationWarnings = Array.Empty<string>();
         using (var outputWriter = new IndentProcessingWriter(new StringWriter()))
         {
             var codeProvider = CodeDomHelper.CreateCodeDomProvider();
-            var codeNamespace = GenerateTestFileCode(featureFileInput, out generationWarnings);
+            var codeNamespace = GenerateTestFileCode(featureFileInput, featureFilesEmbedded, out generationWarnings);
             if (codeNamespace == null) return "";
 
             var options = new CodeGeneratorOptions
@@ -137,7 +137,7 @@ public class TestGenerator : ErrorHandlingTestGenerator, ITestGenerator
         return result;
     }
         
-    private CodeNamespace GenerateTestFileCode(FeatureFileInput featureFileInput, out IEnumerable<string> generationWarnings)
+    private CodeNamespace GenerateTestFileCode(FeatureFileInput featureFileInput, bool featureFilesEmbedded, out IEnumerable<string> generationWarnings)
     {
         generationWarnings = Array.Empty<string>();
         string targetNamespace = GetTargetNamespace(featureFileInput) ?? "Reqnroll.GeneratedTests";
@@ -153,7 +153,7 @@ public class TestGenerator : ErrorHandlingTestGenerator, ITestGenerator
 
         var featureGenerator = _featureGeneratorRegistry.CreateGenerator(reqnrollDocument);
 
-        var codeNamespace = featureGenerator.GenerateUnitTestFixture(reqnrollDocument, null, targetNamespace, out generationWarnings);
+        var codeNamespace = featureGenerator.GenerateUnitTestFixture(reqnrollDocument, null, targetNamespace, out generationWarnings, featureFilesEmbedded);
         return codeNamespace;
     }
 

--- a/Reqnroll.Generator/UnitTestConverter/IFeatureGenerator.cs
+++ b/Reqnroll.Generator/UnitTestConverter/IFeatureGenerator.cs
@@ -6,6 +6,6 @@ namespace Reqnroll.Generator.UnitTestConverter
 {
     public interface IFeatureGenerator
     {
-        CodeNamespace GenerateUnitTestFixture(ReqnrollDocument document, string testClassName, string targetNamespace, out IEnumerable<string> warnings);
+        CodeNamespace GenerateUnitTestFixture(ReqnrollDocument document, string testClassName, string targetNamespace, out IEnumerable<string> warnings, bool featureFilesEmbedded = false);
     }
 }

--- a/Reqnroll.Tools.MsBuild.Generation/FeatureCodeBehindGenerator.cs
+++ b/Reqnroll.Tools.MsBuild.Generation/FeatureCodeBehindGenerator.cs
@@ -13,13 +13,13 @@ namespace Reqnroll.Tools.MsBuild.Generation
             _testGenerator = testGenerator;
         }
 
-        public TestFileGeneratorResult GenerateCodeBehindFile(string featureFile)
+        public TestFileGeneratorResult GenerateCodeBehindFile(string featureFile, bool featureFilesEmbedded = false)
         {
             var featureFileInput = new FeatureFileInput(featureFile);
 
             var generatedFeatureFileName = Path.GetFileName(_testGenerator.GetTestFullPath(featureFileInput));
 
-            var testGeneratorResult = _testGenerator.GenerateTestFile(featureFileInput, new GenerationSettings());
+            var testGeneratorResult = _testGenerator.GenerateTestFile(featureFileInput, new GenerationSettings() { FeatureFilesEmbedded = featureFilesEmbedded});
 
             return new TestFileGeneratorResult(testGeneratorResult, generatedFeatureFileName);
         }

--- a/Reqnroll.Tools.MsBuild.Generation/FeatureFileCodeBehindGenerator.cs
+++ b/Reqnroll.Tools.MsBuild.Generation/FeatureFileCodeBehindGenerator.cs
@@ -22,7 +22,8 @@ namespace Reqnroll.Tools.MsBuild.Generation
         public IEnumerable<string> GenerateFilesForProject(
             IReadOnlyCollection<string> featureFiles,
             string projectFolder,
-            string outputPath)
+            string outputPath,
+            bool featureFilesEmbedded = false)
         {
             var codeBehindWriter = new CodeBehindWriter(null);
 
@@ -34,7 +35,7 @@ namespace Reqnroll.Tools.MsBuild.Generation
             foreach (var featureFile in featureFiles)
             {
                 string featureFileItemSpec = featureFile;
-                var generatorResult = _featureCodeBehindGenerator.GenerateCodeBehindFile(featureFileItemSpec);
+                var generatorResult = _featureCodeBehindGenerator.GenerateCodeBehindFile(featureFileItemSpec, featureFilesEmbedded);
 
                 if (!generatorResult.Success)
                 {

--- a/Reqnroll.Tools.MsBuild.Generation/GenerateFeatureFileCodeBehindTask.cs
+++ b/Reqnroll.Tools.MsBuild.Generation/GenerateFeatureFileCodeBehindTask.cs
@@ -36,6 +36,8 @@ namespace Reqnroll.Tools.MsBuild.Generation
         public string TargetFramework { get; set; }
         public string ProjectGuid { get; set; }
 
+        public bool ReqnrollFeatureFilesEmbedded { get; set; } = false;
+
         public override bool Execute()
         {
             var generateFeatureFileCodeBehindTaskContainerBuilder = new GenerateFeatureFileCodeBehindTaskContainerBuilder();
@@ -44,7 +46,7 @@ namespace Reqnroll.Tools.MsBuild.Generation
 
             var msbuildInformationProvider = new MSBuildInformationProvider(MSBuildVersion);
             var generateFeatureFileCodeBehindTaskConfiguration = new GenerateFeatureFileCodeBehindTaskConfiguration(AnalyticsTransmitter, CodeBehindGenerator);
-            var generateFeatureFileCodeBehindTaskInfo = new ReqnrollProjectInfo(generatorPlugins, featureFiles, ProjectPath, ProjectFolder, ProjectGuid, AssemblyName, OutputPath, RootNamespace, TargetFrameworks, TargetFramework);
+            var generateFeatureFileCodeBehindTaskInfo = new ReqnrollProjectInfo(generatorPlugins, featureFiles, ProjectPath, ProjectFolder, ProjectGuid, AssemblyName, OutputPath, RootNamespace, TargetFrameworks, TargetFramework, ReqnrollFeatureFilesEmbedded);
 
             using (var taskRootContainer = generateFeatureFileCodeBehindTaskContainerBuilder.BuildRootContainer(Log, generateFeatureFileCodeBehindTaskInfo, msbuildInformationProvider, generateFeatureFileCodeBehindTaskConfiguration))
             {

--- a/Reqnroll.Tools.MsBuild.Generation/GenerateFeatureFileCodeBehindTaskExecutor.cs
+++ b/Reqnroll.Tools.MsBuild.Generation/GenerateFeatureFileCodeBehindTaskExecutor.cs
@@ -46,6 +46,7 @@ namespace Reqnroll.Tools.MsBuild.Generation
             try
             {
                 var reqnrollProject = _reqnrollProjectProvider.GetReqnrollProject();
+                reqnrollProject.ProjectSettings.FeatureFilesEmbedded = _reqnrollProjectInfo.FeatureFilesEmbedded;
 
                 using var generatorContainer = _wrappedGeneratorContainerBuilder.BuildGeneratorContainer(
                     reqnrollProject.ProjectSettings.ConfigurationHolder,

--- a/Reqnroll.Tools.MsBuild.Generation/IFeatureFileCodeBehindGenerator.cs
+++ b/Reqnroll.Tools.MsBuild.Generation/IFeatureFileCodeBehindGenerator.cs
@@ -4,7 +4,7 @@ namespace Reqnroll.Tools.MsBuild.Generation
 {
     public interface IFeatureFileCodeBehindGenerator
     {
-        IEnumerable<string> GenerateFilesForProject(IReadOnlyCollection<string> featureFiles, string projectFolder, string outputPath);
+        IEnumerable<string> GenerateFilesForProject(IReadOnlyCollection<string> featureFiles, string projectFolder, string outputPath, bool featureFilesEmbedded);
 
     }
 }

--- a/Reqnroll.Tools.MsBuild.Generation/ProjectCodeBehindGenerator.cs
+++ b/Reqnroll.Tools.MsBuild.Generation/ProjectCodeBehindGenerator.cs
@@ -21,7 +21,8 @@ namespace Reqnroll.Tools.MsBuild.Generation
             var generatedFiles = _featureFileCodeBehindGenerator.GenerateFilesForProject(
                 _reqnrollProjectInfo.FeatureFiles,
                 _reqnrollProjectInfo.ProjectFolder,
-                _reqnrollProjectInfo.OutputPath);
+                _reqnrollProjectInfo.OutputPath,
+                _reqnrollProjectInfo.FeatureFilesEmbedded);
 
             return generatedFiles.Select(file => new TaskItem { ItemSpec = file })
                                  .Cast<ITaskItem>()

--- a/Reqnroll.Tools.MsBuild.Generation/ReqnrollProjectInfo.cs
+++ b/Reqnroll.Tools.MsBuild.Generation/ReqnrollProjectInfo.cs
@@ -16,7 +16,9 @@ namespace Reqnroll.Tools.MsBuild.Generation
             string outputPath,
             string rootNamespace,
             string targetFrameworks,
-            string currentTargetFramework)
+            string currentTargetFramework,
+            bool featureFilesEmbedded = false
+            )
         {
             GeneratorPlugins = generatorPlugins;
             FeatureFiles = FileFilter.GetValidFiles(featureFiles);
@@ -28,6 +30,7 @@ namespace Reqnroll.Tools.MsBuild.Generation
             ProjectGuid = projectGuid;
             ProjectAssemblyName = projectAssemblyName;
             ProjectPath = projectPath;
+            FeatureFilesEmbedded = featureFilesEmbedded;
         }
 
         public IReadOnlyCollection<GeneratorPluginInfo> GeneratorPlugins { get; }
@@ -35,7 +38,7 @@ namespace Reqnroll.Tools.MsBuild.Generation
         public IReadOnlyCollection<string> FeatureFiles { get; }
 
         public string ProjectPath { get; }
-
+        public bool FeatureFilesEmbedded { get; }
         public string ProjectFolder { get; }
 
         public string ProjectGuid { get; }

--- a/Reqnroll.Tools.MsBuild.Generation/build/Reqnroll.Tools.MsBuild.Generation.targets
+++ b/Reqnroll.Tools.MsBuild.Generation/build/Reqnroll.Tools.MsBuild.Generation.targets
@@ -102,6 +102,7 @@
       TargetFrameworks="$(Reqnroll_TargetFrameworks)"
       TargetFramework="$(Reqnroll_TargetFramework)"
       ProjectGuid="$(ProjectGuid)"
+      ReqnrollFeatureFilesEmbedded="$(ReqnrollEmbedFeatureFiles)"
       >
 
       <Output TaskParameter="GeneratedFiles" ItemName="ReqnrollGeneratedFiles" />

--- a/Reqnroll/Formatters/RuntimeSupport/FeatureLevelCucumberMessages.cs
+++ b/Reqnroll/Formatters/RuntimeSupport/FeatureLevelCucumberMessages.cs
@@ -1,6 +1,10 @@
 using Io.Cucumber.Messages.Types;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Reflection;
 
 namespace Reqnroll.Formatters.RuntimeSupport;
 
@@ -8,14 +12,90 @@ namespace Reqnroll.Formatters.RuntimeSupport;
 /// This class is used at Code Generation time to provide serialized representations of the Source, GherkinDocument, and Pickles 
 /// to be used at runtime.
 /// </summary>
-public class FeatureLevelCucumberMessages(Func<Source> source, Func<GherkinDocument> gherkinDocument, Func<IEnumerable<Pickle>> pickles)
+public class FeatureLevelCucumberMessages
 {
-    private Lazy<Source> _source = new Lazy<Source>(source);
-    private Lazy<GherkinDocument> _gherkinDocument = new Lazy<GherkinDocument>(gherkinDocument);
-    private Lazy<IEnumerable<Pickle>> _pickles = new Lazy<IEnumerable<Pickle>>(pickles);
+    private readonly Func<Source> _sourceFunc;
+    private readonly Func<GherkinDocument> _gherkinDocumentFunc;
+    private readonly Func<IEnumerable<Pickle>> _picklesFunc;
+
+    private Lazy<Source> _source;
+    private Lazy<GherkinDocument> _gherkinDocument;
+    private Lazy<IEnumerable<Pickle>> _pickles;
+
+    public FeatureLevelCucumberMessages(Func<Source> source, Func<GherkinDocument> gherkinDocument, Func<IEnumerable<Pickle>> pickles)
+    {
+        _sourceFunc = source;
+        _gherkinDocumentFunc = gherkinDocument;
+        _picklesFunc = pickles;
+
+        _source = new Lazy<Source>(() => ProcessSource(_sourceFunc));
+        _gherkinDocument = new Lazy<GherkinDocument>(_gherkinDocumentFunc);
+        _pickles = new Lazy<IEnumerable<Pickle>>(_picklesFunc);
+    }
 
     public bool HasMessages => Source is not null && GherkinDocument is not null && Pickles is not null;
     public Source Source { get => _source.Value; }
     public GherkinDocument GherkinDocument { get => _gherkinDocument.Value; }
     public IEnumerable<Pickle> Pickles { get => _pickles.Value; }
+
+    internal Source ProcessSource(Func<Source> sourceGeneratorFunc)
+    {
+        var fromCompiler = sourceGeneratorFunc();
+        if (fromCompiler != null && fromCompiler.Data != null)
+            return fromCompiler;
+
+        // Determine the assembly that contains the provided delegate (feature class)
+        var assembly = sourceGeneratorFunc?.Method?.DeclaringType?.Assembly
+                        ?? sourceGeneratorFunc?.Method?.Module?.Assembly;
+
+        if (fromCompiler == null || string.IsNullOrEmpty(fromCompiler.Uri))
+            throw new InvalidOperationException("Compiler-provided Source is missing or has no Uri.");
+
+        return CreateSourceFromEmbeddedResource(fromCompiler.Uri, assembly);
+    }
+
+    // Retrieves text from an embedded resource and returns a Cucumber Messages Source.
+    // The resourceName can be the full manifest resource name or a suffix; 
+    internal Source CreateSourceFromEmbeddedResource(string resourceName, Assembly assembly)
+    {
+        if (string.IsNullOrWhiteSpace(resourceName))
+            throw new ArgumentNullException(nameof(resourceName));
+
+        if (assembly == null)
+            throw new ArgumentNullException(nameof(assembly));
+
+        // Find and read the resource text from the most likely assemblies first
+        string ReadResourceFrom(Assembly asm, string resName)
+        {
+            // exact match
+            using (var exact = asm.GetManifestResourceStream(resName))
+            {
+                if (exact != null)
+                    using (var sr = new StreamReader(exact))
+                        return sr.ReadToEnd();
+            }
+
+            // suffix match (resource names are namespace-prefixed)
+            var manifestName = asm.GetManifestResourceNames()
+                                   .FirstOrDefault(n => n.Equals(resName, StringComparison.Ordinal) || n.EndsWith(resName, StringComparison.Ordinal));
+            if (manifestName != null)
+            {
+                using (var stream = asm.GetManifestResourceStream(manifestName))
+                using (var sr = new StreamReader(stream))
+                {
+                    return sr.ReadToEnd();
+                }
+            }
+
+            return null;
+        }
+
+        var text = ReadResourceFrom(assembly, resourceName);
+
+        if (text == null)
+            throw new InvalidOperationException($"Embedded resource '{resourceName}' was not found in any loaded assembly.");
+
+        // Convert the parsed AST into a Source message (Source contains raw text plus media type)
+        return new Source(resourceName, text, SourceMediaType.TEXT_X_CUCUMBER_GHERKIN_PLAIN);
+    }
 }

--- a/Reqnroll/Formatters/RuntimeSupport/FeatureLevelCucumberMessages.cs
+++ b/Reqnroll/Formatters/RuntimeSupport/FeatureLevelCucumberMessages.cs
@@ -41,8 +41,11 @@ public class FeatureLevelCucumberMessages
     internal Source ProcessSource(Func<Source> sourceGeneratorFunc)
     {
         var fromCompiler = sourceGeneratorFunc();
-        if (fromCompiler != null && fromCompiler.Data != null)
+        if (fromCompiler != null && !String.IsNullOrEmpty(fromCompiler.Data) )
             return fromCompiler;
+
+        // If the SourceFunc returns a Source object with an empty Data field (the source text),
+        // then the source of the feature has been embedded in the assembly
 
         // Determine the assembly that contains the provided delegate (feature class)
         var assembly = sourceGeneratorFunc?.Method?.DeclaringType?.Assembly
@@ -51,7 +54,7 @@ public class FeatureLevelCucumberMessages
         if (fromCompiler == null || string.IsNullOrEmpty(fromCompiler.Uri))
             throw new InvalidOperationException("Compiler-provided Source is missing or has no Uri.");
 
-        return CreateSourceFromEmbeddedResource(fromCompiler.Uri, assembly);
+        return CreateSourceFromEmbeddedResource(fromCompiler.Uri.Replace('/', '\\'), assembly);
     }
 
     // Retrieves text from an embedded resource and returns a Cucumber Messages Source.

--- a/Tests/Reqnroll.GeneratorTests/MSBuildTask/GenerateFeatureFileCodeBehindTaskTests.cs
+++ b/Tests/Reqnroll.GeneratorTests/MSBuildTask/GenerateFeatureFileCodeBehindTaskTests.cs
@@ -25,7 +25,8 @@ namespace Reqnroll.GeneratorTests.MSBuildTask
                 .Setup(m => m.GenerateFilesForProject(
                     It.IsAny<List<string>>(),
                     It.IsAny<string>(),
-                    It.IsAny<string>()))
+                    It.IsAny<string>(),
+                    It.IsAny<bool>()))
                 .Returns(new List<string>());
             return generatorMock;
         }

--- a/Tests/Reqnroll.GeneratorTests/UnitTestFeatureGeneratorTests.cs
+++ b/Tests/Reqnroll.GeneratorTests/UnitTestFeatureGeneratorTests.cs
@@ -38,7 +38,7 @@ namespace Reqnroll.GeneratorTests
 
         protected void GenerateFeature(IFeatureGenerator generator, ReqnrollDocument document)
         {
-            generator.GenerateUnitTestFixture(document, "dummy", "dummyNS", out var generationWarnings);
+            generator.GenerateUnitTestFixture(document, "dummy", "dummyNS", out var generationWarnings, false);
         }
     }
 


### PR DESCRIPTION
### 🤔 What's changed?

This is initial commit to experiment with a fix for #785 
This PR attempts to address Phase 1 as described in #785.
This change reads the source text of feature files from the assembly embedded resources when the `ReqnrollEmbedFeatureFiles` build variable is set to true. When true, the UnitTestFeatureGenerator will skip emitting the text of the feature file as a string in the Func<> that builds the Source message object.

### ⚡️ What's your motivation? 

Fix #785.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)


### ♻️ Anything particular you want feedback on?

Feedback please on the way in which the build variable's value is plumbed through the MsBuildGenerator infrastucture and then to the Reqnroll.Generator infrastructure.

Have not yet updated tests (beyond adapting to new method signatures) or added new tests.

### 📋 Checklist:


- [X] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
