### PR TITLE
Add support for scenario-level non-parallelizable tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [vNext]
 
+## New features:
+
+* Generator: `addNonParallelizableMarkerForTags` now also applies to scenario-level tags for frameworks supporting method-level isolation (NUnit, MsTest V2, TUnit).
+
 ## Improvements:
 
 ## Bug fixes:

--- a/Plugins/Reqnroll.TUnit.Generator.ReqnrollPlugin/TUnitTestGeneratorProvider.cs
+++ b/Plugins/Reqnroll.TUnit.Generator.ReqnrollPlugin/TUnitTestGeneratorProvider.cs
@@ -88,6 +88,11 @@ public class TUnitTestGeneratorProvider : IUnitTestGeneratorProvider
         CodeDomHelper.AddAttribute(generationContext.TestClass, NOTINPARALLEL_ATTR);
     }
 
+    public void SetTestMethodNonParallelizable(TestClassGenerationContext generationContext, CodeMemberMethod testMethod)
+    {
+        CodeDomHelper.AddAttribute(testMethod, NOTINPARALLEL_ATTR);
+    }
+
     public void SetTestClassInitializeMethod(TestClassGenerationContext generationContext)
     {
         // For class-level initialization, use [Before(Class)].

--- a/Reqnroll.Generator/DefaultDependencyProvider.cs
+++ b/Reqnroll.Generator/DefaultDependencyProvider.cs
@@ -38,7 +38,8 @@ namespace Reqnroll.Generator
             container.RegisterTypeAs<DecoratorRegistry, IDecoratorRegistry>();
             container.RegisterTypeAs<IgnoreDecorator, ITestClassTagDecorator>("ignore");
             container.RegisterTypeAs<IgnoreDecorator, ITestMethodTagDecorator>("ignore");
-            container.RegisterTypeAs<NonParallelizableDecorator, ITestClassDecorator>("nonparallelizable");
+            container.RegisterTypeAs<NonParallelizableDecorator, ITestClassTagDecorator>("nonparallelizable");
+            container.RegisterTypeAs<NonParallelizableDecorator, ITestMethodTagDecorator>("nonparallelizable");
 
             container.RegisterInstanceAs(GenerationTargetLanguage.CreateCodeDomHelper(GenerationTargetLanguage.CSharp), GenerationTargetLanguage.CSharp, dispose: true);
             container.RegisterInstanceAs(GenerationTargetLanguage.CreateCodeDomHelper(GenerationTargetLanguage.VB), GenerationTargetLanguage.VB, dispose: true);

--- a/Reqnroll.Generator/UnitTestConverter/NonParallelizableDecorator.cs
+++ b/Reqnroll.Generator/UnitTestConverter/NonParallelizableDecorator.cs
@@ -1,12 +1,12 @@
+using System.CodeDom;
 using System.Collections.Generic;
 using System.Linq;
 using Reqnroll.Configuration;
 using Reqnroll.Generator.UnitTestProvider;
-using Reqnroll.Parser;
 
 namespace Reqnroll.Generator.UnitTestConverter
 {
-    public class NonParallelizableDecorator : ITestClassDecorator
+    public class NonParallelizableDecorator : ITestClassTagDecorator, ITestMethodTagDecorator
     {
         private readonly string[] nonParallelizableTags;
         private readonly ITagFilterMatcher tagFilterMatcher;
@@ -22,12 +22,32 @@ namespace Reqnroll.Generator.UnitTestConverter
             get { return PriorityValues.Low; }
         }
 
-        public bool CanDecorateFrom(TestClassGenerationContext generationContext)
+        public bool RemoveProcessedTags
         {
-            return ProviderSupportsParallelExecution(generationContext) && ConfiguredTagIsPresent(generationContext.Feature.Tags.Select(x => x.GetNameWithoutAt()));
+            get { return false; }
         }
 
-        public void DecorateFrom(TestClassGenerationContext generationContext)
+        public bool ApplyOtherDecoratorsForProcessedTags
+        {
+            get { return true; }
+        }
+
+        public bool CanDecorateFrom(string tagName, TestClassGenerationContext generationContext, CodeMemberMethod testMethod)
+        {
+            return ProviderSupportsParallelExecution(generationContext) && ConfiguredTagIsPresent(new[] { tagName });
+        }
+
+        public void DecorateFrom(string tagName, TestClassGenerationContext generationContext, CodeMemberMethod testMethod)
+        {
+            generationContext.UnitTestGeneratorProvider.SetTestMethodNonParallelizable(generationContext, testMethod);
+        }
+
+        public bool CanDecorateFrom(string tagName, TestClassGenerationContext generationContext)
+        {
+            return ProviderSupportsParallelExecution(generationContext) && ConfiguredTagIsPresent(new[] { tagName });
+        }
+
+        public void DecorateFrom(string tagName, TestClassGenerationContext generationContext)
         {
             generationContext.UnitTestGeneratorProvider.SetTestClassNonParallelizable(generationContext);
         }

--- a/Reqnroll.Generator/UnitTestProvider/IUnitTestGeneratorProvider.cs
+++ b/Reqnroll.Generator/UnitTestProvider/IUnitTestGeneratorProvider.cs
@@ -12,6 +12,7 @@ namespace Reqnroll.Generator.UnitTestProvider
         void SetTestClassIgnore(TestClassGenerationContext generationContext);
         void FinalizeTestClass(TestClassGenerationContext generationContext);
         void SetTestClassNonParallelizable(TestClassGenerationContext generationContext);
+        void SetTestMethodNonParallelizable(TestClassGenerationContext generationContext, CodeMemberMethod testMethod);
 
         void SetTestClassInitializeMethod(TestClassGenerationContext generationContext);
         void SetTestClassCleanupMethod(TestClassGenerationContext generationContext);

--- a/Reqnroll.Generator/UnitTestProvider/MsTestGeneratorProvider.cs
+++ b/Reqnroll.Generator/UnitTestProvider/MsTestGeneratorProvider.cs
@@ -102,6 +102,11 @@ namespace Reqnroll.Generator.UnitTestProvider
             //Not Supported            
         }
 
+        public virtual void SetTestMethodNonParallelizable(TestClassGenerationContext generationContext, CodeMemberMethod testMethod)
+        {
+            // Not Supported
+        }
+
         public virtual void SetTestClassInitializeMethod(TestClassGenerationContext generationContext)
         {
             generationContext.TestClassInitializeMethod.Attributes |= MemberAttributes.Static;

--- a/Reqnroll.Generator/UnitTestProvider/MsTestV2GeneratorProvider.cs
+++ b/Reqnroll.Generator/UnitTestProvider/MsTestV2GeneratorProvider.cs
@@ -265,6 +265,11 @@ namespace Reqnroll.Generator.UnitTestProvider
             CodeDomHelper.AddAttribute(generationContext.TestClass, DONOTPARALLELIZE_ATTR);
         }
 
+        public override void SetTestMethodNonParallelizable(TestClassGenerationContext generationContext, CodeMemberMethod testMethod)
+        {
+            CodeDomHelper.AddAttribute(testMethod, DONOTPARALLELIZE_ATTR);
+        }
+
         private IEnumerable<string> GetNonMSTestSpecificTags(IEnumerable<string> tags)
         {
             return tags == null ? new string[0] : tags.Where(t => !t.StartsWith(OWNER_TAG, StringComparison.InvariantCultureIgnoreCase))

--- a/Reqnroll.Generator/UnitTestProvider/NUnit3TestGeneratorProvider.cs
+++ b/Reqnroll.Generator/UnitTestProvider/NUnit3TestGeneratorProvider.cs
@@ -69,6 +69,11 @@ namespace Reqnroll.Generator.UnitTestProvider
             CodeDomHelper.AddAttribute(generationContext.TestClass, NONPARALLELIZABLE_ATTR);
         }
 
+        public virtual void SetTestMethodNonParallelizable(TestClassGenerationContext generationContext, CodeMemberMethod testMethod)
+        {
+            CodeDomHelper.AddAttribute(testMethod, NONPARALLELIZABLE_ATTR);
+        }
+
         public void SetTestClass(TestClassGenerationContext generationContext, string featureTitle, string featureDescription)
         {
             CodeDomHelper.AddAttribute(generationContext.TestClass, TESTFIXTURE_ATTR);

--- a/Reqnroll.Generator/UnitTestProvider/XUnit2TestGeneratorProvider.cs
+++ b/Reqnroll.Generator/UnitTestProvider/XUnit2TestGeneratorProvider.cs
@@ -203,6 +203,11 @@ namespace Reqnroll.Generator.UnitTestProvider
             CodeDomHelper.AddAttribute(generationContext.TestClass, COLLECTION_ATTRIBUTE, new CodeAttributeArgument(new CodePrimitiveExpression(NONPARALLELIZABLE_COLLECTION_NAME)));
         }
 
+        public virtual void SetTestMethodNonParallelizable(TestClassGenerationContext generationContext, CodeMemberMethod testMethod)
+        {
+            // xUnit does not support method-level parallelization
+        }
+
         public virtual void FinalizeTestClass(TestClassGenerationContext generationContext)
         {
             IgnoreFeature(generationContext);

--- a/Tests/Reqnroll.GeneratorTests/Reqnroll.GeneratorTests.csproj
+++ b/Tests/Reqnroll.GeneratorTests/Reqnroll.GeneratorTests.csproj
@@ -21,6 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\Plugins\Reqnroll.TUnit.Generator.ReqnrollPlugin\Reqnroll.TUnit.Generator.ReqnrollPlugin.csproj" />
     <ProjectReference Include="..\..\Reqnroll.Tools.MsBuild.Generation\Reqnroll.Tools.MsBuild.Generation.csproj" />
     <ProjectReference Include="..\..\Reqnroll.Generator\Reqnroll.Generator.csproj" />
   </ItemGroup>

--- a/Tests/Reqnroll.GeneratorTests/UnitTestProvider/MsTestGeneratorProviderTests.cs
+++ b/Tests/Reqnroll.GeneratorTests/UnitTestProvider/MsTestGeneratorProviderTests.cs
@@ -245,6 +245,29 @@ namespace Reqnroll.GeneratorTests.UnitTestProvider
             attributes.Should().NotContain(a => a.Name == "Microsoft.VisualStudio.TestTools.UnitTesting.DoNotParallelizeAttribute");
         }
 
+        [Fact]
+        public void MsTestGeneratorProvider_WithScenarioTagOnly_ShouldNotAddDoNotParallelizeAttribute()
+        {
+            // ARRANGE
+            var document = ParseDocumentFromString(@"
+            Feature: Sample feature file
+
+            @nonparallelizable
+            Scenario: Isolated scenario
+                Given there is something");
+
+            var provider = new MsTestGeneratorProvider(new CodeDomHelper(CodeDomProviderLanguage.CSharp));
+            var featureGenerator = provider.CreateFeatureGenerator(addNonParallelizableMarkerForTags: new[] { "nonparallelizable" });
+
+            // ACT
+            var code = featureGenerator.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace").CodeNamespace;
+
+            // ASSERT
+            code.Class().CustomAttributes().Should().NotContain(a => a.Name == "Microsoft.VisualStudio.TestTools.UnitTesting.DoNotParallelizeAttribute");
+            var method = code.Class().Members().Single(m => m.Name == "IsolatedScenario");
+            method.CustomAttributes().Should().NotContain(a => a.Name == "Microsoft.VisualStudio.TestTools.UnitTesting.DoNotParallelizeAttribute");
+        }
+
         // Test for GH#588 - Generator Provider adds Friendly Name as an argument to the TestMethodAttribute on a non-paramterized test
         [Fact]
         public void MsTestGeneratorProvider_SimpleScenario_ShouldProvideFriendlyNameForTestMethodAttribute()

--- a/Tests/Reqnroll.GeneratorTests/UnitTestProvider/NUnit3GeneratorProviderTests.cs
+++ b/Tests/Reqnroll.GeneratorTests/UnitTestProvider/NUnit3GeneratorProviderTests.cs
@@ -258,6 +258,22 @@ namespace Reqnroll.GeneratorTests.UnitTestProvider
             var attribute = attributes.Should().NotContain(a => a.Name == "NUnit.Framework.NonParallelizableAttribute");
         }
 
+        [Fact]
+        public void NUnit3TestGeneratorProvider_ScenarioTagMatching_ShouldAddNonParallelizableAttributeToMethodOnly()
+        {
+            var feature = @"
+            Feature: Sample feature file
+
+            @nonparallelizable
+            Scenario: Isolated scenario
+                Given there is something";            
+            var code = GenerateCodeNamespaceFromFeature(feature, addNonParallelizableMarkerForTags: new[] { "nonparallelizable" });
+            code.Class().CustomAttributes().Should().NotContain(a => a.Name == "NUnit.Framework.NonParallelizableAttribute");
+            
+            var method = code.Class().Members().Single(m => m.Name == "IsolatedScenario");
+            method.CustomAttributes().Should().Contain(a => a.Name == "NUnit.Framework.NonParallelizableAttribute");
+        }
+
         public CodeNamespace GenerateCodeNamespaceFromFeature(string feature, bool parallelCode = false, string[] addNonParallelizableMarkerForTags = null)
         {
             CodeNamespace code;

--- a/Tests/Reqnroll.GeneratorTests/UnitTestProvider/TUnitTestGeneratorProviderTests.cs
+++ b/Tests/Reqnroll.GeneratorTests/UnitTestProvider/TUnitTestGeneratorProviderTests.cs
@@ -1,0 +1,70 @@
+using System.CodeDom;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using FluentAssertions;
+using Reqnroll.Configuration;
+using Reqnroll.Generator;
+using Reqnroll.Generator.CodeDom;
+using Reqnroll.Generator.Interfaces;
+using Reqnroll.Generator.UnitTestConverter;
+using Reqnroll.Generator.UnitTestProvider;
+using Reqnroll.Parser;
+using Reqnroll.TUnit.Generator.ReqnrollPlugin;
+using Reqnroll.UnitTestProvider;
+using Xunit;
+
+namespace Reqnroll.GeneratorTests.UnitTestProvider
+{
+    public class TUnitTestGeneratorProviderTests
+    {
+        private const string FeatureTemplate = "Feature: Sample feature file\n\nScenario: Simple scenario\n    Given there is something";
+
+        [Fact]
+        public void TUnitTestGeneratorProvider_FeatureTag_ShouldAddNotInParallelAttributeToClass()
+        {
+            var feature = "@nonparallelizable\n" + FeatureTemplate;
+            var code = GenerateCodeNamespaceFromFeature(feature, addNonParallelizableMarkerForTags: new[] { "nonparallelizable" });
+            code.Class().CustomAttributes().Should().Contain(a => a.Name == "TUnit.Core.NotInParallelAttribute");
+        }
+
+        [Fact]
+        public void TUnitTestGeneratorProvider_ScenarioTagOnly_ShouldAddNotInParallelAttributeToMethod()
+        {
+            var feature = "Feature: Sample feature file\n\n@nonparallelizable\nScenario: Isolated scenario\n    Given there is something";
+            var code = GenerateCodeNamespaceFromFeature(feature, addNonParallelizableMarkerForTags: new[] { "nonparallelizable" });
+            code.Class().CustomAttributes().Should().NotContain(a => a.Name == "TUnit.Core.NotInParallelAttribute");
+            var method = code.Class().Members().Single(m => m.Name == "IsolatedScenario");
+            method.CustomAttributes().Should().Contain(a => a.Name == "TUnit.Core.NotInParallelAttribute");
+        }
+
+        private CodeNamespace GenerateCodeNamespaceFromFeature(string featureSource, string[] addNonParallelizableMarkerForTags)
+        {
+            using var reader = new StringReader(featureSource);
+            var parser = new ReqnrollGherkinParser(new CultureInfo("en-US"));
+            var document = parser.Parse(reader, new ReqnrollDocumentLocation("test.feature"));
+            var featureGenerator = CreateFeatureGenerator(addNonParallelizableMarkerForTags);
+            return featureGenerator.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace").CodeNamespace;
+        }
+
+        private IFeatureGenerator CreateFeatureGenerator(string[] addNonParallelizableMarkerForTags)
+        {
+            var container = new GeneratorContainerBuilder().CreateContainer(
+                new ReqnrollConfigurationHolder(ConfigSource.Default, null),
+                new ProjectSettings(),
+                Enumerable.Empty<GeneratorPluginInfo>());
+
+            container.RegisterTypeAs<TUnitTestGeneratorProvider, IUnitTestGeneratorProvider>("tunit");
+
+            var unitTestProviderConfig = container.Resolve<UnitTestProviderConfiguration>();
+            unitTestProviderConfig.UseUnitTestProvider("tunit");
+
+            container.RegisterInstanceAs<IUnitTestGeneratorProvider>(new TUnitTestGeneratorProvider(new CodeDomHelper(CodeDomProviderLanguage.CSharp)));
+
+            var config = container.Resolve<ReqnrollConfiguration>();
+            config.AddNonParallelizableMarkerForTags = addNonParallelizableMarkerForTags;
+
+            return container.Resolve<UnitTestFeatureGeneratorProvider>().CreateGenerator(ParserHelper.CreateAnyDocument());
+        }
+    }
+}

--- a/Tests/Reqnroll.GeneratorTests/UnitTestProvider/XUnit2TestGeneratorProviderTests.cs
+++ b/Tests/Reqnroll.GeneratorTests/UnitTestProvider/XUnit2TestGeneratorProviderTests.cs
@@ -450,6 +450,28 @@ namespace Reqnroll.GeneratorTests.UnitTestProvider
             attributes.Should().NotContain(a => a.Name == XUnitCollectionAttribute);
         }
 
+        [Fact]
+        public void XUnit2TestGeneratorProvider_ScenarioTagOnly_ShouldNotAddNonParallelizableCollectionAttribute()
+        {
+            // ARRANGE
+            var document = ParseDocumentFromString(@"
+            Feature: Sample feature file
+
+            @nonparallelizable
+            Scenario: Isolated scenario
+                Given there is something");
+            var provider = new XUnit2TestGeneratorProvider(new CodeDomHelper(CodeDomProviderLanguage.CSharp));
+            var featureGenerator = provider.CreateFeatureGenerator(addNonParallelizableMarkerForTags: new [] { "nonparallelizable" });
+
+            // ACT
+            var code = featureGenerator.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace").CodeNamespace;
+
+            // ASSERT
+            code.Class().CustomAttributes().Should().NotContain(a => a.Name == XUnitCollectionAttribute);
+            var method = code.Class().Members().Single(m => m.Name == "IsolatedScenario");
+            method.CustomAttributes().Should().NotContain(a => a.Name == XUnitCollectionAttribute);
+        }
+
         public ReqnrollDocument ParseDocumentFromString(string documentSource, CultureInfo parserCultureInfo = null)
         {
             var parser = new ReqnrollGherkinParser(parserCultureInfo ?? new CultureInfo("en-US"));

--- a/docs/installation/configuration.md
+++ b/docs/installation/configuration.md
@@ -113,7 +113,7 @@ Use this section to define test generation options.
   - Determines whether "row tests" should be generated for [scenario outlines](../gherkin/gherkin-reference.md#scenario-outline). This setting is ignored if the [test execution framework](setup-project.md#choosing-your-test-execution-framework) does not support row based testing. <br/> *Default:* `true`
 * - addNonParallelizableMarkerForTags
   - List of tags
-  - Defines a set of tags, any of which specify that a feature should be excluded from running in parallel with any other feature. See [](../execution/parallel-execution).<br/> *Default:* empty
+  - Defines a set of tags that mark tests as exclusive (non-parallelizable). If the tag appears on a feature, the whole generated test class is marked non-parallelizable. If the tag appears only on a scenario (and not on the feature), the generated test method is marked non-parallelizable on frameworks that support scenario/method level isolation (currently NUnit, MsTest V2 and TUnit). See [](../execution/parallel-execution).<br/> *Default:* empty
 ```
 
 ### `runtime`


### PR DESCRIPTION
### 🤔 What’s changed?

This PR extends the existing `generator.addNonParallelizableMarkerForTags` so it applies not only to **features** (class level) but also to **scenarios** (method level) **where the test framework supports method-level isolation**—without introducing any new configuration keys.

**Per framework behavior:**

* **NUnit** → when a scenario has any tag listed in `addNonParallelizableMarkerForTags`, the generated **scenario test method** is decorated with `[NUnit.Framework.NonParallelizable]`.
  Docs: [https://docs.nunit.org/articles/nunit/writing-tests/attributes/nonparallelizable.html](https://docs.nunit.org/articles/nunit/writing-tests/attributes/nonparallelizable.html)
* **MSTest v2** → the scenario test method is decorated with `[Microsoft.VisualStudio.TestTools.UnitTesting.DoNotParallelize]`.
  Docs: [https://learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-mstest-writing-tests-attributes#donotparallelizeattribute](https://learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-mstest-writing-tests-attributes#donotparallelizeattribute)
* **TUnit** → the scenario test method is decorated with `[TUnit.Framework.NotInParallel]`.
  Docs: [https://tunit.dev/docs/parallelism/not-in-parallel](https://tunit.dev/docs/parallelism/not-in-parallel)
* **xUnit** → unchanged (xUnit/collection/fixture model); scenario-level tags are ignored by design, while existing **feature-level** behavior remains.

Feature-level logic is kept intact for all frameworks: tagging a **feature** with any of these tags still marks the generated **test class** as non-parallelizable.

**No new config:** the PR **reuses** `generator.addNonParallelizableMarkerForTags` and does not add new keys.

---

### ⚡️ What’s your motivation?

Some suites only need to isolate **a few scenarios** (e.g., seed/cleanup shared state) while keeping the rest of the feature parallel for speed. Today this requires splitting features or creating separate CI jobs. By applying the existing setting to **scenario methods** where supported (NUnit, MSTest v2, TUnit), teams can keep parallelism high and isolate only what’s necessary—without changing configuration.

Related discussion: [https://github.com/orgs/reqnroll/discussions/825](https://github.com/orgs/reqnroll/discussions/825)

---

### 🏷️ What kind of change is this?

* \:zap: New feature (non-breaking change which adds new behaviour)
* \:book: Documentation (adds small notes to parallel-execution/config pages)

---

### ♻️ Anything particular you want feedback on?

* Placement and naming of the small helper that checks scenario tags vs. `AddNonParallelizableMarkerForTags`.
* Provider-specific attribute types (NUnit/MSTest v2/TUnit) — confirm we’ve used the correct attribute class names and namespaces for each provider.
* Whether we should also emit an explicit Category for the matched tag on the method (we **did not**; kept this PR focused).

---

### 📋 Checklist:

* [ ] I’ve changed the behaviour of the code

  * [ ] I have added/updated tests to cover my changes (NUnit, MSTest v2, TUnit providers).
* [ ] My change requires a change to the documentation.

  * [ ] I have updated the documentation accordingly (parallel execution + configuration pages: note that `addNonParallelizableMarkerForTags` now applies to **features and scenarios**, with scenario-level effect on NUnit/MSTest v2/TUnit only; xUnit remains feature-level).
* [ ] Users should know about my change

  * [ ] I have added an entry to the “\[vNext]” section of the **CHANGELOG**, linking to this PR and including my GitHub handle.

---

### Usage example

```jsonc
// reqnroll.json
{
  "generator": {
    "addNonParallelizableMarkerForTags": [ "serial", "isolation" ]
  }
}
```

```gherkin
Feature: Sample

  @serial
  Scenario: Only this scenario must run in isolation
    Given ...
    When  ...
    Then  ...
```

* With NUnit/MSTest v2/TUnit: the generated **scenario method** is marked non-parallelizable.
* With xUnit: scenario-level tag is ignored; feature-level tagging continues to work as today.
