### PR TITLE
Formatters additional file handling exception logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # [vNext]
 
 ## Improvements:
+* Formatters: enchanced logging of exception information when file-based formatters throw exceptions
 
 ## Bug fixes:
 * Fix: Step Execution improperly handles error flows when StopAtFirstError is true resulting in skipped StepStartedEvent.

--- a/Reqnroll/Formatters/FileWritingFormatterBase.cs
+++ b/Reqnroll/Formatters/FileWritingFormatterBase.cs
@@ -98,7 +98,9 @@ public abstract class FileWritingFormatterBase : FormatterBase
             catch (System.Exception e)
             {
                 onInitialized(false);
-                Logger.WriteMessage($"An exception {e.Message} occurred creating the destination directory({baseDirectory} for Formatter {Name}. The formatter will be disabled.");
+                Logger.WriteMessage($"An exception {e.Message} occurred creating the destination directory({baseDirectory} for Formatter {Name}. The formatter will be disabled."
+                    + Environment.NewLine
+                    + e.StackTrace);
                 return;
             }
         }
@@ -123,7 +125,7 @@ public abstract class FileWritingFormatterBase : FormatterBase
                     Logger.WriteMessage($"Formatter {Name} has been cancelled.");
                     break;
                 }
-                await WriteToFile(message, cancellationToken);                
+                await WriteToFile(message, cancellationToken);
             }
         }
         catch (OperationCanceledException)
@@ -133,7 +135,9 @@ public abstract class FileWritingFormatterBase : FormatterBase
         }
         catch (System.Exception e)
         {
-            Logger.WriteMessage($"Formatter {Name} threw an exception: {e.Message}. No further messages will be processed.");
+            Logger.WriteMessage($"Formatter {Name} threw an exception: {e.Message}. No further messages will be processed."
+                    + Environment.NewLine
+                    + e.StackTrace);
             throw;
         }
         finally
@@ -145,7 +149,9 @@ public abstract class FileWritingFormatterBase : FormatterBase
             }
             catch (System.Exception e)
             {
-                Logger.WriteMessage($"Formatter {Name} file stream flush threw an exception: {e.Message}.");
+                Logger.WriteMessage($"Formatter {Name} file stream flush threw an exception: {e.Message}."
+                    + Environment.NewLine
+                    + e.StackTrace);
             }
         }
     }
@@ -159,14 +165,17 @@ public abstract class FileWritingFormatterBase : FormatterBase
             onInitialized(true);
             Logger.WriteMessage($"Formatter {Name} opened file stream.");
         }
-        catch
+        catch(System.Exception e)
         {
-            Logger.WriteMessage($"Formatter {Name} closing because of an exception opening the file stream.");
+            Logger.WriteMessage($"Formatter {Name} closing because of an exception opening the file stream."
+                                 + Environment.NewLine
+                                 + e.StackTrace);
+
             onInitialized(false);
         }
     }
 
-    protected virtual Stream CreateTargetFileStream(string outputPath) => 
+    protected virtual Stream CreateTargetFileStream(string outputPath) =>
         File.Create(outputPath, TUNING_PARAM_FILE_WRITE_BUFFER_SIZE);
 
     protected abstract void OnTargetFileStreamInitialized(Stream targetFileStream);


### PR DESCRIPTION

### 🤔 What's changed?

Stack trace information is added to the Formatters log when the File based formatters encounter an exception.

### ⚡️ What's your motivation? 

Easier debugging.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)


### ♻️ Anything particular you want feedback on?

Are there any other locations where this type of logging should occur?

### 📋 Checklist:


- [X] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [X] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
