### PR TITLE
Tighter validation over Binding Class inheritance

### DIFF
--- a/Reqnroll/Bindings/Discovery/BindingSourceProcessor.cs
+++ b/Reqnroll/Bindings/Discovery/BindingSourceProcessor.cs
@@ -317,6 +317,10 @@ namespace Reqnroll.Bindings.Discovery
         {
             bool BindingClassInheritsFromBindingClass(BindingSourceType bindingSourceType)
             {
+                if (bindingSourceType.BindingType == null)
+                    return false;
+                if (string.IsNullOrEmpty(bindingSourceType.BindingType.FullName) || string.IsNullOrEmpty(bindingSourceType.BindingType.AssemblyName))
+                    return false;
                 var type = GetTypeFromFullNameAndAssembly(bindingSourceType.BindingType?.FullName, bindingSourceType.BindingType?.AssemblyName);
                 int count = 0;
                 while (type != null && type != typeof(object))

--- a/Reqnroll/Bindings/Discovery/BindingSourceProcessor.cs
+++ b/Reqnroll/Bindings/Discovery/BindingSourceProcessor.cs
@@ -99,12 +99,12 @@ namespace Reqnroll.Bindings.Discovery
 
         private bool IsHookAttribute(BindingSourceAttribute attribute)
         {
-// ReSharper disable AssignNullToNotNullAttribute
+            // ReSharper disable AssignNullToNotNullAttribute
             return (attribute.AttributeType.FullName.StartsWith(typeof(BeforeScenarioAttribute).Namespace) ||
                     attribute.AttributeType.Name.StartsWith("Before", StringComparison.InvariantCulture) ||
                     attribute.AttributeType.Name.StartsWith("After", StringComparison.InvariantCulture)) &&
                 TryGetHookType(attribute) != null;
-// ReSharper restore AssignNullToNotNullAttribute
+            // ReSharper restore AssignNullToNotNullAttribute
         }
 
         private bool IsStepArgumentTransformationAttribute(BindingSourceAttribute attribute)
@@ -245,7 +245,7 @@ namespace Reqnroll.Bindings.Discovery
         private void ProcessStepDefinitionAttribute(BindingSourceMethod bindingSourceMethod, BindingSourceAttribute stepDefinitionAttribute, BindingScope scope)
         {
             var stepDefinitionTypes = GetStepDefinitionTypes(stepDefinitionAttribute);
-            
+
             var expressionString = GetExpressionString(stepDefinitionAttribute);
             var expressionType = stepDefinitionAttribute.TryGetAttributeValue<ExpressionType>(nameof(StepDefinitionBaseAttribute.ExpressionType));
 
@@ -280,7 +280,7 @@ namespace Reqnroll.Bindings.Discovery
         protected readonly struct BindingValidationResult
         {
             public static BindingValidationResult Valid = new();
-            public static BindingValidationResult Error(string errorMessage) => new (errorMessage);
+            public static BindingValidationResult Error(string errorMessage) => new(errorMessage);
 
             public List<string> ErrorMessages { get; }
 
@@ -315,11 +315,29 @@ namespace Reqnroll.Bindings.Discovery
 
         protected virtual BindingValidationResult ValidateType(BindingSourceType bindingSourceType)
         {
+            bool BindingClassInheritsFromBindingClass(BindingSourceType bindingSourceType)
+            {
+                var type = GetTypeFromFullNameAndAssembly(bindingSourceType.BindingType?.FullName, bindingSourceType.BindingType?.AssemblyName);
+                int count = 0;
+                while (type != null && type != typeof(object))
+                {
+                    if (type.IsDefined(typeof(BindingAttribute), false))
+                    {
+                        count++;
+                        if (count > 1)
+                            return true;
+                    }
+                    type = type.BaseType;
+                }
+                return false;
+            }
             var result = BindingValidationResult.Valid;
             if (!bindingSourceType.IsClass)
                 result += BindingValidationResult.Error($"Binding types must be classes: {bindingSourceType}");
             if (bindingSourceType.IsGenericTypeDefinition)
                 result += BindingValidationResult.Error($"Binding types cannot be generic: {bindingSourceType}");
+            if (BindingClassInheritsFromBindingClass(bindingSourceType))
+                result += BindingValidationResult.Error($"Binding types cannot inherit from other binding types: {bindingSourceType}");
             return result;
         }
 
@@ -404,6 +422,20 @@ namespace Reqnroll.Bindings.Discovery
             {
                 action(null);
             }
+        }
+
+        private Type GetTypeFromFullNameAndAssembly(string fullName, string assemblyName)
+        {
+            // Construct the assembly-qualified name
+            string assemblyQualifiedName = $"{fullName}, {assemblyName}";
+            // Try to get the Type
+            var type = Type.GetType(assemblyQualifiedName);
+            if (type == null)
+            {
+                // Optionally, handle the error or throw
+                throw new InvalidOperationException($"Type '{assemblyQualifiedName}' could not be found.");
+            }
+            return type;
         }
     }
 }

--- a/Tests/Reqnroll.RuntimeTests/Bindings/Discovery/BindingSourceProcessorTestsWithInheritedBindingClasses.cs
+++ b/Tests/Reqnroll.RuntimeTests/Bindings/Discovery/BindingSourceProcessorTestsWithInheritedBindingClasses.cs
@@ -1,0 +1,64 @@
+﻿using FluentAssertions;
+using Reqnroll.Bindings.Discovery;
+using Reqnroll.RuntimeTests.Bindings.Discovery.TestSubjects;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Reqnroll.RuntimeTests.Bindings.Discovery;
+
+public class BindingSourceProcessorTestsWithInheritedBindingClasses
+{
+    private BindingSourceProcessorStub CreateBindingSourceProcessor()
+    {
+        //NOTE: BindingSourceProcessor is abstract, to test its base functionality we need to instantiate a subclass
+        return new BindingSourceProcessorStub();
+    }
+
+    [Theory]
+    [InlineData(typeof(TestSubjects.DerivedBoundClassBoundMethods_InheritsFromBaseClassNoBindingNoBoundMethods), true, 1, new string[] { })]
+    [InlineData(typeof(TestSubjects.DerivedBoundClassBoundMethods_InheritsFromBaseClassNoBindingWithBoundMethods), true, 2, new string[] { })]
+    [InlineData(typeof(TestSubjects.DerivedBoundClassBoundMethods_InheritsFromBaseClassWithBindingNoBoundMethods), false, 0, new string[] { "Binding types cannot inherit from other binding types" })]
+    [InlineData(typeof(TestSubjects.DerivedBoundClassBoundMethods_InheritsFromBaseClassWithBindingWithBoundMethods), false, 0, new string[] { "Binding types cannot inherit from other binding types" })]
+    [InlineData(typeof(TestSubjects.DerivedBoundClassBoundMethodswithBindingaAttributes_InheritsFromBaseClassNoBindingNoBoundMethod), true, 1, new string[] { })]
+    [InlineData(typeof(TestSubjects.DerivedBoundClassBoundMethodswithBindingaAttributes_InheritsFromBaseClassNoBindingBoundMethod), true, 1, new string[] { })]
+    [InlineData(typeof(TestSubjects.DerivedBoundClassBoundMethodswithBindingaAttributes_InheritsFromBaseClassWithBindingNoBoundMethod), false, 0, new string[] { "Binding types cannot inherit from other binding types" })]
+    [InlineData(typeof(TestSubjects.DerivedBoundClassBoundMethodswithBindingaAttributes_InheritsFromBaseClassWithBindingBoundMethod), false, 0, new string[] { "Binding types cannot inherit from other binding types" })]
+    [InlineData(typeof(TestSubjects.DerivedBoundClassOverriddenMethodsWithoutBindingAttributes_InheritsFromBaseClassNoBindingBoundMethods), true, 1, new string[] { })]
+    [InlineData(typeof(TestSubjects.DerivedBoundClassOverriddenMethodsWithoutBindingAttributes_InheritsFromBaseClassWithBindingBoundMethods), false, 0, new string[] { "Binding types cannot inherit from other binding types" })]
+    [InlineData(typeof(TestSubjects.DerivedUnBoundClassNoBoundMethods_InheritsFromBaseClassNoBindingNoBoundMethods), false, 0, new string[] { })]
+    [InlineData(typeof(TestSubjects.DerivedUnBoundClassNoBoundMethods_InheritsFromBaseClassNoBindingWithBoundMethods), false, 0, new string[] { })]
+    [InlineData(typeof(TestSubjects.DerivedUnBoundClassNoBoundMethods_InheritsFromBaseClassWithBindingNoBoundMethods), true, 0, new string[] { })]
+    [InlineData(typeof(TestSubjects.DerivedUnBoundClassNoBoundMethods_InheritsFromBaseClassWithBindingWithBoundMethods), true, 1, new string[] { })]
+    [InlineData(typeof(TestSubjects.DerivedUnboundClassWithBoundMethods_InheritsFromBaseClassNoBindingNoBoundMethods), false, 0, new string[] { })]
+    [InlineData(typeof(TestSubjects.DerivedUnboundClassWithBoundMethods_InheritsFromBaseClassNoBindingWithBoundMethods), false, 0, new string[] { })]
+    [InlineData(typeof(TestSubjects.DerivedUnboundClassWithBoundMethods_InheritsFromBaseClassWithBindingNoBoundMethods), true, 1, new string[] { })]
+    [InlineData(typeof(TestSubjects.DerivedUnboundClassWithBoundMethods_InheritsFromBaseClassWithBindingWithBoundMethods), true, 2, new string[] { })]
+    [InlineData(typeof(TestSubjects.DerivedUnBoundClassOveriddenMethodsWithBindingAttributes_InheritsFromBaseClassNoBindingNoBoundMethods), false, 0, new string[] { })]
+    [InlineData(typeof(TestSubjects.DerivedUnBoundClassOveriddenMethodsWithBindingAttributes_InheritsFromBaseClassNoBindingWithBoundMethods), false, 0, new string[] { })]
+    [InlineData(typeof(TestSubjects.DerivedUnBoundClassOveriddenMethodsWithBindingAttributes_InheritsFromBaseClassWithBindingNoBoundMethods), true, 1, new string[] { })]
+    [InlineData(typeof(TestSubjects.DerivedUnBoundClassOveriddenMethodsWithBindingAttributes_InheritsFromBaseClassWithBindingWithBoundMethods), true, 1, new string[] { })]
+    [InlineData(typeof(TestSubjects.DerivedUnBoundClassOverriddenMethodsWithoutBindingAttributes_InheritsFromBaseClassNoBindingNoBoundMethods), false, 0, new string[] { })]
+    [InlineData(typeof(TestSubjects.DerivedUnBoundClassOverriddenMethodsWithoutBindingAttributes_InheritsFromBaseClassNoBindingWithBoundMethods), false, 0, new string[] { })]
+    [InlineData(typeof(TestSubjects.DerivedUnBoundClassOverriddenMethodsWithoutBindingAttributes_InheritsFromBaseClassWithBindingNoBoundMethods), true, 0, new string[] { })]
+    [InlineData(typeof(TestSubjects.DerivedUnBoundClassOverriddenMethodsWithoutBindingAttributes_InheritsFromBaseClassWithBindingWithBoundMethods), true, 1, new string[] { })]
+    public void ProcessType_WithInheritedBindingClasses_ShouldFindBoundMethods(Type bindingClassType, bool outcome, int expectedBoundMethodCount, IEnumerable<string> expectedErrors)
+    {
+        //ARRANGE
+        var sut = CreateBindingSourceProcessor();
+        var builder = new RuntimeBindingRegistryBuilder(sut, new ReqnrollAttributesFilter(), null, null, null);
+        //ACT
+        builder.BuildBindingsFromType(bindingClassType).Should().Be(outcome);
+        sut.BuildingCompleted();
+        //ASSERT
+        sut.StepDefinitionBindings.Should().HaveCount(expectedBoundMethodCount);
+
+        foreach (var expectedError in expectedErrors)
+        {
+            sut.ValidationErrors.Should().Contain(m => m.Contains(expectedError));
+        }
+    }
+
+
+
+}

--- a/Tests/Reqnroll.RuntimeTests/Bindings/Discovery/TestSubjects/BaseClasses.cs
+++ b/Tests/Reqnroll.RuntimeTests/Bindings/Discovery/TestSubjects/BaseClasses.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Reqnroll.RuntimeTests.Bindings.Discovery.TestSubjects;
+
+internal class BaseClassNoBindingNoBoundMethods
+{
+    public virtual void UnBoundMethod()
+    {
+    }
+}
+
+internal class BaseClassNoBindingWithBoundMethods
+{
+    [Given("something")]
+    public virtual void GivenSomething() { }
+
+    public virtual void UnBoundMethod()
+    {
+    }
+}
+
+[Binding]
+internal class BaseClassWithBindingNoBoundMethods
+{
+    public virtual void UnBoundMethod()
+    {
+    }
+}
+
+[Binding]
+internal class BaseClassWithBindingWithBoundMethods
+{
+    [Given("something")]
+    public virtual void GivenSomething() { }
+}

--- a/Tests/Reqnroll.RuntimeTests/Bindings/Discovery/TestSubjects/DerivedBoundClassBoundMethods.cs
+++ b/Tests/Reqnroll.RuntimeTests/Bindings/Discovery/TestSubjects/DerivedBoundClassBoundMethods.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Reqnroll.RuntimeTests.Bindings.Discovery.TestSubjects;
+
+[Binding]
+internal class DerivedBoundClassBoundMethods_InheritsFromBaseClassNoBindingNoBoundMethods : BaseClassNoBindingNoBoundMethods
+{
+    public override void UnBoundMethod() { }
+
+    [Given("derived something")]
+    public void GivenDerivedSomething() { }
+}
+
+[Binding]
+internal class DerivedBoundClassBoundMethods_InheritsFromBaseClassWithBindingNoBoundMethods : BaseClassWithBindingNoBoundMethods
+{
+    public override void UnBoundMethod() { }
+
+    [Given("derived something")]
+    public void GivenDerivedSomething() { }
+}
+
+[Binding]
+internal class DerivedBoundClassBoundMethods_InheritsFromBaseClassNoBindingWithBoundMethods : BaseClassNoBindingWithBoundMethods
+{
+    [Given("derived something")]
+    public void GivenDerivedSomething() { }
+}
+
+[Binding]
+internal class DerivedBoundClassBoundMethods_InheritsFromBaseClassWithBindingWithBoundMethods : BaseClassWithBindingWithBoundMethods
+{
+    [Given("derived something")]
+    public void GivenDerivedSomething() { }
+}

--- a/Tests/Reqnroll.RuntimeTests/Bindings/Discovery/TestSubjects/DerivedBoundClassOverriddenMethodsWithoutBindingAttributes.cs
+++ b/Tests/Reqnroll.RuntimeTests/Bindings/Discovery/TestSubjects/DerivedBoundClassOverriddenMethodsWithoutBindingAttributes.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Reqnroll.RuntimeTests.Bindings.Discovery.TestSubjects;
+
+[Binding]
+internal class DerivedBoundClassOverriddenMethodsWithoutBindingAttributes_InheritsFromBaseClassNoBindingBoundMethods : BaseClassNoBindingWithBoundMethods
+{
+    public override void GivenSomething()
+    {
+    }
+}
+
+[Binding]
+internal class DerivedBoundClassOverriddenMethodsWithoutBindingAttributes_InheritsFromBaseClassWithBindingBoundMethods : BaseClassWithBindingWithBoundMethods
+{
+    public override void GivenSomething()
+    {
+    }
+}

--- a/Tests/Reqnroll.RuntimeTests/Bindings/Discovery/TestSubjects/DerivedBoundClassOverriddenMethodswithBindingaAttributes.cs
+++ b/Tests/Reqnroll.RuntimeTests/Bindings/Discovery/TestSubjects/DerivedBoundClassOverriddenMethodswithBindingaAttributes.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Reqnroll.RuntimeTests.Bindings.Discovery.TestSubjects;
+
+[Binding]
+internal class DerivedBoundClassBoundMethodswithBindingaAttributes_InheritsFromBaseClassNoBindingNoBoundMethod : BaseClassNoBindingNoBoundMethods
+{
+    [Given("derived something")]
+    public override void UnBoundMethod()
+    {
+        base.UnBoundMethod();
+    }
+}
+
+[Binding]
+internal class DerivedBoundClassBoundMethodswithBindingaAttributes_InheritsFromBaseClassNoBindingBoundMethod : BaseClassNoBindingWithBoundMethods
+{
+    [Given("something")]
+    public override void GivenSomething()
+    {
+        base.GivenSomething();
+    }
+}
+
+[Binding]
+internal class DerivedBoundClassBoundMethodswithBindingaAttributes_InheritsFromBaseClassWithBindingNoBoundMethod : BaseClassWithBindingNoBoundMethods
+{
+    [Given("derived something")]
+    public override void UnBoundMethod()
+    {
+        base.UnBoundMethod();
+    }
+}
+
+[Binding]
+internal class DerivedBoundClassBoundMethodswithBindingaAttributes_InheritsFromBaseClassWithBindingBoundMethod : BaseClassWithBindingWithBoundMethods
+{
+    [Given("something")]
+    public override void GivenSomething()
+    {
+        base.GivenSomething();
+    }
+}

--- a/Tests/Reqnroll.RuntimeTests/Bindings/Discovery/TestSubjects/DerivedUnBoundClassNoBoundMethods.cs
+++ b/Tests/Reqnroll.RuntimeTests/Bindings/Discovery/TestSubjects/DerivedUnBoundClassNoBoundMethods.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Reqnroll.RuntimeTests.Bindings.Discovery.TestSubjects;
+
+internal class DerivedUnBoundClassNoBoundMethods_InheritsFromBaseClassNoBindingNoBoundMethods : BaseClassNoBindingNoBoundMethods
+{
+    public void AnotherUnBoundMethod()
+    {
+    }
+}
+
+internal class DerivedUnBoundClassNoBoundMethods_InheritsFromBaseClassNoBindingWithBoundMethods : BaseClassNoBindingWithBoundMethods
+{
+    public void AnotherUnBoundMethod()
+    {
+    }
+}
+
+internal class DerivedUnBoundClassNoBoundMethods_InheritsFromBaseClassWithBindingNoBoundMethods : BaseClassWithBindingNoBoundMethods
+{
+    public void AnotherUnBoundMethod()
+    {
+    }
+}
+
+internal class DerivedUnBoundClassNoBoundMethods_InheritsFromBaseClassWithBindingWithBoundMethods : BaseClassWithBindingWithBoundMethods
+{
+    public void AnotherUnBoundMethod()
+    {
+    }
+}

--- a/Tests/Reqnroll.RuntimeTests/Bindings/Discovery/TestSubjects/DerivedUnBoundClassOveriddenMethodsWithBindingAttributes.cs
+++ b/Tests/Reqnroll.RuntimeTests/Bindings/Discovery/TestSubjects/DerivedUnBoundClassOveriddenMethodsWithBindingAttributes.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Reqnroll.RuntimeTests.Bindings.Discovery.TestSubjects;
+
+internal class DerivedUnBoundClassOveriddenMethodsWithBindingAttributes_InheritsFromBaseClassNoBindingNoBoundMethods : BaseClassNoBindingNoBoundMethods
+{
+    [Given("derived something")]
+    public override void UnBoundMethod()
+    {
+    }
+}
+
+internal class DerivedUnBoundClassOveriddenMethodsWithBindingAttributes_InheritsFromBaseClassNoBindingWithBoundMethods : BaseClassNoBindingWithBoundMethods
+{
+    [Given("derived something")]
+    public override void GivenSomething()
+    {
+    }
+}
+
+
+internal class DerivedUnBoundClassOveriddenMethodsWithBindingAttributes_InheritsFromBaseClassWithBindingNoBoundMethods : BaseClassWithBindingNoBoundMethods
+{
+    [Given("derived something")]
+    public override void UnBoundMethod()
+    {
+    }
+}
+
+internal class DerivedUnBoundClassOveriddenMethodsWithBindingAttributes_InheritsFromBaseClassWithBindingWithBoundMethods : BaseClassWithBindingWithBoundMethods
+{
+    [Given("derived something")]
+    public override void GivenSomething()
+    {
+    }
+}

--- a/Tests/Reqnroll.RuntimeTests/Bindings/Discovery/TestSubjects/DerivedUnBoundClassOverriddenMethodsWithoutBindingAttributes.cs
+++ b/Tests/Reqnroll.RuntimeTests/Bindings/Discovery/TestSubjects/DerivedUnBoundClassOverriddenMethodsWithoutBindingAttributes.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Reqnroll.RuntimeTests.Bindings.Discovery.TestSubjects;
+
+internal class DerivedUnBoundClassOverriddenMethodsWithoutBindingAttributes_InheritsFromBaseClassNoBindingNoBoundMethods : BaseClassNoBindingNoBoundMethods
+{
+    public override void UnBoundMethod()
+    {
+    }
+}
+
+internal class DerivedUnBoundClassOverriddenMethodsWithoutBindingAttributes_InheritsFromBaseClassNoBindingWithBoundMethods : BaseClassNoBindingWithBoundMethods
+{
+    public override void GivenSomething()
+    {
+    }
+}
+
+internal class DerivedUnBoundClassOverriddenMethodsWithoutBindingAttributes_InheritsFromBaseClassWithBindingNoBoundMethods : BaseClassWithBindingNoBoundMethods
+{
+    public override void UnBoundMethod()
+    {
+    }
+}
+
+internal class DerivedUnBoundClassOverriddenMethodsWithoutBindingAttributes_InheritsFromBaseClassWithBindingWithBoundMethods : BaseClassWithBindingWithBoundMethods
+{
+    public override void GivenSomething()
+    {
+    }
+}

--- a/Tests/Reqnroll.RuntimeTests/Bindings/Discovery/TestSubjects/DerivedUnboundClassWithBoundMethods.cs
+++ b/Tests/Reqnroll.RuntimeTests/Bindings/Discovery/TestSubjects/DerivedUnboundClassWithBoundMethods.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Reqnroll.RuntimeTests.Bindings.Discovery.TestSubjects;
+
+internal class DerivedUnboundClassWithBoundMethods_InheritsFromBaseClassNoBindingNoBoundMethods : BaseClassNoBindingNoBoundMethods
+{
+    [Given("something else")]
+    public void BoundMethodInDerivedUnboundClass() { }
+}
+
+internal class DerivedUnboundClassWithBoundMethods_InheritsFromBaseClassNoBindingWithBoundMethods : BaseClassNoBindingWithBoundMethods
+{
+    [Given("something else")]
+    public void BoundMethodInDerivedUnboundClass() { }
+
+}
+
+internal class DerivedUnboundClassWithBoundMethods_InheritsFromBaseClassWithBindingNoBoundMethods : BaseClassWithBindingNoBoundMethods
+{
+    [Given("something else")]
+    public void BoundMethodInDerivedUnboundClass() { }
+
+}
+
+internal class DerivedUnboundClassWithBoundMethods_InheritsFromBaseClassWithBindingWithBoundMethods : BaseClassWithBindingWithBoundMethods
+{
+    [Given("something else")]
+    public void BoundMethodInDerivedUnboundClass() { }
+
+}
+


### PR DESCRIPTION
### 🤔 What's changed?

Binding Source Processor is changed to return an Error BindingValidationResult when a binding class inherits from another binding class. 

Testing added in RuntimeTests\Binding\Discovery to exercise 30 inheritance combinations.

### ⚡️ What's your motivation? 

To prevent problems as shown in #676 

### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)

### ♻️ Anything particular you want feedback on?

I have identified 30 different scenarios that are combinations of base and derived classes; those with or without the `[Binding]` attribute, methods that may or may not have Step attributes on them (such as `[Given]`) and variations that involve derived classes overriding those base class methods that may or may not be step methods.

See the attached for a matrix describing these situations. 
[Reqnroll Binding Inheritance Situations.xlsx](https://github.com/user-attachments/files/23508782/Reqnroll.Binding.Inheritance.Situations.xlsx)

Each of these combinations is embodied as a test subject class added in this PR (see RuntimeTests\Bindings\Discovery\TestSubjects).

The attached matrix also identifies errors/warnings that Reqnroll does not yet provide, such as a warning when a Step method exists in a class hierarchy that is missing a `[Binding]` attribute and duplicative binding method registrations (due to class inheritance) that will result in AmbiguousBinding exceptions at run-time.

I invite feedback on how sophisticated Reqnroll should be at identifying these (potential) error conditions during binding discovery. Such checks could be added to this PR or in subsequent work.

### 📋 Checklist:

- [X] I've changed the behaviour of the code
  - [X] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
