### PR TITLE
Add docco warning against resolving ScenarioContext here

### DIFF
--- a/Reqnroll/Plugins/RuntimePluginEvents.cs
+++ b/Reqnroll/Plugins/RuntimePluginEvents.cs
@@ -18,7 +18,7 @@ namespace Reqnroll.Plugins
         /// <remarks>
         /// <para>
         /// Note that you may not resolve the <see cref="ScenarioContext"/> from the container exposed by this event, attempts
-        /// to do so will raise <see cref="Reqnroll.BoDi.ObjectContainerException"/>.  
+        /// to do so will raise <see cref="Reqnroll.BoDi.ObjectContainerException"/>. 
         /// This event is invoked before the scenario context is ready to be resolved.
         /// If you would like information about the Scenario, please resolve <see cref="ScenarioInfo"/> instead.
         /// </para>


### PR DESCRIPTION
### 🤔 What's changed?

Add a C# documentation comment for the `CustomizeScenarioDependencies` event hook (for plugin authors).  This warns them off attempting to resolve a `ScenarioContext`, as doing so will result in a crash error which is difficult to diagnose.

### ⚡️ What's your motivation? 

A cautionary tale - if you attempt to resolve the `ScenarioContext` from this event, then it won't have been created/initialised by the `ContextManager` yet.  That means that the DI container attempts to create it during resolution.

If that happens, you'll encounter an object container exception, because the container in-turn tries to resolve a `RuleInfo` instance, which also has yet to be added to the container. Because `RuleInfo` has ctor params which include primitives (strings), this throws because the container doesn't permit the resolution of primitives (for good reason).

FYI, resolving scenario context from this location had worked in old SpecFlow and worked in Reqnroll 2.x.  I suspect that this came about because of the changes made here:

* This PR: https://github.com/reqnroll/Reqnroll/pull/454
* Particularly this comment:  https://github.com/reqnroll/Reqnroll/pull/454#pullrequestreview-2663681634
  * At the point where `CustomizeScenarioDependencies` is invoked, it seems that the context manager initialization hasn't happened yet
  * Which in-turn becomes another way to trigger the troublesome container behaviour documented in that discussion

I think _it's most likely that it was never intended_ for a plugin to attempt to resolve `ScenarioContext` from this position; the fact that it had worked before the addition of `RuleInfo` is likely a coincidence.  That's why I wouldn't describe this as a bug or regression, even though _"something that used to work doesn't anymore"_.  In essence the already-documented breaking change in 3.0.0 has a slightly wider impact than previously documented.  That's why I think that this docco is a useful addition, to warn future plugin-authors away from doing something bad, which could take a while to diagnose.

_In my specific case_, I found out that I was being stupid and resolving `ScenarioContext` from this event, when all I ever wanted was `ScenarioInfo`.  So, I've fixed my own plugin code by resolving the info type and not the context type.

### 🏷️ What kind of change is this?

- :book: Documentation (improvements without changing code)

### ♻️ Anything particular you want feedback on?

Are my presumptions in the **Motivations** section correct?  If not then maybe this needs more than just a docco tweak?