### PR TITLE
Fix #997: Visual Studio Test Explorer does not navigate to the correct source line for MsTest v4 and TUnit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@
 ## Bug fixes:
 
 * Fix: Partially defined CI Environment variables (missing relevant environment variables) cause missing Meta envelope in Cucumber Messages report and Javascript errors in HTML report. (#990)
+* Fix: Visual Studio Test Explorer does not navigate to the correct source line for MsTest v4 tests when 'ReqnrollUseIntermediateOutputPathForCodeBehind' is enabled. (#997)
+* Fix: Visual Studio Test Explorer does not navigate to the correct source line for TUnit tests. (#997)
 
-*Contributors of this release (in alphabetical order):* @clrudolphi
+*Contributors of this release (in alphabetical order):* @clrudolphi, @gasparnagy
 
 # v3.3.1 - 2026-01-08
 

--- a/Plugins/Reqnroll.TUnit.Generator.ReqnrollPlugin/TUnitTestGeneratorProvider.cs
+++ b/Plugins/Reqnroll.TUnit.Generator.ReqnrollPlugin/TUnitTestGeneratorProvider.cs
@@ -148,7 +148,11 @@ public class TUnitTestGeneratorProvider : IUnitTestGeneratorProvider
     public void SetTestMethod(TestClassGenerationContext generationContext, CodeMemberMethod testMethod, string friendlyTestName)
     {
         // Mark the method as a test and add a friendly name.
-        CodeDomHelper.AddAttribute(testMethod, TEST_ATTR);
+        var testAttribute = CodeDomHelper.AddAttribute(testMethod, TEST_ATTR);
+        // we only support line number in C#
+        if (CodeDomHelper.TargetLanguage == CodeDomProviderLanguage.CSharp) 
+            testAttribute.Arguments.Add(new CodeAttributeArgument(new CodeSnippetExpression($"line: {generationContext.CurrentScenarioDefinition.ScenarioDefinition.Location.Line}")));
+
         CodeDomHelper.AddAttribute(testMethod, DISPLAYNAME_ATTR, friendlyTestName);
     }
 

--- a/Reqnroll.Generator/Generation/UnitTestMethodGenerator.cs
+++ b/Reqnroll.Generator/Generation/UnitTestMethodGenerator.cs
@@ -67,6 +67,8 @@ namespace Reqnroll.Generator.Generation
                 throw new TestGeneratorException("The scenario must have a title specified.");
             }
 
+            generationContext.CurrentScenarioDefinition = scenarioDefinitionInFeatureFile;
+
             if (scenarioDefinitionInFeatureFile.IsScenarioOutline)
             {
                 GenerateScenarioOutlineTest(generationContext, scenarioDefinitionInFeatureFile, ref pickleIndex);

--- a/Reqnroll.Generator/TestClassGenerationContext.cs
+++ b/Reqnroll.Generator/TestClassGenerationContext.cs
@@ -1,5 +1,6 @@
 using System.CodeDom;
 using System.Collections.Generic;
+using Reqnroll.Generator.Generation;
 using Reqnroll.Generator.Interfaces;
 using Reqnroll.Generator.UnitTestProvider;
 using Reqnroll.Parser;
@@ -38,6 +39,11 @@ namespace Reqnroll.Generator
         internal string FeatureMessages { get; set; }
 
         public FeatureFileInput FeatureFileInput { get; set; }
+
+        /// <summary>
+        /// Contains the scenario definition being currently processed
+        /// </summary>
+        public ScenarioDefinitionInFeatureFile CurrentScenarioDefinition { get; set; }
 
         public TestClassGenerationContext(
             IUnitTestGeneratorProvider unitTestGeneratorProvider,

--- a/Reqnroll.Generator/UnitTestProvider/MsTestV4GeneratorProvider.cs
+++ b/Reqnroll.Generator/UnitTestProvider/MsTestV4GeneratorProvider.cs
@@ -19,13 +19,18 @@ public class MsTestV4GeneratorProvider(CodeDomHelper codeDomHelper) : MsTestV2Ge
     {
         // V4 - the DisplayName property must be explicitly set
 
+        CodeAttributeDeclaration testAttribute;
         if (generationContext.DisableFriendlyTestNames)
         {
-            CodeDomHelper.AddAttribute(testMethod, TEST_ATTR);
+            testAttribute = CodeDomHelper.AddAttribute(testMethod, TEST_ATTR);
         }
         else
         {
-            CodeDomHelper.AddAttribute(testMethod, TEST_ATTR, new CodeAttributeArgument("DisplayName", new CodePrimitiveExpression(friendlyTestName)));
+            testAttribute = CodeDomHelper.AddAttribute(testMethod, TEST_ATTR, new CodeAttributeArgument("DisplayName", new CodePrimitiveExpression(friendlyTestName)));
         }
+
+        // we only support line number in C#
+        if (CodeDomHelper.TargetLanguage == CodeDomProviderLanguage.CSharp)
+            testAttribute.Arguments.Insert(0, new CodeAttributeArgument(new CodeSnippetExpression($"callerLineNumber: {generationContext.CurrentScenarioDefinition.ScenarioDefinition.Location.Line}")));
     }
 }


### PR DESCRIPTION
### 🤔 What's changed?

Modified generator to pass line number data for the MsTest v4 `[TestMethod]` and TUnit `[Test]` attributes. Since Code Dom is limited on providing optional parameter values, the solution is only provided for C#. In VB, the issue will not be resolved (acceptable).

### ⚡️ What's your motivation? 

Fixes #997: Visual Studio Test Explorer does not navigate to the correct source line for MsTest v4 and TUnit tests

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

Tested it manually.

### 📋 Checklist:

- [x] I've changed the behaviour of the code
- [x] Users should know about my change
  - [x] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
