### PR TITLE
Fix: Exceptions from before scenario plugin hook events are not shown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ## Bug fixes:
 
 * Fix: Exceptions from before scenario plugin hook events (RuntimePluginTestExecutionLifecycleEvents.BeforeScenario) are not shown (#856)
+* Fix: Before scenario hooks are not raised immediately when `runtime/stopAtFirstError` is true, but handled delayed (#857)
 
 *Contributors of this release (in alphabetical order):* @chekkan, @Code-Grump, @gasparnagy, @konarx
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@
 
 ## Bug fixes:
 
-*Contributors of this release (in alphabetical order):* @chekkan, @Code-Grump, @konarx
+* Fix: Exceptions from before scenario plugin hook events (RuntimePluginTestExecutionLifecycleEvents.BeforeScenario) are not shown (#856)
+
+*Contributors of this release (in alphabetical order):* @chekkan, @Code-Grump, @gasparnagy, @konarx
 
 # v3.0.3 - 2025-09-17
 

--- a/Reqnroll/Infrastructure/TestExecutionEngine.cs
+++ b/Reqnroll/Infrastructure/TestExecutionEngine.cs
@@ -352,8 +352,16 @@ namespace Reqnroll.Infrastructure
             }
 
             //Note: plugin-hooks are still executed even if a user-hook failed with an exception
-            //A plugin-hook should not throw an exception under normal circumstances, exceptions are not handled/caught here
-            await FireRuntimePluginTestExecutionLifecycleEventsAsync(hookType);
+            //A plugin-hook should not throw an exception under normal circumstances, still, we handle them like user-hooks
+            try
+            {
+                await FireRuntimePluginTestExecutionLifecycleEventsAsync(hookType);
+            }
+            catch (Exception hookExceptionCaught)
+            {
+                hookException = hookExceptionCaught;
+                SetHookError(hookType, hookException);
+            }
 
             await _testThreadExecutionEventPublisher.PublishEventAsync(new HookFinishedEvent(hookType, FeatureContext, ScenarioContext, _contextManager.StepContext, hookException));
 

--- a/Reqnroll/Infrastructure/TestExecutionEngine.cs
+++ b/Reqnroll/Infrastructure/TestExecutionEngine.cs
@@ -192,9 +192,9 @@ namespace Reqnroll.Infrastructure
             }
             catch (Exception)
             {
-                // Removed code that sets the ScenarioContext.TestError and ScenarioContext.ScenarioExecutionStatus, because
-                // FireEventsAsync called by FireScenarioEventsAsync sets *Context.TestError and ScenarioContext.ScenarioExecutionStatus.
-                // The fact that the exception is not rethrown here is suspicious, but it is the current behavior. We need to check it eventually.
+                // When StopAtFirstError is false (default), we do not rethrow the exception, because it will be handled in OnAfterLastStepAsync
+                if (_reqnrollConfiguration.StopAtFirstError)
+                    throw;
             }
         }
 

--- a/Reqnroll/Infrastructure/TestExecutionEngine.cs
+++ b/Reqnroll/Infrastructure/TestExecutionEngine.cs
@@ -359,8 +359,12 @@ namespace Reqnroll.Infrastructure
             }
             catch (Exception hookExceptionCaught)
             {
-                hookException = hookExceptionCaught;
-                SetHookError(hookType, hookException);
+                // we do not overwrite an existing exception as that might be the root cause of the failure
+                if (hookException == null)
+                {
+                    hookException = hookExceptionCaught;
+                    SetHookError(hookType, hookException);
+                }
             }
 
             await _testThreadExecutionEventPublisher.PublishEventAsync(new HookFinishedEvent(hookType, FeatureContext, ScenarioContext, _contextManager.StepContext, hookException));

--- a/Tests/Reqnroll.RuntimeTests/Infrastructure/TestExecutionEngineRuntimePluginEventsTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/Infrastructure/TestExecutionEngineRuntimePluginEventsTests.cs
@@ -121,9 +121,12 @@ namespace Reqnroll.RuntimeTests.Infrastructure
             _runtimePluginTestExecutionLifecycleEventEmitter.Verify(e => e.RaiseExecutionLifecycleEventAsync(HookType.BeforeScenario, It.IsAny<IObjectContainer>()));
         }
         
