### PR TITLE
Fix JSON syntax and typo in Reqnroll.Assist.Dynamic README

### DIFF
--- a/Plugins/Reqnroll.Assist.Dynamic/README.md
+++ b/Plugins/Reqnroll.Assist.Dynamic/README.md
@@ -11,7 +11,7 @@ CLI : dotnet add package ReqnrollExtra.Assist.Dynamic
 Add to reqnroll.json
 ```json
 {
-  bindingAssemblies: [
+  "bindingAssemblies": [
     {
       "assembly": "Reqnroll.Assist.Dynamic"
     }


### PR DESCRIPTION
Corrected JSON structure and fixed assembly name typo (DynamSic → Dynamic)


### 🤔 What's changed?

  Fixed JSON syntax errors and a typo in the Reqnroll.Assist.Dynamic plugin README:
  - Added proper JSON object structure with curly braces around the configuration
  - Corrected assembly name from "Reqnroll.Assist.DynamSic" to "Reqnroll.Assist.Dynamic"

  ### ⚡️ What's your motivation?

  The README contained invalid JSON syntax that would prevent users from properly configuring the plugin.
   The assembly name typo would also cause configuration errors when users try to follow the
  documentation.

  ### 🏷️ What kind of change is this?

  - :book: Documentation (improvements without changing code)

  ### ♻️ Anything particular you want feedback on?

  N/A - straightforward documentation fix.

  ### 📋 Checklist:

  - [ ] I've changed the behaviour of the code
    - [ ] ~~I have added/updated tests to cover my changes.~~ (Not applicable - documentation only)
  - [x] My change requires a change to the documentation.
    - [x] I have updated the documentation accordingly.
  - [ ] Users should know about my change
    - [ ] ~~I have added an entry to the "[vNext]" section of the
  [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to
   the release contributors list.~~ (Minor documentation fix - not user-facing)