### PR TITLE
Performance: Cache the value of IsDryRun environment variable

### DIFF
--- a/Reqnroll/EnvironmentAccess/EnvironmentOptions.cs
+++ b/Reqnroll/EnvironmentAccess/EnvironmentOptions.cs
@@ -1,10 +1,11 @@
-﻿#nullable enable
+#nullable enable
+using System;
 using System.Collections.Generic;
 using Reqnroll.CommonModels;
 
 namespace Reqnroll.EnvironmentAccess;
 
-public class EnvironmentOptions(IEnvironmentWrapper environment) : IEnvironmentOptions
+public class EnvironmentOptions : IEnvironmentOptions
 {
     public const string REQNROLL_FORMATTERS_ENVIRONMENT_VARIABLE = "REQNROLL_FORMATTERS";
     public const string REQNROLL_FORMATTERS_ENVIRONMENT_VARIABLE_PREFIX = "REQNROLL_FORMATTERS_";
@@ -13,10 +14,21 @@ public class EnvironmentOptions(IEnvironmentWrapper environment) : IEnvironmentO
     public const string REQNROLL_BINDING_OUTPUT_ENVIRONMENT_VARIABLE = "REQNROLL_BINDING_OUTPUT";
     public const string DOTNET_RUNNING_IN_CONTAINER_ENVIRONMENT_VARIABLE = "DOTNET_RUNNING_IN_CONTAINER";
 
-    public bool IsDryRun => 
+    private readonly Lazy<bool> _isDryRunLazy;
+    private readonly IEnvironmentWrapper environment;
+
+    public EnvironmentOptions(IEnvironmentWrapper environment)
+    {
+        this.environment = environment;
+        _isDryRunLazy = new Lazy<bool>(() => IsDryRunInternal);
+    }
+
+    private bool IsDryRunInternal => 
         environment.GetEnvironmentVariable(REQNROLL_DRY_RUN_ENVIRONMENT_VARIABLE) is ISuccess<string> dryRunVar
             && bool.TryParse(dryRunVar.Result, out bool isDryRun)
             && isDryRun;
+
+    public bool IsDryRun => _isDryRunLazy.Value;
 
     public string? BindingsOutputFilepath => 
         environment.GetEnvironmentVariable(REQNROLL_BINDING_OUTPUT_ENVIRONMENT_VARIABLE) is ISuccess<string> outputVar


### PR DESCRIPTION
### 🤔 What's changed?

The `EnvironmentOptions` class provides access to commonly used Environment Variables. The `IsDryRun` property is cached in a `Lazy<bool>`

### ⚡️ What's your motivation? 

This property is invoked on every binding method invocation and every method argument resolution. Since it is frequently evaluated, the caching avoids a performance penalty of frequent invocation.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

No changes to tests as the overall behavior not changed. Is that acceptable?

### 📋 Checklist:



- [X] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
