### PR TITLE
Remove unnecessary build message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ## Bug fixes:
 
-*Contributors of this release (in alphabetical order):* 
+* Fix: Unnecessary build output messages are shown during build (#815)
+
+*Contributors of this release (in alphabetical order):* @gasparnagy
 
 # v3.0.1 - 2025-09-05
 

--- a/Reqnroll.Tools.MsBuild.Generation/build/Reqnroll.Tools.MsBuild.Generation.targets
+++ b/Reqnroll.Tools.MsBuild.Generation/build/Reqnroll.Tools.MsBuild.Generation.targets
@@ -154,9 +154,6 @@
       </EmbeddedResource>
     </ItemGroup>
     
-    <!-- TODO: Remove this Message after Messages Development -->
-    <Message Text="ReqnrollGeneratedNdjsonFiles: @(ReqnrollGeneratedFiles->'%(EmbeddedMessagesStoragePath)')" Importance="high" />
-
     <ItemGroup>
       <EmbeddedResource Include="@(ReqnrollGeneratedFiles->'%(EmbeddedMessagesStoragePath)')" Condition="'%(ReqnrollGeneratedFiles.EmbeddedMessagesStoragePath)' != ''">
         <LogicalName>%(ReqnrollGeneratedFiles.EmbeddedMessagesResourceName)</LogicalName>


### PR DESCRIPTION
### 🤔 What's changed?

Removed a leftover build message that has been introduced for debug purposes by #802.

### ⚡️ What's your motivation? 

Currently Reqnroll shows extra messages during build.

```
2>------ Build started: Project: ReqnrollCalculator.Specs, Configuration: Debug Any CPU ------
2>ReqnrollGeneratedNdjsonFiles: obj\Debug\net8.0\Features\Addition.feature.ndjson;obj\Debug\net8.0\Features\Multiplication.feature.ndjson    <-----
2>ReqnrollCalculator.Specs -> C:\Users\GáspárNagy\source\repos\Reqnroll.ExploratoryTestProjects\ReqnrollCalculator\ReqnrollCalculator.Specs\bin\Debug\net8.0\ReqnrollCalculator.Specs.dll

```

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

### 📋 Checklist:

- [x] I've changed the behaviour of the code
- [x] Users should know about my change
  - [x] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
