### PR TITLE
Fix grammar/typo in legacy project guide

### DIFF
--- a/docs/guides/how-to-configure-cucumber-expression-behavior.md
+++ b/docs/guides/how-to-configure-cucumber-expression-behavior.md
@@ -1,6 +1,6 @@
 # How to configure Cucumber Expression behavior for large legacy projects
 
-Reqnroll uses Cucumber Expressions as the default method to connect step definitions to steps, while regular expressions are still supported. Cucumber expressions are provide a nice and convenient way to define which step should match to a step definition, but if you migrated a large project that uses regular expressions extensively, you might run into some issues.
+Reqnroll uses Cucumber Expressions as the default method to connect step definitions to steps, while regular expressions are still supported. Cucumber expressions provide a nice and convenient way to define which step should match to a step definition, but if you migrated a large project that uses regular expressions extensively, you might run into some issues.
 
 The main problem is that Reqnroll needs to decide based on an expression whether it is a regular expression or a cucumber expression. As SpecFlow introduced regular expression support without forcing the users to use the regex start (`^`) and end (`$`) markers, this is not an easy task to do. Reqnroll uses some heuristics to make the decision:
 


### PR DESCRIPTION
Fix grammar/typo in documentation for how to configure regex for large legacy projects.

<!---
Thanks for helping to make Reqnroll better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻

You can delete these comment sections as you process them.
-->

### 🤔 What's changed?

<!-- Describe your changes in detail -->

Improved spelling 

### ⚡️ What's your motivation? 

<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :book: Documentation (improvements without changing code)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->




*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
