### PR TITLE
File formatter fails under net462 when output file path is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,10 @@
 ## Improvements:
 
 ## Bug fixes:
+* Fix Formatters Fail under .NET Framework when OutputFilePath is not configured (#797)
 
 *Contributors of this release (in alphabetical order):* 
+@clrudolphi
 
 # v3.0.0 - 2025-08-21
 

--- a/Reqnroll/Formatters/FileWritingFormatterBase.cs
+++ b/Reqnroll/Formatters/FileWritingFormatterBase.cs
@@ -58,7 +58,7 @@ public abstract class FileWritingFormatterBase : FormatterBase
         {
             string fileName;
 
-            // Path.GetFileName and GetDirectoryName may under .NET 4.6.2
+            // Path.GetFileName and GetDirectoryName may throw exceptions under .NET 4.6.2 while .net core will return null
             try
             {
                 fileName = Path.GetFileName(configuredPath);

--- a/Reqnroll/Formatters/FileWritingFormatterBase.cs
+++ b/Reqnroll/Formatters/FileWritingFormatterBase.cs
@@ -30,9 +30,9 @@ public abstract class FileWritingFormatterBase : FormatterBase
         string defaultFileExtension,
         string defaultFileName) : base(configurationProvider, logger, pluginName)
     {
-        if (String.IsNullOrEmpty(defaultFileExtension))
+        if (string.IsNullOrEmpty(defaultFileExtension))
             throw new ArgumentNullException(nameof(defaultFileExtension));
-        if (String.IsNullOrEmpty(defaultFileName))
+        if (string.IsNullOrEmpty(defaultFileName))
             throw new ArgumentNullException(nameof(defaultFileName));
         _defaultFileExtension = defaultFileExtension;
         _defaultFileName = defaultFileName;

--- a/Reqnroll/Formatters/FileWritingFormatterBase.cs
+++ b/Reqnroll/Formatters/FileWritingFormatterBase.cs
@@ -44,7 +44,7 @@ public abstract class FileWritingFormatterBase : FormatterBase
     public override void LaunchInner(IDictionary<string, object> formatterConfiguration, Action<bool> onInitialized)
     {
         var defaultBaseDirectory = ".";
-        var configuredPath = ConfiguredOutputFilePath(formatterConfiguration)?.Trim() ?? string.Empty;
+        var configuredPath = ConfiguredOutputFilePath(formatterConfiguration)?.Trim();
         string outputPath;
         string baseDirectory;
 


### PR DESCRIPTION
### 🤔 What's changed?

Refactored FileWritingFormatterBase more robustly handle empty or missing configuration.

### ⚡️ What's your motivation? 

Fix #797 

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)


### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [X] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [X] Users should know about my change
  - [X] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
