### PR TITLE
Introduce ServiceProviderLifetimeType for scoped dependency container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## Improvements:
 
-* Microsoft.Extensions.DependencyInjection.ReqnrollPlugin: Added support for configurable service provider lifetimes to control at which scope the services are registered (#998)
-  * Options are Global (default, previous behavior), Test Thread, Feature, Scenario
+* Microsoft.Extensions.DependencyInjection.ReqnrollPlugin: Added support for configurable service provider lifetimes to control which level the services are registered. Options are Global (default, previous behavior), Test Thread, Feature, Scenario. (#998)
 
 ## Bug fixes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,14 @@
 
 ## Improvements:
 
+* Microsoft.Extensions.DependencyInjection.ReqnrollPlugin: Added support for configurable service provider lifetimes to control at which scope the services are registered (#998)
+  * Options are Global (default, previous behavior), Test Thread, Feature, Scenario
+
 ## Bug fixes:
 
 * Fix: Partially defined CI Environment variables (missing relevant environment variables) cause missing Meta envelope in Cucumber Messages report and Javascript errors in HTML report. (#990)
 
-*Contributors of this release (in alphabetical order):* @clrudolphi
+*Contributors of this release (in alphabetical order):* @AidenFuller, @clrudolphi
 
 # v3.3.1 - 2026-01-08
 

--- a/Plugins/Reqnroll.Microsoft.Extensions.DependencyInjection.ReqnrollPlugin/IServiceCollectionFinder.cs
+++ b/Plugins/Reqnroll.Microsoft.Extensions.DependencyInjection.ReqnrollPlugin/IServiceCollectionFinder.cs
@@ -4,6 +4,7 @@ namespace Reqnroll.Microsoft.Extensions.DependencyInjection
 {
     public interface IServiceCollectionFinder
     {
+        ServiceProviderLifetimeType GetServiceProviderLifetime();
         (IServiceCollection, ScopeLevelType) GetServiceCollection();
     }
 }

--- a/Plugins/Reqnroll.Microsoft.Extensions.DependencyInjection.ReqnrollPlugin/ScenarioDependenciesAttribute.cs
+++ b/Plugins/Reqnroll.Microsoft.Extensions.DependencyInjection.ReqnrollPlugin/ScenarioDependenciesAttribute.cs
@@ -14,6 +14,26 @@ namespace Reqnroll.Microsoft.Extensions.DependencyInjection
         Feature
     }
 
+    public enum ServiceProviderLifetimeType
+    {
+        /// <summary>
+        /// Global lifetime. The container is created once for the entire test run.
+        /// </summary>
+        Global,
+        /// <summary>
+        /// Test thread lifetime. The container is created once for each test thread.
+        /// </summary>
+        TestThread,
+        /// <summary>
+        /// Feature lifetime. The container is created once for each feature.
+        /// </summary>
+        Feature,
+        /// <summary>
+        /// Scenario lifetime. The container is created once for each scenario.
+        /// </summary>
+        Scenario
+    }
+
     [AttributeUsage(AttributeTargets.Method)]
     public class ScenarioDependenciesAttribute : Attribute
     {
@@ -26,5 +46,10 @@ namespace Reqnroll.Microsoft.Extensions.DependencyInjection
         /// Define when to create and destroy scope. 
         /// </summary>
         public ScopeLevelType ScopeLevel { get; set; } = ScopeLevelType.Scenario;
+
+        /// <summary>
+        /// Define the lifetime of the Service Provider instance.
+        /// </summary>
+        public ServiceProviderLifetimeType ServiceProviderLifetime { get; set; } = ServiceProviderLifetimeType.Global;
     }
 }

--- a/Plugins/Reqnroll.Microsoft.Extensions.DependencyInjection.ReqnrollPlugin/ServiceCollectionFinder.cs
+++ b/Plugins/Reqnroll.Microsoft.Extensions.DependencyInjection.ReqnrollPlugin/ServiceCollectionFinder.cs
@@ -15,7 +15,7 @@ namespace Reqnroll.Microsoft.Extensions.DependencyInjection
         private readonly ITestAssemblyProvider _testAssemblyProvider;
         private (IServiceCollection ServiceCollection, ScenarioDependenciesAttribute Attribute) _cache;
 
-        public ServiceCollectionFinder(ITestRunnerManager testRunnerManager, IRuntimeBindingRegistryBuilder bindingRegistryBuilder, ITestAssemblyProvider testAssemblyProvider, IBindingAssemblyLoader bindingAssemblyLoader)
+        public ServiceCollectionFinder(ITestRunnerManager testRunnerManager, IRuntimeBindingRegistryBuilder bindingRegistryBuilder, ITestAssemblyProvider testAssemblyProvider)
         {
             _testRunnerManager = testRunnerManager;
             _bindingRegistryBuilder = bindingRegistryBuilder;
@@ -65,6 +65,13 @@ namespace Reqnroll.Microsoft.Extensions.DependencyInjection
                             {
                                 AddBindingAttributes(assemblies, serviceCollection);
                             }
+
+                            // If the ServiceProviderLifetime is Scenario, set the ScopeLevel to Scenario to match.
+                            if (scenarioDependenciesAttribute.ServiceProviderLifetime == ServiceProviderLifetimeType.Scenario)
+                            {
+                                scenarioDependenciesAttribute.ScopeLevel = ScopeLevelType.Scenario;
+                            }
+
                             _cache = (serviceCollection, scenarioDependenciesAttribute);
                             return;
                         }

--- a/docs/integrations/dependency-injection.md
+++ b/docs/integrations/dependency-injection.md
@@ -7,19 +7,19 @@ Reqnroll plugin for using Microsoft.Extensions.DependencyInjection as a dependen
 Currently supports Microsoft.Extensions.DependencyInjection v6.0.0 or above
 ```
 
-## Step by step walkthrough of using Reqnroll.Microsoft.Extensions.DependencyInjection
+## Install the plugin from NuGet into your Reqnroll project
 
+Install the `Reqnroll.Microsoft.Extensions.DependencyInjection` NuGet package directly into your test project.
 
-### 1.  Install plugin from NuGet into your Reqnroll project.
-
-```csharp
-PM> Install-Package Reqnroll.Microsoft.Extensions.DependencyInjection
+```powershell
+Install-Package Reqnroll.Microsoft.Extensions.DependencyInjection
 ```
-### 2. Create static methods somewhere in the Reqnroll project
 
-Create a static method in your SpecFlow project that returns a Microsoft.Extensions.DependencyInjection.IServiceCollection and tag it with the [ScenarioDependencies] attribute. Configure your test dependencies for the scenario execution within this method. Step definition classes (i.e. classes with the SpecFlow [Binding] attribute) are automatically added to the service collection.
-  
-### 3. A typical dependency builder method looks like this:
+## Using the plugin
+
+Create a static, parameterless method in your Reqnroll project that returns an instance of `Microsoft.Extensions.DependencyInjection.IServiceCollection` and tag it with the `[ScenarioDependencies]` attribute. Configure your test dependencies for the scenario execution within this method. Step definition classes (i.e. classes with the Reqnroll `[Binding]` attribute) are automatically added to the service collection.
+
+A typical dependency builder method looks like this:
 
 ```csharp
 public class SetupTestDependencies
@@ -35,4 +35,24 @@ public class SetupTestDependencies
     return services;
   }
 }
+```
+
+### Configuring the scope and lifetime of the service provider
+
+For services registered with a scoped lifetime (as opposed to singleton), it might make sense to have a new scope for each scenario rather than each feature (the default). If this is the case, this can be adjusted with the `ScopeLevel` property on the `[ScenarioDependencies]` attribute. For example
+
+```csharp
+[ScenarioDependencies(ScopeLevel = ScopeLevelType.Scenario)]
+public static IServiceCollection CreateServices()
+```
+
+It's also possible to change the lifetime of the entire service provider, rather than just its scope. This is particularly useful when you want a new instance of a singleton service for each feature or each scenario.
+
+```csharp
+[ScenarioDependencies(ServiceProviderLifetime = ServiceProviderLifetimeType.Feature)]
+public static IServiceCollection CreateServices()
+```
+
+```{note}
+If the `ServiceProviderLifetime` is set to `Scenario` then the `ScopeLevel` is implicitly `Scenario` as well.
 ```

--- a/docs/integrations/dependency-injection.md
+++ b/docs/integrations/dependency-injection.md
@@ -39,10 +39,10 @@ public class SetupTestDependencies
 
 ### Configuring the scope and lifetime of the service provider
 
-For services registered with a scoped lifetime (as opposed to singleton), it might make sense to have a new scope for each scenario rather than each feature (the default). If this is the case, this can be adjusted with the `ScopeLevel` property on the `[ScenarioDependencies]` attribute. For example
+For services registered with a scoped lifetime (as opposed to singleton), it might make sense to have a new scope for each feature instead of the default per-scenario scope. If this is the case, this can be adjusted with the `ScopeLevel` property on the `[ScenarioDependencies]` attribute. For example
 
 ```csharp
-[ScenarioDependencies(ScopeLevel = ScopeLevelType.Scenario)]
+[ScenarioDependencies(ScopeLevel = ScopeLevelType.Feature)]
 public static IServiceCollection CreateServices()
 ```
 
@@ -54,5 +54,5 @@ public static IServiceCollection CreateServices()
 ```
 
 ```{note}
-If the `ServiceProviderLifetime` is set to `Scenario` then the `ScopeLevel` is implicitly `Scenario` as well.
+`ServiceProviderLifetime` and `ScopeLevel` are configured independently. If the `ServiceProviderLifetime` is set to `Scenario` then the `ScopeLevel` is implicitly `Scenario` as well.
 ```


### PR DESCRIPTION
### 🤔 What's changed?

The Microsoft Dependency Injection plugin for Reqnroll provides no way of limiting the lifetime of the service provider, with the current implementation being at a global level. Some tests would benefit from this container being rebuilt at a feature or scenario level. This implementation adds that ability with a new property on the ScenarioDependenciesAttribute class, and uses that throughout the rest of the plugin stack.

### ⚡️ What's your motivation? 

See above, since I have projects that would benefit from this :)

### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)

### ♻️ Anything particular you want feedback on?

Correctness :)

### 📋 Checklist:

- [X] I've changed the behaviour of the code
  - [X] I have added/updated tests to cover my changes.
- [X] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [X] Users should know about my change
  - [x] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.
