### PR TITLE
Fixes source navigation in test explorer when using TUnit

### DIFF
--- a/Plugins/Reqnroll.TUnit.Generator.ReqnrollPlugin/TUnitTestGeneratorProvider.cs
+++ b/Plugins/Reqnroll.TUnit.Generator.ReqnrollPlugin/TUnitTestGeneratorProvider.cs
@@ -148,7 +148,7 @@ public class TUnitTestGeneratorProvider : IUnitTestGeneratorProvider
     public void SetTestMethod(TestClassGenerationContext generationContext, CodeMemberMethod testMethod, string friendlyTestName)
     {
         // Mark the method as a test and add a friendly name.
-        CodeDomHelper.AddAttribute(testMethod, TEST_ATTR);
+        CodeDomHelper.AddAttribute(testMethod, TEST_ATTR, generationContext.Document.SourceFilePath, generationContext.CustomData["linenumber"]);
         CodeDomHelper.AddAttribute(testMethod, DISPLAYNAME_ATTR, friendlyTestName);
     }
 

--- a/Reqnroll.Generator/Generation/UnitTestMethodGenerator.cs
+++ b/Reqnroll.Generator/Generation/UnitTestMethodGenerator.cs
@@ -581,13 +581,14 @@ namespace Reqnroll.Generator.Generation
             {
                 friendlyTestName = $"{scenarioDefinition.Name}: {variantName}";
             }
-
             if (rowTest)
             {
+                generationContext.CustomData["linenumber"] = scenarioDefinition.Location.Line;
                 _unitTestGeneratorProvider.SetRowTest(generationContext, testMethod, friendlyTestName);
             }
             else
             {
+                generationContext.CustomData["linenumber"] = scenarioDefinition.Location.Line;
                 _unitTestGeneratorProvider.SetTestMethod(generationContext, testMethod, friendlyTestName);
             }
 


### PR DESCRIPTION


<!---
Thanks for helping to make Reqnroll better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻

You can delete these comment sections as you process them.
-->

### 🤔 What's changed?
Enhanced the `SetTestMethod` method in `TUnitTestGeneratorProvider` to include `SourceFilePath` and `linenumber` as additional parameters when adding the `TEST_ATTR` attribute. This makes TUnit override the usual behaviour.

Updated `UnitTestMethodGenerator` to populate `generationContext.CustomData["linenumber"]` with the scenario definition's line number for both row tests and standard tests.

<!-- Describe your changes in detail -->

### ⚡️ What's your motivation? 
Fixes  #872
<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
