### PR TITLE
apply workaround to avoid generating symbols package for Reqnroll.Templates.DotNet

### DIFF
--- a/Templates/Reqnroll.Templates.DotNet/Reqnroll.Templates.DotNet.csproj
+++ b/Templates/Reqnroll.Templates.DotNet/Reqnroll.Templates.DotNet.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <PackageType>Template</PackageType>
@@ -43,6 +43,18 @@
     <ItemGroup>
       <Content Include="$(OutDir)\templates\**\*" PackagePath="content" />
     </ItemGroup>
+  </Target>
+
+  <!-- 
+    Temporary workawound: Recently (since .NET 10 SDK?) the Symbols Package .snupkg is generated, 
+    even though we set 'IncludeSymbols' to false. As this package is content-only, the generated 
+    symbols package will be empty that causes an error when the release script tries to upload it 
+    to nuget.org. We delete the symbols package immediately after creation as a workaround.  -->
+  <Target Name="DeleteSymbolPackage" AfterTargets="Pack" BeforeTargets="CopyPackageToPackagesOutputPath">
+    <ItemGroup>
+      <_TemplatesSymbolPackage Include="$(PackageOutputAbsolutePath)\$(PackageId)*.snupkg" />
+    </ItemGroup>
+    <Delete Files="@(_TemplatesSymbolPackage)" />
   </Target>
   
 </Project> 


### PR DESCRIPTION
### 🤔 What's changed?

apply workaround to avoid generating symbols package for Reqnroll.Templates.DotNet

### ⚡️ What's your motivation? 

fix release build

See related issue: https://github.com/dotnet/sdk/issues/52231

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

- [x] I've changed the behaviour of the code

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
