### PR TITLE
Update documentation on StepArgumentTransformation

### DIFF
--- a/docs/automation/step-argument-conversions.md
+++ b/docs/automation/step-argument-conversions.md
@@ -102,7 +102,7 @@ public record Rating(int Value)
 }
 ```
 
-Specifying the `Name` property in the `StepArgumentTransformation` attribute allows for [Parameters](cucumber-expressions#parameters) to be specified with that name.
+Specifying the `Name` property in the `StepArgumentTransformation` attribute allows for [Parameters](cucumber-expressions.md#parameters) to be specified with that name.
 This `Name` property does not enforce strict scoping to Cucumber expression parameters with that name, but is instead intended for clarity.
 
 ## Standard Conversion


### PR DESCRIPTION
Clarify the use of the 'Name' property in StepArgumentTransformation.

### 🤔 What's changed?

Updated documentation to improve clarity around the intended usage of the "Name" property for StepArgumentTransformation

### ⚡️ What's your motivation? 

- Resolves a discussion question
- Clarity!!

### 🏷️ What kind of change is this?

- :book: Documentation (improvements without changing code)

### ♻️ Anything particular you want feedback on?

Correctness :)

### 📋 Checklist:

- [X] I have updated the documentation accordingly.
