### PR TITLE
Formatters.Tests: Support running tests parallel

### DIFF
--- a/Tests/Reqnroll.Formatters.Tests/CucumberMessagesBasicTests.cs
+++ b/Tests/Reqnroll.Formatters.Tests/CucumberMessagesBasicTests.cs
@@ -8,7 +8,6 @@ using Reqnroll.SystemTests;
 
 namespace Reqnroll.Formatters.Tests;
 
-[DoNotParallelize]
 [TestClass]
 public class CucumberMessagesBasicTests : MessagesCompatibilityTestBase
 {

--- a/Tests/Reqnroll.Formatters.Tests/MessagesCompatibilityTestBase.cs
+++ b/Tests/Reqnroll.Formatters.Tests/MessagesCompatibilityTestBase.cs
@@ -57,43 +57,34 @@ public class MessagesCompatibilityTestBase : SystemTestBase
     {
         fileToDelete = string.IsNullOrEmpty(fileToDelete) ? fileToDelete : fileToDelete + ".ndjson";
         DeletePreviousMessagesOutput(fileToDelete);
-        ResetCucumberMessagesOutputFileName();
-        Environment.SetEnvironmentVariable(EnvironmentOptions.REQNROLL_FORMATTERS_DISABLED_ENVIRONMENT_VARIABLE, null);
     }
     protected void ResetCucumberMessagesHtml(string? fileToDelete = null)
     {
         fileToDelete = string.IsNullOrEmpty(fileToDelete) ? fileToDelete : fileToDelete + ".html";
         DeletePreviousMessagesOutput(fileToDelete);
-        ResetCucumberMessagesOutputFileName();
-        Environment.SetEnvironmentVariable(EnvironmentOptions.REQNROLL_FORMATTERS_DISABLED_ENVIRONMENT_VARIABLE, null);
-    }
-
-    protected void ResetCucumberMessagesOutputFileName()
-    {
-        Environment.SetEnvironmentVariable(EnvironmentOptions.REQNROLL_FORMATTERS_ENVIRONMENT_VARIABLE, null);
     }
 
     protected void MimicGitHubActionsEnvironment()
     {
-        Environment.SetEnvironmentVariable("GITHUB_ACTIONS", "true");
-        Environment.SetEnvironmentVariable("GITHUB_SERVER_URL", "https://github.com");
-        Environment.SetEnvironmentVariable("GITHUB_REPOSITORY", "reqnroll/reqnroll");
-        Environment.SetEnvironmentVariable("GITHUB_RUN_ID", "1234567890");
-        Environment.SetEnvironmentVariable("GITHUB_RUN_NUMBER", "1");
-        Environment.SetEnvironmentVariable("GITHUB_REF_TYPE", "branch");
-        Environment.SetEnvironmentVariable("GITHUB_REF_NAME", "main");
-        Environment.SetEnvironmentVariable("GITHUB_SHA", "abcdef1234567890abcdef1234567890abcdef12");
+        _testSuiteInitializationDriver.AddEnvironmentVariableOverride("GITHUB_ACTIONS", "true");
+        _testSuiteInitializationDriver.AddEnvironmentVariableOverride("GITHUB_SERVER_URL", "https://github.com");
+        _testSuiteInitializationDriver.AddEnvironmentVariableOverride("GITHUB_REPOSITORY", "reqnroll/reqnroll");
+        _testSuiteInitializationDriver.AddEnvironmentVariableOverride("GITHUB_RUN_ID", "1234567890");
+        _testSuiteInitializationDriver.AddEnvironmentVariableOverride("GITHUB_RUN_NUMBER", "1");
+        _testSuiteInitializationDriver.AddEnvironmentVariableOverride("GITHUB_REF_TYPE", "branch");
+        _testSuiteInitializationDriver.AddEnvironmentVariableOverride("GITHUB_REF_NAME", "main");
+        _testSuiteInitializationDriver.AddEnvironmentVariableOverride("GITHUB_SHA", "abcdef1234567890abcdef1234567890abcdef12");
     }
 
     protected void MimicAzurePipelinesEnvironment()
     {
-        Environment.SetEnvironmentVariable("TF_BUILD", "true");
-        Environment.SetEnvironmentVariable("BUILD_BUILDURI", "https://dev.azure.com/reqnroll/reqnroll/_build");
-        Environment.SetEnvironmentVariable("BUILD_BUILDNUMBER", "20231001.1");
-        Environment.SetEnvironmentVariable("BUILD_REPOSITORY_URI", "https://dev.azure.com/reqnroll/reqnroll/_git/reqnroll");
-        Environment.SetEnvironmentVariable("BUILD_SOURCEBRANCHNAME", "1b1c2588e46d5c995d54da1082b618fa13553eb3");
-        Environment.SetEnvironmentVariable("BUILD_SOURCEVERSION", "main");
-        Environment.SetEnvironmentVariable("Build_SOURCEBRANCH", "refs/tags/v1.0.0");
+        _testSuiteInitializationDriver.AddEnvironmentVariableOverride("TF_BUILD", "true");
+        _testSuiteInitializationDriver.AddEnvironmentVariableOverride("BUILD_BUILDURI", "https://dev.azure.com/reqnroll/reqnroll/_build");
+        _testSuiteInitializationDriver.AddEnvironmentVariableOverride("BUILD_BUILDNUMBER", "20231001.1");
+        _testSuiteInitializationDriver.AddEnvironmentVariableOverride("BUILD_REPOSITORY_URI", "https://dev.azure.com/reqnroll/reqnroll/_git/reqnroll");
+        _testSuiteInitializationDriver.AddEnvironmentVariableOverride("BUILD_SOURCEBRANCHNAME", "1b1c2588e46d5c995d54da1082b618fa13553eb3");
+        _testSuiteInitializationDriver.AddEnvironmentVariableOverride("BUILD_SOURCEVERSION", "main");
+        _testSuiteInitializationDriver.AddEnvironmentVariableOverride("Build_SOURCEBRANCH", "refs/tags/v1.0.0");
     }
     protected void DeletePreviousMessagesOutput(string? fileToDelete = null)
     {

--- a/Tests/Reqnroll.Formatters.Tests/MessagesCompatibilityTests.cs
+++ b/Tests/Reqnroll.Formatters.Tests/MessagesCompatibilityTests.cs
@@ -3,7 +3,6 @@ using System.Reflection;
 
 namespace Reqnroll.Formatters.Tests;
 
-[DoNotParallelize]
 [TestClass]
 public class MessagesCompatibilityTests : MessagesCompatibilityTestBase
 {

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Driver/TestSuiteEnvironmentVariableGenerator.cs
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Driver/TestSuiteEnvironmentVariableGenerator.cs
@@ -48,10 +48,19 @@ namespace Reqnroll.TestProjectGenerator.Driver
             {
                 envVariables.Add("REQNROLL_FORMATTERS_DISABLED", formattersEnable ? "false" : "true");
             }
+            else
+                envVariables.Add("REQNROLL_FORMATTERS_DISABLED", null); // Always override to avoid conflicts between local config and expected settings in the tests
 
             if (_testSuiteInitializationDriver.OverrideCucumberMessagesFormatters is string cucumberMessagesFormatters)
             {
                 envVariables.Add("REQNROLL_FORMATTERS", cucumberMessagesFormatters);
+            }
+            else
+                envVariables.Add("REQNROLL_FORMATTERS", null); // Always override to avoid conflicts between local config and expected settings in the tests
+
+            foreach (var envOverride in _testSuiteInitializationDriver.EnvironmentVariableOverrides)
+            {
+                envVariables.Add(envOverride.Key, envOverride.Value);
             }
 
             return envVariables;

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Driver/TestSuiteInitializationDriver.cs
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Driver/TestSuiteInitializationDriver.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace Reqnroll.TestProjectGenerator.Driver
 {
@@ -17,5 +18,11 @@ namespace Reqnroll.TestProjectGenerator.Driver
         public bool? OverrideCucumberEnable { get; set; }
 
         public string OverrideCucumberMessagesFormatters { get; set; }
+
+        internal Dictionary<string, string> EnvironmentVariableOverrides { get; } = [];
+        public void AddEnvironmentVariableOverride(string envKey, string envVar)
+        {
+            EnvironmentVariableOverrides.Add(envKey, envVar);
+        }
     }
 }


### PR DESCRIPTION
<!---
Thanks for helping to make Reqnroll better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻

You can delete these comment sections as you process them.
-->

### 🤔 What's changed?

<!-- Describe your changes in detail -->
- Avoid using `Environment.SetEnvironmentVariable` in all Formatter tests
- Passed/override environment variables when [starting the child process](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.processstartinfo.environment)

### ⚡️ What's your motivation? 

<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->

- Improve the runtime of tests (on my machine the execute times changes from 162s to 36s -78%)
- Reduce possibility that environment variables set with `Environment.SetEnvironmentVariable` affect other tests (that are run in the same process)

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)


----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
