### PR TITLE
Remove licenses folder from Reqnroll.CustomPlugin package (restore v3.3.0 behavior)

### DIFF
--- a/Plugins/Reqnroll.CustomPlugin/Reqnroll.CustomPlugin.csproj
+++ b/Plugins/Reqnroll.CustomPlugin/Reqnroll.CustomPlugin.csproj
@@ -22,11 +22,6 @@
     <ProjectReference Include="../../Reqnroll.Parser/Reqnroll.Parser.csproj" PrivateAssets="all" PackAsComponent="true" />
   </ItemGroup>
 
-  <ItemGroup>
-    <!-- Include the third-party license files. -->
-    <None Include="../../Licenses/*" Pack="true" PackagePath="Licenses/" />
-  </ItemGroup>
-
   <!-- Trims the empty primary assembly from the NuGet package. -->
   <Target Name="RemoveBuildOutputFromPackageContent" BeforeTargets="GenerateNuspec">
     <ItemGroup>


### PR DESCRIPTION
### 🤔 What's changed?

Removed licenses folder from Reqnroll.CustomPlugin package (restore v3.3.0 behavior)

### ⚡️ What's your motivation? 

* licenses are not necessary in this package
* in the main package we anyway have them in the package root (package conventions)
* in v3.3.0 we have removed them anyway

Related to #980 

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?


### 📋 Checklist:

- [x] I've changed the behaviour of the code

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
