### PR TITLE
Add integration tests for ReportPortal.Reqnroll plugin compatibility

### DIFF
--- a/Tests/Reqnroll.SystemTests/ExternalPlugins/ReportPortalPluginTest.cs
+++ b/Tests/Reqnroll.SystemTests/ExternalPlugins/ReportPortalPluginTest.cs
@@ -12,7 +12,7 @@ public class ReportPortalPluginTest : ExternalPluginsTestBase
     {
         base.TestInitialize();
         _testRunConfiguration.UnitTestProvider = UnitTestProvider.MSTest;
-        _projectsDriver.AddNuGetPackage("ReportPortal.Reqnroll", "1.4.0");
+        _projectsDriver.AddNuGetPackage("ReportPortal.Reqnroll", "1.5.0");
     }
 
     [TestMethod]

--- a/Tests/Reqnroll.SystemTests/ExternalPlugins/ReportPortalPluginTest.cs
+++ b/Tests/Reqnroll.SystemTests/ExternalPlugins/ReportPortalPluginTest.cs
@@ -1,0 +1,49 @@
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Reqnroll.TestProjectGenerator;
+using Reqnroll.TestProjectGenerator.Driver;
+
+namespace Reqnroll.SystemTests.ExternalPlugins;
+
+[TestClass]
+public class ReportPortalPluginTest : ExternalPluginsTestBase
+{
+    protected override void TestInitialize()
+    {
+        base.TestInitialize();
+        _testRunConfiguration.UnitTestProvider = UnitTestProvider.MSTest;
+        _projectsDriver.AddNuGetPackage("ReportPortal.Reqnroll", "1.4.0");
+    }
+
+    [TestMethod]
+    public void ReportPortal_agent_business_integration_smoke_should_pass_when_compatible()
+    {
+        AddFeatureFileFromResource("ReportPortalPlugin/ReportPortalPluginTestFeature.feature", resourceGroup: "ExternalPlugins");
+        // Enable plugin with minimal configuration; it should initialize without external calls in local environment
+        AddContentFileFromResource("ReportPortalPlugin/ReportPortal.config.json", resourceGroup: "ExternalPlugins");
+        AddPassingStepBinding();
+
+        ExecuteTests();
+        
+        ConfirmAllTestsRan();
+        ShouldFinishWithoutTestExecutionWarnings();
+
+        // The integration should not produce constructor-mismatch errors
+        _vsTestExecutionDriver.LastTestExecutionResult.Output.Should().NotContain("MissingMethodException");
+        _vsTestExecutionDriver.LastTestExecutionResult.TrxOutput.Should().NotContain("MissingMethodException");
+
+        // Some hint that the plugin has participated in the run (console/TRX usually contains 'ReportPortal')
+        _vsTestExecutionDriver.CheckAnyOutputContainsText("ReportPortal");
+        
+        ShouldAllScenariosPass();
+    }
+
+    [TestMethod]
+    [TestCategory("MsBuild")]
+    public void ReportPortal_agent_business_integration_smoke_should_pass_when_compatible_on_DotNetFramework_generation()
+    {
+        // compiling with MsBuild forces the generation to run with .NET Framework
+        _compilationDriver.SetBuildTool(BuildTool.MSBuild);
+        ReportPortal_agent_business_integration_smoke_should_pass_when_compatible();
+    }
+}

--- a/Tests/Reqnroll.SystemTests/ExternalPlugins/Resources/ReportPortalPlugin/ReportPortal.config.json
+++ b/Tests/Reqnroll.SystemTests/ExternalPlugins/Resources/ReportPortalPlugin/ReportPortal.config.json
@@ -1,0 +1,13 @@
+{
+  "enabled": true,
+  "server": {
+    "url": "http://localhost",
+    "project": "demo",
+    "apiKey": "00000000-0000-0000-0000-000000000000"
+  },
+  "launch": {
+    "name": "Reqnroll SystemTests",
+    "attributes": [ "tests" ],
+    "description": "Disabled launch for integration test"
+  }
+}

--- a/Tests/Reqnroll.SystemTests/ExternalPlugins/Resources/ReportPortalPlugin/ReportPortalPluginTestFeature.feature
+++ b/Tests/Reqnroll.SystemTests/ExternalPlugins/Resources/ReportPortalPlugin/ReportPortalPluginTestFeature.feature
@@ -1,0 +1,7 @@
+Feature: ReportPortal agent integration
+  In order to verify the Reqnroll integration with the ReportPortal agent
+  As a test suite
+  I want a simple passing scenario
+
+  Scenario: Simple passing scenario
+    When something happens


### PR DESCRIPTION
### 🤔 What's changed?

Add integration tests that verify [ReportPortal.Reqnroll](https://github.com/reportportal/agent-dotnet-reqnroll) plugin compatibility with Reqnroll. These tests reproduce the previous incompatibility and will guard against regressions going forward.