### PR TITLE
CI: specify dotnet versions to install only once and pin dotnet 9 version to workaround a msbuild bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ permissions:
 env:
   SPECS_FILTER: "" # use for testing CI: "&Category=basicExecution"
   REQNROLL_TEST_PIPELINEMODE: true
+  DOTNET_VERSIONS: |
+    8.0.x
+    9.0.306
 
 jobs:
   build:
@@ -376,9 +379,7 @@ jobs:
       # It is faster to install all required .NET versions to D: drive than installing only the missing one to C: drive and use it from there.
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: | 
-          8.0.x
-          9.0.x
+        dotnet-version: ${{ env.DOTNET_VERSIONS }}
     - name: .NET Information
       run: |
         dotnet --list-sdks
@@ -440,9 +441,7 @@ jobs:
       # The default image contains .NET 8 only, but reusing it would not provide much performance benefit
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: | 
-          8.0.x
-          9.0.x
+        dotnet-version: ${{ env.DOTNET_VERSIONS }}
     - name: .NET Information
       run: |
         dotnet --list-sdks


### PR DESCRIPTION
<!---
Thanks for helping to make Reqnroll better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻

You can delete these comment sections as you process them.
-->

### 🤔 What's changed?

<!-- Describe your changes in detail -->

- Specify dotnet versions to install only once (as env variable)
- Pin dotnet 9 version to workaround a msbuild bug, see #921

### ⚡️ What's your motivation? 

<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->

Workaround #921 until a proper fix is there.
Also have only one place in CI yml for the needed dotnet versions. This helps when updating the versions (e.g. support of .NET 10 is added to CI or this kind of workaround).

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)
- :bug: Bug fix (non-breaking change which fixes a defect)

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
