### PR TITLE
Fix Azure DevOps build URL detection

### DIFF
--- a/Reqnroll/EnvironmentAccess/BuildMetadataProvider.cs
+++ b/Reqnroll/EnvironmentAccess/BuildMetadataProvider.cs
@@ -78,7 +78,10 @@ namespace Reqnroll.EnvironmentAccess
                 return null;
             }
 
-            var buildUrl = GetVariable("BUILD_BUILDURI");
+            var collectionUri = GetVariable("SYSTEM_COLLECTIONURI");
+            var teamProject = GetVariable("SYSTEM_TEAMPROJECT");
+            var buildId = GetVariable("BUILD_BUILDID");
+            var buildUrl = $"{collectionUri}{teamProject}/_build/results?buildId={buildId}&_a=summary";
             var buildNumber = GetVariable("BUILD_BUILDNUMBER");
             var remote = GetVariable("BUILD_REPOSITORY_URI");
             var revision = GetVariable("BUILD_SOURCEVERSION");

--- a/Tests/Reqnroll.RuntimeTests/EnvironmentAccess/BuildMetadataProviderTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/EnvironmentAccess/BuildMetadataProviderTests.cs
@@ -22,7 +22,7 @@ namespace Reqnroll.RuntimeTests.EnvironmentAccess
         public static IEnumerable<object[]> BuildServers => new[]
         {
             new object[] { "Azure Pipelines", new Dictionary<string, string> {
-                ["BUILD_BUILDURI"] = "url", ["BUILD_BUILDNUMBER"] = "num", ["BUILD_REPOSITORY_URI"] = "repo", ["BUILD_SOURCEVERSION"] = "rev", ["BUILD_SOURCEBRANCHNAME"] = "branch", ["BUILD_SOURCEBRANCH"] = "refs/tags/v1.2.3" } },
+                ["SYSTEM_COLLECTIONURI"] = "https://url/", ["SYSTEM_TEAMPROJECT"] = "myprj", ["BUILD_BUILDID"] = "123", ["BUILD_BUILDNUMBER"] = "num", ["BUILD_REPOSITORY_URI"] = "repo", ["BUILD_SOURCEVERSION"] = "rev", ["BUILD_SOURCEBRANCHNAME"] = "branch", ["BUILD_SOURCEBRANCH"] = "refs/tags/v1.2.3" } },
             new object[] { "TeamCity", new Dictionary<string, string> {
                 ["BUILD_URL"] = "url", ["BUILD_NUMBER"] = "num", ["TEAMCITY_GIT_REPOSITORY_URL"] = "repo", ["BUILD_VCS_NUMBER"] = "rev", ["TEAMCITY_BUILD_BRANCH"] = "branch", ["TEAMCITY_BUILD_TAG"] = "tag" } },
             new object[] { "Jenkins", new Dictionary<string, string> {
@@ -77,7 +77,7 @@ namespace Reqnroll.RuntimeTests.EnvironmentAccess
             switch (buildServer)
             {
                 case "Azure Pipelines":
-                    metadata.BuildUrl.Should().Be("url");
+                    metadata.BuildUrl.Should().Be("https://url/myprj/_build/results?buildId=123&_a=summary");
                     metadata.BuildNumber.Should().Be("num");
                     metadata.Remote.Should().Be("repo");
                     metadata.Revision.Should().Be("rev");
@@ -133,8 +133,10 @@ namespace Reqnroll.RuntimeTests.EnvironmentAccess
         public void GetBuildMetadata_AzurePipelines_ExtractsTagFromSourceBranch()
         {
             var env = new EnvironmentWrapperStub();
-            env.SetEnvironmentVariable("BUILD_BUILDURI", "https://build.uri");
-            env.SetEnvironmentVariable("BUILD_BUILDNUMBER", "123");
+            env.SetEnvironmentVariable("SYSTEM_COLLECTIONURI", "https://dev.azure.com/myorg/");
+            env.SetEnvironmentVariable("SYSTEM_TEAMPROJECT", "myproject");
+            env.SetEnvironmentVariable("BUILD_BUILDID", "123");
+            env.SetEnvironmentVariable("BUILD_BUILDNUMBER", "123.456");
             env.SetEnvironmentVariable("BUILD_REPOSITORY_URI", "https://repo.uri");
             env.SetEnvironmentVariable("BUILD_SOURCEVERSION", "abc123");
             env.SetEnvironmentVariable("BUILD_SOURCEBRANCHNAME", "main");
@@ -146,8 +148,8 @@ namespace Reqnroll.RuntimeTests.EnvironmentAccess
             
             metadata.Should().NotBeNull();
             metadata.ProductName.Should().Be("Azure Pipelines");
-            metadata.BuildUrl.Should().Be("https://build.uri");
-            metadata.BuildNumber.Should().Be("123");
+            metadata.BuildUrl.Should().Be("https://dev.azure.com/myorg/myproject/_build/results?buildId=123&_a=summary");
+            metadata.BuildNumber.Should().Be("123.456");
             metadata.Remote.Should().Be("https://repo.uri");
             metadata.Revision.Should().Be("abc123");
             metadata.Branch.Should().Be("main");


### PR DESCRIPTION
### 🤔 What's changed?

Changed the way how the build URL is detected based on https://stackoverflow.com/a/52111404/26530.

### ⚡️ What's your motivation? 

Before the fix the build URL in the HTML report pointed to something like `vstfs:///Build/Build/4450` that cannot be opened.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?


### 📋 Checklist:

- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] Users should know about my change
  - [ ] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
