### PR TITLE
Omit DisplayName property for MsTest row tests when DisableFriendlyTestNames config is true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 ## Improvements:
 
 ## Bug fixes:
+* FIX: MSTEST Parameterized row test names have formatting inconsistent with that generated in Reqnroll v2 (#867)
 
-*Contributors of this release (in alphabetical order):* 
+*Contributors of this release (in alphabetical order):* @clrudolphi
 
 # v3.1.1 - 2025-09-29
 

--- a/Tests/Reqnroll.GeneratorTests/UnitTestProvider/MsTestV2GeneratorProviderTests.cs
+++ b/Tests/Reqnroll.GeneratorTests/UnitTestProvider/MsTestV2GeneratorProviderTests.cs
@@ -200,8 +200,10 @@ namespace Reqnroll.GeneratorTests.UnitTestProvider
                                                            x.ArgumentValues().OfType<string>().ElementAt(1) == "black");
         }
 
-        [Fact]
-        public void MsTestV2GeneratorProvider_WithScenarioOutline_ShouldGenerateDisplayNamePropertyOfEachDataRow()
+        [Theory]
+        [InlineData([true])]
+        [InlineData([false])]
+        public void MsTestV2GeneratorProvider_WithScenarioOutline_ShouldGenerateDisplayNamePropertyOfEachDataRowPerConfiguration(bool disableFriendlyName)
         {
             // ARRANGE
             var document = ParseDocumentFromString(@"
@@ -216,7 +218,7 @@ namespace Reqnroll.GeneratorTests.UnitTestProvider
                     |     2 | blue  |");
 
             var provider = new MsTestV2GeneratorProvider(new CodeDomHelper(CodeDomProviderLanguage.CSharp));
-            var featureGenerator = provider.CreateFeatureGenerator();
+            var featureGenerator = provider.CreateUnitTestConverter(disableFriendlyName);
 
             // ACT
             var code = featureGenerator.GenerateUnitTestFixture(document, "TestClassName", "Target.Namespace").CodeNamespace;
@@ -236,16 +238,23 @@ namespace Reqnroll.GeneratorTests.UnitTestProvider
                 .Where(arg => !string.IsNullOrEmpty(arg.Name))
                 .ToDictionary(arg => arg.Name, arg => arg.Value);
 
-            row0arguments.Should().ContainKey("DisplayName");
-            row1arguments.Should().ContainKey("DisplayName");
+            if (disableFriendlyName) {
+                row0arguments.Should().NotContainKey("DisplayName");
+                row1arguments.Should().NotContainKey("DisplayName");
+            }
+            else
+            {
+                row0arguments.Should().ContainKey("DisplayName");
+                row1arguments.Should().ContainKey("DisplayName");
 
-            var ArgValue = row0arguments["DisplayName"] as CodePrimitiveExpression;
-            var stringValue = ArgValue?.Value as string;
-            stringValue.Should().Be("Add items(1,red,0)");
+                var ArgValue = row0arguments["DisplayName"] as CodePrimitiveExpression;
+                var stringValue = ArgValue?.Value as string;
+                stringValue.Should().Be("Add items(1,red,0)");
 
-            ArgValue = row1arguments["DisplayName"] as CodePrimitiveExpression;
-            stringValue = ArgValue?.Value as string;
-            stringValue.Should().Be("Add items(2,blue,1)");
+                ArgValue = row1arguments["DisplayName"] as CodePrimitiveExpression;
+                stringValue = ArgValue?.Value as string;
+                stringValue.Should().Be("Add items(2,blue,1)");
+            }
         }
 
         [Fact]


### PR DESCRIPTION


### 🤔 What's changed?

This PR honors the DisableFriendlyTestNames configuration setting to omit the DisplayName property when that config value is true.

### ⚡️ What's your motivation? 

MsTest row tests are given a DisplayName that is inconsistent with that provided by Reqnroll v2. This causes problems with test filtering in CI jobs. 
Fixes #867 

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)


### 📋 Checklist:


- [X] I've changed the behaviour of the code
  - [X] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [X] Users should know about my change
  - [X] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