-        [Fact]
-        public async Task Should_emit_runtime_plugin_test_execution_lifecycle_event_beforescenario_after_hook_error_and_throw_error()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Should_emit_runtime_plugin_test_execution_lifecycle_event_beforescenario_after_hook_error_and_throw_error(bool stopAtFirstError)
         {
+            _reqnrollConfiguration.StopAtFirstError = stopAtFirstError;
             var testExecutionEngine = CreateTestExecutionEngine();
             var handledInOnAfterLastStep = false;
 
@@ -138,15 +141,18 @@ namespace Reqnroll.RuntimeTests.Infrastructure
 
             await act.Should().ThrowAsync<Exception>().WithMessage(SimulatedErrorMessage);
             _runtimePluginTestExecutionLifecycleEventEmitter.Verify(e => e.RaiseExecutionLifecycleEventAsync(HookType.BeforeScenario, It.IsAny<IObjectContainer>()));
-            handledInOnAfterLastStep.Should().BeTrue();
+            handledInOnAfterLastStep.Should().Be(!stopAtFirstError); // in case of stopAtFirstError, the error should come from OnScenarioStartAsync
         }
 
-        [Fact]
-        public async Task Should_emit_runtime_plugin_test_execution_lifecycle_event_beforescenario_after_plugin_hook_error_and_throw_error()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Should_emit_runtime_plugin_test_execution_lifecycle_event_beforescenario_after_plugin_hook_error_and_throw_error(bool stopAtFirstError)
         {
             // this test is similar to the previous one, but it simulates an error from the plugin hook infrastructure, not a user hook
             // "normally" the plugin hooks should not throw exceptions, but still, we should ensure that the error is somehow visible
 
+            _reqnrollConfiguration.StopAtFirstError = stopAtFirstError;
             var testExecutionEngine = CreateTestExecutionEngine();
             var handledInOnAfterLastStep = false;
 
@@ -163,7 +169,7 @@ namespace Reqnroll.RuntimeTests.Infrastructure
 
             await act.Should().ThrowAsync<Exception>().WithMessage(SimulatedErrorMessage);
             _runtimePluginTestExecutionLifecycleEventEmitter.Verify(e => e.RaiseExecutionLifecycleEventAsync(HookType.BeforeScenario, It.IsAny<IObjectContainer>()));
-            handledInOnAfterLastStep.Should().BeTrue();
+            handledInOnAfterLastStep.Should().Be(!stopAtFirstError); // in case of stopAtFirstError, the error should come from OnScenarioStartAsync
         }
 
         [Fact]

--- a/Tests/Reqnroll.RuntimeTests/Infrastructure/TestExecutionEngineRuntimePluginEventsTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/Infrastructure/TestExecutionEngineRuntimePluginEventsTests.cs
@@ -173,9 +173,12 @@ namespace Reqnroll.RuntimeTests.Infrastructure
         }
 
 
-        [Fact]
-        public async Task Should_keep_user_hook_error_when_both_user_and_plugin_beforescenario_hook_fails()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Should_keep_user_hook_error_when_both_user_and_plugin_beforescenario_hook_fails(bool stopAtFirstError)
         {
+            _reqnrollConfiguration.StopAtFirstError = stopAtFirstError;
             var testExecutionEngine = CreateTestExecutionEngine();
 
             // user hook will fail with SimulatedErrorMessage


### PR DESCRIPTION
### 🤔 What's changed?

Fix #856: Exceptions from before scenario plugin hook events (RuntimePluginTestExecutionLifecycleEvents.BeforeScenario) are not shown

Also fixed a closely related bug:
* Before scenario hooks are not raised immediately when `runtime/stopAtFirstError` is true, but handled delayed

### ⚡️ What's your motivation? 

#856 

This is a regression issue in v3.0.0

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] Users should know about my change
  - [x] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
