### PR TITLE
Add log level filtering support

### DIFF
--- a/Reqnroll/Configuration/ConfigDefaults.cs
+++ b/Reqnroll/Configuration/ConfigDefaults.cs
@@ -23,6 +23,7 @@ namespace Reqnroll.Configuration
 
         public const ObsoleteBehavior ObsoleteBehavior = Configuration.ObsoleteBehavior.Warn;
         public const bool ColoredOutput = false;
+        public const TraceLevel TraceLevel = Configuration.TraceLevel.Normal;
 
         public const bool AllowDebugGeneratedFiles = false;
         public const bool AllowRowTests = true;

--- a/Reqnroll/Configuration/ConfigurationLoader.cs
+++ b/Reqnroll/Configuration/ConfigurationLoader.cs
@@ -50,6 +50,8 @@ namespace Reqnroll.Configuration
 
         public static bool DefaultColoredOutput => ConfigDefaults.ColoredOutput;
 
+        public static TraceLevel DefaultTraceLevel => ConfigDefaults.TraceLevel;
+
         public bool HasJsonConfig
         {
             get
@@ -132,7 +134,8 @@ namespace Reqnroll.Configuration
                 DefaultAddNonParallelizableMarkerForTags,
                 DefaultDisableFriendlyTestNames,
                 DefaultObsoleteBehavior,
-                DefaultColoredOutput
+                DefaultColoredOutput,
+                DefaultTraceLevel
                 );
         }
 

--- a/Reqnroll/Configuration/JsonConfig/JsonConfigurationLoader.cs
+++ b/Reqnroll/Configuration/JsonConfig/JsonConfigurationLoader.cs
@@ -25,6 +25,7 @@ namespace Reqnroll.Configuration.JsonConfig
             bool traceTimings = reqnrollConfiguration.TraceTimings;
             var minTracedDuration = reqnrollConfiguration.MinTracedDuration;
             bool coloredOutput = reqnrollConfiguration.ColoredOutput;
+            var traceLevel = reqnrollConfiguration.TraceLevel;
             var stepDefinitionSkeletonStyle = reqnrollConfiguration.StepDefinitionSkeletonStyle;
             var additionalStepAssemblies = reqnrollConfiguration.AdditionalStepAssemblies;
             bool allowRowTests = reqnrollConfiguration.AllowRowTests;
@@ -87,6 +88,7 @@ namespace Reqnroll.Configuration.JsonConfig
                 minTracedDuration = jsonConfig.Trace.MinTracedDuration;
                 stepDefinitionSkeletonStyle = jsonConfig.Trace.StepDefinitionSkeletonStyle;
                 coloredOutput = jsonConfig.Trace.ColoredOutput;
+                traceLevel = jsonConfig.Trace.TraceLevel;
             }
 
             // legacy config
@@ -124,7 +126,8 @@ namespace Reqnroll.Configuration.JsonConfig
                 addNonParallelizableMarkerForTags,
                 disableFriendlyTestNames,
                 obsoleteBehavior,
-                coloredOutput
+                coloredOutput,
+                traceLevel
             )
             {
                 ConfigSourceText = jsonContent

--- a/Reqnroll/Configuration/JsonConfig/TraceElement.cs
+++ b/Reqnroll/Configuration/JsonConfig/TraceElement.cs
@@ -20,6 +20,9 @@ namespace Reqnroll.Configuration.JsonConfig
         [JsonPropertyName("ColoredOutput")]
         public bool ColoredOutput { get; set; } = ConfigDefaults.ColoredOutput;
 
+        [JsonPropertyName("traceLevel")]
+        public TraceLevel TraceLevel { get; set; } = ConfigDefaults.TraceLevel;
+
         // legacy config
         [JsonPropertyName("traceSuccessfulSteps")]
         public bool TraceSuccessfulSteps { get; set; } = ConfigDefaults.TraceSuccessfulSteps;

--- a/Reqnroll/Configuration/ReqnrollConfiguration.cs
+++ b/Reqnroll/Configuration/ReqnrollConfiguration.cs
@@ -33,7 +33,8 @@ namespace Reqnroll.Configuration
             string[] addNonParallelizableMarkerForTags,
             bool disableFriendlyTestNames,
             ObsoleteBehavior obsoleteBehavior,
-            bool coloredOutput
+            bool coloredOutput,
+            TraceLevel traceLevel = ConfigDefaults.TraceLevel
         )
         {
             ConfigSource = configSource;
@@ -54,6 +55,7 @@ namespace Reqnroll.Configuration
             DisableFriendlyTestNames = disableFriendlyTestNames;
             ObsoleteBehavior = obsoleteBehavior;
             ColoredOutput = coloredOutput;
+            TraceLevel = traceLevel;
         }
 
         public ConfigSource ConfigSource { get; set; }
@@ -83,6 +85,7 @@ namespace Reqnroll.Configuration
         public bool TraceTimings { get; set; }
         public TimeSpan MinTracedDuration { get; set; }
         public StepDefinitionSkeletonStyle StepDefinitionSkeletonStyle { get; set; }
+        public TraceLevel TraceLevel { get; set; }
 
         public List<string> AdditionalStepAssemblies { get; set; }
 
@@ -102,7 +105,8 @@ namespace Reqnroll.Configuration
                                                               && StepDefinitionSkeletonStyle == other.StepDefinitionSkeletonStyle
                                                               && AdditionalStepAssemblies.SequenceEqual(other.AdditionalStepAssemblies)
                                                               && AddNonParallelizableMarkerForTags.SequenceEqual(other.AddNonParallelizableMarkerForTags)
-                                                              && DisableFriendlyTestNames == other.DisableFriendlyTestNames;
+                                                              && DisableFriendlyTestNames == other.DisableFriendlyTestNames
+                                                              && TraceLevel == other.TraceLevel;
 
         public override bool Equals(object obj)
         {
@@ -145,6 +149,7 @@ namespace Reqnroll.Configuration
                 hashCode = (hashCode * 397) ^ (AdditionalStepAssemblies != null ? AdditionalStepAssemblies.GetHashCode() : 0);
                 hashCode = (hashCode * 397) ^ (AddNonParallelizableMarkerForTags != null ? AddNonParallelizableMarkerForTags.GetHashCode() : 0);
                 hashCode = (hashCode * 397) ^ DisableFriendlyTestNames.GetHashCode();
+                hashCode = (hashCode * 397) ^ (int)TraceLevel;
                 return hashCode;
             }
         }

--- a/Reqnroll/Configuration/TraceLevel.cs
+++ b/Reqnroll/Configuration/TraceLevel.cs
@@ -1,0 +1,20 @@
+namespace Reqnroll.Configuration
+{
+    /// <summary>
+    /// Controls the verbosity of trace output from the test tracer.
+    /// The default is <see cref="Normal"/>, which preserves the existing behavior.
+    /// </summary>
+    public enum TraceLevel
+    {
+        /// <summary>No trace output at all.</summary>
+        None = 0,
+        /// <summary>Only errors, warnings, pending steps, and undefined steps.</summary>
+        Minimal = 1,
+        /// <summary>Standard step execution output (default, matches current behavior).</summary>
+        Normal = 2,
+        /// <summary>Includes step completion confirmations with method names and duration.</summary>
+        Detailed = 3,
+        /// <summary>All information including feature/scenario duration timings.</summary>
+        Diagnostic = 4
+    }
+}

--- a/Reqnroll/EnvironmentAccess/EnvironmentOptions.cs
+++ b/Reqnroll/EnvironmentAccess/EnvironmentOptions.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using Reqnroll.CommonModels;
+using Reqnroll.Configuration;
 
 namespace Reqnroll.EnvironmentAccess;
 
@@ -13,6 +14,7 @@ public class EnvironmentOptions(IEnvironmentWrapper environment) : IEnvironmentO
     public const string REQNROLL_DRY_RUN_ENVIRONMENT_VARIABLE = "REQNROLL_DRY_RUN";
     public const string REQNROLL_BINDING_OUTPUT_ENVIRONMENT_VARIABLE = "REQNROLL_BINDING_OUTPUT";
     public const string DOTNET_RUNNING_IN_CONTAINER_ENVIRONMENT_VARIABLE = "DOTNET_RUNNING_IN_CONTAINER";
+    public const string REQNROLL_TRACE_LEVEL_ENVIRONMENT_VARIABLE = "REQNROLL_TRACE_LEVEL";
 
     private readonly Lazy<bool> _isDryRunLazy = new Lazy<bool>(() =>
         environment.GetEnvironmentVariable(REQNROLL_DRY_RUN_ENVIRONMENT_VARIABLE) is ISuccess<string> dryRunVar
@@ -40,4 +42,10 @@ public class EnvironmentOptions(IEnvironmentWrapper environment) : IEnvironmentO
 
     public IDictionary<string, string> FormatterSettings =>
         environment.GetEnvironmentVariables(REQNROLL_FORMATTERS_ENVIRONMENT_VARIABLE_PREFIX, trimPrefix: true);
+
+    public TraceLevel? TraceLevel =>
+        environment.GetEnvironmentVariable(REQNROLL_TRACE_LEVEL_ENVIRONMENT_VARIABLE) is ISuccess<string> traceLevelVar
+            && Enum.TryParse<TraceLevel>(traceLevelVar.Result, ignoreCase: true, out var level)
+            ? level
+            : null;
 }

--- a/Reqnroll/EnvironmentAccess/IEnvironmentOptions.cs
+++ b/Reqnroll/EnvironmentAccess/IEnvironmentOptions.cs
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 using System.Collections.Generic;
+using Reqnroll.Configuration;
 
 namespace Reqnroll.EnvironmentAccess;
 
@@ -19,4 +20,10 @@ public interface IEnvironmentOptions
     string? FormattersJson { get; }
 
     IDictionary<string, string> FormatterSettings { get; }
+
+    /// <summary>
+    /// Override for the trace level, set via the REQNROLL_TRACE_LEVEL environment variable.
+    /// Returns null if the environment variable is not set or has an invalid value.
+    /// </summary>
+    TraceLevel? TraceLevel { get; }
 }

--- a/Tests/Reqnroll.RuntimeTests/Configuration/JsonConfigTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/Configuration/JsonConfigTests.cs
@@ -318,6 +318,33 @@ namespace Reqnroll.RuntimeTests.Configuration
             runtimeConfig.ColoredOutput.Should().Be(true);
         }
 
+        [Theory]
+        [InlineData("None", TraceLevel.None)]
+        [InlineData("Minimal", TraceLevel.Minimal)]
+        [InlineData("Normal", TraceLevel.Normal)]
+        [InlineData("Detailed", TraceLevel.Detailed)]
+        [InlineData("Diagnostic", TraceLevel.Diagnostic)]
+        public void Check_Trace_TraceLevel(string configValue, TraceLevel expected)
+        {
+            string config = @$"{{
+                                ""trace"": {{ ""traceLevel"": ""{configValue}"" }}
+                            }}";
+
+            var runtimeConfig = new JsonConfigurationLoader().LoadJson(ConfigurationLoader.GetDefault(), config);
+
+            runtimeConfig.TraceLevel.Should().Be(expected);
+        }
+
+        [Fact]
+        public void Check_Trace_TraceLevel_Default()
+        {
+            string config = "{}";
+
+            var runtimeConfig = new JsonConfigurationLoader().LoadJson(ConfigurationLoader.GetDefault(), config);
+
+            runtimeConfig.TraceLevel.Should().Be(TraceLevel.Normal);
+        }
+
         [Fact]
         public void Check_StepAssemblies_IsEmpty()
         {
@@ -499,6 +526,7 @@ namespace Reqnroll.RuntimeTests.Configuration
             config.StepDefinitionSkeletonStyle.Should().Be(ConfigDefaults.StepDefinitionSkeletonStyle);
             config.TraceSuccessfulSteps.Should().Be(ConfigDefaults.TraceSuccessfulSteps);
             config.ColoredOutput.Should().Be(ConfigDefaults.ColoredOutput);
+            config.TraceLevel.Should().Be(ConfigDefaults.TraceLevel);
 
             config.AdditionalStepAssemblies.Should().NotBeNull();
             config.AdditionalStepAssemblies.Should().BeEmpty();

--- a/Tests/Reqnroll.RuntimeTests/Tracing/TestTracerTraceLevelTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/Tracing/TestTracerTraceLevelTests.cs
@@ -1,0 +1,244 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using FluentAssertions;
+using Moq;
+using Reqnroll.BindingSkeletons;
+using Reqnroll.Bindings;
+using Reqnroll.Bindings.Reflection;
+using Reqnroll.Configuration;
+using Reqnroll.EnvironmentAccess;
+using Reqnroll.Infrastructure;
+using Reqnroll.Tracing;
+using Reqnroll.Tracing.AnsiColor;
+using Xunit;
+
+namespace Reqnroll.RuntimeTests.Tracing
+{
+    public class TestTracerTraceLevelTests
+    {
+        private readonly Mock<ITraceListener> _traceListenerMock = new();
+        private readonly Mock<IStepFormatter> _stepFormatterMock = new();
+        private readonly Mock<IStepDefinitionSkeletonProvider> _skeletonProviderMock = new();
+        private readonly Mock<IColorOutputTheme> _colorThemeMock = new();
+        private readonly Mock<IColorOutputHelper> _colorHelperMock = new();
+        private readonly Mock<IEnvironmentOptions> _environmentOptionsMock = new();
+
+        private TestTracer CreateTracer(TraceLevel configLevel, TraceLevel? envOverride = null)
+        {
+            var config = ConfigurationLoader.GetDefault();
+            config.TraceLevel = configLevel;
+
+            _environmentOptionsMock.Setup(e => e.TraceLevel).Returns(envOverride);
+            _stepFormatterMock.Setup(f => f.GetStepText(It.IsAny<StepInstance>())).Returns("Given a step");
+            _stepFormatterMock.Setup(f => f.GetMatchText(It.IsAny<BindingMatch>(), It.IsAny<object[]>())).Returns("StepClass.Method()");
+            _stepFormatterMock.Setup(f => f.GetMatchText(It.IsAny<IBindingMethod>(), It.IsAny<object[]>())).Returns("StepClass.Method()");
+            _colorHelperMock.Setup(c => c.Colorize(It.IsAny<string>(), It.IsAny<AnsiColor>())).Returns<string, AnsiColor>((text, _) => text);
+
+            return new TestTracer(
+                _traceListenerMock.Object,
+                _stepFormatterMock.Object,
+                _skeletonProviderMock.Object,
+                config,
+                _colorThemeMock.Object,
+                _colorHelperMock.Object,
+                _environmentOptionsMock.Object);
+        }
+
+        private static BindingMatch CreateBindingMatch()
+        {
+            var methodMock = new Mock<IBindingMethod>();
+            var stepDefMock = new Mock<IStepDefinitionBinding>();
+            stepDefMock.Setup(sd => sd.Method).Returns(methodMock.Object);
+
+            return new BindingMatch(stepDefMock.Object, 0, Array.Empty<MatchArgument>(),
+                new StepContext("feature", "scenario", new List<string>(), CultureInfo.InvariantCulture));
+        }
+
+        // === TraceLevel.None: nothing should be output ===
+
+        [Fact]
+        public void TraceLevel_None_SuppressesAllOutput()
+        {
+            var tracer = CreateTracer(TraceLevel.None);
+
+            tracer.TraceStep(new StepInstance(StepDefinitionType.Given, StepDefinitionKeyword.Given, "Given", "a step", null, null, null), true);
+            tracer.TraceWarning("test warning");
+            tracer.TraceStepDone(CreateBindingMatch(), Array.Empty<object>(), TimeSpan.FromSeconds(1));
+            tracer.TraceStepSkipped(new Exception("skipped"));
+            tracer.TraceStepSkippedBecauseOfPreviousErrors();
+            tracer.TraceStepPending(CreateBindingMatch(), Array.Empty<object>(), new PendingStepException());
+            tracer.TraceBindingError(new Exception("binding error"));
+            tracer.TraceError(new Exception("error"), TimeSpan.FromSeconds(1));
+            tracer.TraceDuration(TimeSpan.FromSeconds(1), "test");
+
+            _traceListenerMock.Verify(t => t.WriteTestOutput(It.IsAny<string>()), Times.Never);
+            _traceListenerMock.Verify(t => t.WriteToolOutput(It.IsAny<string>()), Times.Never);
+        }
+
+        // === TraceLevel.Minimal: errors, warnings, pending, undefined ===
+
+        [Fact]
+        public void TraceLevel_Minimal_ShowsWarning()
+        {
+            var tracer = CreateTracer(TraceLevel.Minimal);
+            tracer.TraceWarning("test warning");
+            _traceListenerMock.Verify(t => t.WriteToolOutput(It.IsAny<string>()), Times.Once);
+        }
+
+        [Fact]
+        public void TraceLevel_Minimal_ShowsError()
+        {
+            var tracer = CreateTracer(TraceLevel.Minimal);
+            tracer.TraceError(new Exception("error"), TimeSpan.FromSeconds(1));
+            _traceListenerMock.Verify(t => t.WriteToolOutput(It.IsAny<string>()), Times.AtLeastOnce);
+        }
+
+        [Fact]
+        public void TraceLevel_Minimal_ShowsBindingError()
+        {
+            var tracer = CreateTracer(TraceLevel.Minimal);
+            tracer.TraceBindingError(new Exception("binding error"));
+            _traceListenerMock.Verify(t => t.WriteToolOutput(It.IsAny<string>()), Times.Once);
+        }
+
+        [Fact]
+        public void TraceLevel_Minimal_ShowsStepPending()
+        {
+            var tracer = CreateTracer(TraceLevel.Minimal);
+            tracer.TraceStepPending(CreateBindingMatch(), Array.Empty<object>(), new PendingStepException());
+            _traceListenerMock.Verify(t => t.WriteToolOutput(It.IsAny<string>()), Times.Once);
+        }
+
+        [Fact]
+        public void TraceLevel_Minimal_SuppressesStepText()
+        {
+            var tracer = CreateTracer(TraceLevel.Minimal);
+            tracer.TraceStep(new StepInstance(StepDefinitionType.Given, StepDefinitionKeyword.Given, "Given", "a step", null, null, null), true);
+            _traceListenerMock.Verify(t => t.WriteTestOutput(It.IsAny<string>()), Times.Never);
+        }
+
+        [Fact]
+        public void TraceLevel_Minimal_SuppressesStepDone()
+        {
+            var tracer = CreateTracer(TraceLevel.Minimal);
+            tracer.TraceStepDone(CreateBindingMatch(), Array.Empty<object>(), TimeSpan.FromSeconds(1));
+            _traceListenerMock.Verify(t => t.WriteToolOutput(It.IsAny<string>()), Times.Never);
+        }
+
+        [Fact]
+        public void TraceLevel_Minimal_SuppressesDuration()
+        {
+            var tracer = CreateTracer(TraceLevel.Minimal);
+            tracer.TraceDuration(TimeSpan.FromSeconds(1), "test");
+            _traceListenerMock.Verify(t => t.WriteToolOutput(It.IsAny<string>()), Times.Never);
+        }
+
+        // === TraceLevel.Normal: adds step text + skip info ===
+
+        [Fact]
+        public void TraceLevel_Normal_ShowsStepText()
+        {
+            var tracer = CreateTracer(TraceLevel.Normal);
+            tracer.TraceStep(new StepInstance(StepDefinitionType.Given, StepDefinitionKeyword.Given, "Given", "a step", null, null, null), true);
+            _traceListenerMock.Verify(t => t.WriteTestOutput(It.IsAny<string>()), Times.Once);
+        }
+
+        [Fact]
+        public void TraceLevel_Normal_ShowsStepSkipped()
+        {
+            var tracer = CreateTracer(TraceLevel.Normal);
+            tracer.TraceStepSkipped(new Exception("skipped"));
+            _traceListenerMock.Verify(t => t.WriteToolOutput(It.IsAny<string>()), Times.Once);
+        }
+
+        [Fact]
+        public void TraceLevel_Normal_ShowsStepSkippedBecauseOfPreviousErrors()
+        {
+            var tracer = CreateTracer(TraceLevel.Normal);
+            tracer.TraceStepSkippedBecauseOfPreviousErrors();
+            _traceListenerMock.Verify(t => t.WriteToolOutput(It.IsAny<string>()), Times.Once);
+        }
+
+        [Fact]
+        public void TraceLevel_Normal_SuppressesStepDone()
+        {
+            var tracer = CreateTracer(TraceLevel.Normal);
+            tracer.TraceStepDone(CreateBindingMatch(), Array.Empty<object>(), TimeSpan.FromSeconds(1));
+            _traceListenerMock.Verify(t => t.WriteToolOutput(It.IsAny<string>()), Times.Never);
+        }
+
+        [Fact]
+        public void TraceLevel_Normal_SuppressesDuration()
+        {
+            var tracer = CreateTracer(TraceLevel.Normal);
+            tracer.TraceDuration(TimeSpan.FromSeconds(1), "test");
+            _traceListenerMock.Verify(t => t.WriteToolOutput(It.IsAny<string>()), Times.Never);
+        }
+
+        // === TraceLevel.Detailed: adds step done ===
+
+        [Fact]
+        public void TraceLevel_Detailed_ShowsStepDone()
+        {
+            var tracer = CreateTracer(TraceLevel.Detailed);
+            tracer.TraceStepDone(CreateBindingMatch(), Array.Empty<object>(), TimeSpan.FromSeconds(1));
+            _traceListenerMock.Verify(t => t.WriteToolOutput(It.IsAny<string>()), Times.Once);
+        }
+
+        [Fact]
+        public void TraceLevel_Detailed_SuppressesDuration()
+        {
+            var tracer = CreateTracer(TraceLevel.Detailed);
+            tracer.TraceDuration(TimeSpan.FromSeconds(1), "test");
+            _traceListenerMock.Verify(t => t.WriteToolOutput(It.IsAny<string>()), Times.Never);
+        }
+
+        // === TraceLevel.Diagnostic: shows everything ===
+
+        [Fact]
+        public void TraceLevel_Diagnostic_ShowsDuration()
+        {
+            var tracer = CreateTracer(TraceLevel.Diagnostic);
+            tracer.TraceDuration(TimeSpan.FromSeconds(1), "test");
+            _traceListenerMock.Verify(t => t.WriteToolOutput(It.IsAny<string>()), Times.Once);
+        }
+
+        [Fact]
+        public void TraceLevel_Diagnostic_ShowsDurationWithMethod()
+        {
+            var tracer = CreateTracer(TraceLevel.Diagnostic);
+            var methodMock = new Mock<IBindingMethod>();
+            tracer.TraceDuration(TimeSpan.FromSeconds(1), methodMock.Object, Array.Empty<object>());
+            _traceListenerMock.Verify(t => t.WriteToolOutput(It.IsAny<string>()), Times.Once);
+        }
+        
+        // === Environment variable override ===
+
+        [Fact]
+        public void EnvironmentVariable_OverridesConfig()
+        {
+            // Config says Diagnostic, but env var says None
+            var tracer = CreateTracer(TraceLevel.Diagnostic, envOverride: TraceLevel.None);
+
+            tracer.TraceWarning("test warning");
+            tracer.TraceStep(new StepInstance(StepDefinitionType.Given, StepDefinitionKeyword.Given, "Given", "a step", null, null, null), true);
+
+            _traceListenerMock.Verify(t => t.WriteTestOutput(It.IsAny<string>()), Times.Never);
+            _traceListenerMock.Verify(t => t.WriteToolOutput(It.IsAny<string>()), Times.Never);
+        }
+
+        [Fact]
+        public void EnvironmentVariable_Null_UsesConfigLevel()
+        {
+            // Config says Minimal, env var not set (null)
+            var tracer = CreateTracer(TraceLevel.Minimal, envOverride: null);
+
+            tracer.TraceWarning("test warning");
+            _traceListenerMock.Verify(t => t.WriteToolOutput(It.IsAny<string>()), Times.Once);
+
+            tracer.TraceStep(new StepInstance(StepDefinitionType.Given, StepDefinitionKeyword.Given, "Given", "a step", null, null, null), true);
+            _traceListenerMock.Verify(t => t.WriteTestOutput(It.IsAny<string>()), Times.Never);
+        }
+    }
+}

--- a/reqnroll-config.json
+++ b/reqnroll-config.json
@@ -5,6 +5,9 @@
 
   Changelog:
 
+  3.3
+  - Added trace/traceLevel for configurable log level filtering.
+
   3.2
   - Added 'AsyncCucumberExpressionAttribute' and 'AsyncRegexAttribute' to the trace/stepDefinitionSkeletonStyle values.
 
@@ -111,6 +114,12 @@
           "description": "Determine whether Reqnroll should color the test result output.",
           "type": "boolean",
           "default": false
+        },
+        "traceLevel": {
+          "description": "Controls the verbosity of trace output. None: no output. Minimal: errors, warnings, and pending steps only. Normal (default): standard step execution output. Detailed: includes step completion confirmations. Diagnostic: includes duration timings.",
+          "type": "string",
+          "default": "Normal",
+          "enum": [ "None", "Minimal", "Normal", "Detailed", "Diagnostic" ]
         }
       }
     },


### PR DESCRIPTION
### 🤔 What's changed?

Adds configurable log level filtering to Reqnroll, addressing [discussion #919](https://github.com/orgs/reqnroll/discussions/919). Users can now control trace output verbosity via `reqnroll.json` or the `REQNROLL_TRACE_LEVEL` environment variable, reducing log noise in CI/CD pipelines.

**Five trace levels (ascending verbosity):**

| Level | Output |
|-------|--------|
| `None` | No trace output |
| `Minimal` | Errors, warnings, pending steps, undefined steps |
| `Normal` | Step execution text, skip info *(default — matches current behavior)* |
| `Detailed` | Adds step completion confirmations with method name and duration |
| `Diagnostic` | Adds feature/scenario duration timings |

**Configuration via `reqnroll.json`:**

```json
{
  "trace": {
    "traceLevel": "Minimal"
  }
}
```

**Environment variable override (takes precedence over config):**

```bash
REQNROLL_TRACE_LEVEL=Minimal dotnet test
```

#### Design

Filtering is applied inside `TestTracer` using early-return guards — no changes to `ITraceListener`, `ITestTracer`, any of the 5 framework plugins, `TestExecutionEngine`, or DI registration. Default behavior is unchanged (`Normal`).

#### Changes

- **New:** `TraceLevel` enum in `Reqnroll.Configuration`
- **New:** `REQNROLL_TRACE_LEVEL` environment variable support in `EnvironmentOptions`
- **Modified:** `TestTracer` — accepts `IEnvironmentOptions`, computes effective level, gates each trace method
- **Modified:** Configuration pipeline (`ConfigDefaults`, `ReqnrollConfiguration`, `TraceElement`, `JsonConfigurationLoader`, `ConfigurationLoader`) — threads `TraceLevel` through config loading
- **Modified:** `reqnroll-config.json` schema — added `traceLevel` property to trace section
- **New:** 20 unit tests covering all trace levels, environment variable override, and scenario/feature description output

**12 files changed, +377 −7**

#### Test plan

- [x] Verify all new unit tests pass (`TestTracerTraceLevelTests`, `JsonConfigTests`)
- [ ] Verify existing tests still pass (no breaking changes)
- [ ] Manual test: set `REQNROLL_TRACE_LEVEL=Minimal` and run a test project, confirm reduced output
- [ ] Manual test: set `REQNROLL_TRACE_LEVEL=None` and verify no trace output
- [ ] Verify `reqnroll.json` config `"trace": { "traceLevel": "Detailed" }` works correctly

Refs: [#919](https://github.com/orgs/reqnroll/discussions/919), [#805](https://github.com/orgs/reqnroll/discussions/805), [#523](https://github.com/reqnroll/Reqnroll/issues/523)


### ⚡️ What's your motivation? 

When running in a CI/CD environment the Reqnroll tests were producing a huge amount of noise making it hard to review and in some causes causing problems due to log size.  

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->
<!--
- :book: Documentation (improvements without changing code)
- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)
- :bug: Bug fix (non-breaking change which fixes a defect)
-->
- :zap: New feature (non-breaking change which adds new behaviour)
<!--
- :boom: Breaking change (incompatible changes to the API)
-->
### ♻️ Anything particular you want feedback on?

Would like feedback on the implementation. This only implements the Step tracing portion of the log like 

```
Given I am on the login page
-> done: LoginSteps.NavigateToLogin() (0.3s)
When I enter valid credentials
-> done: LoginSteps.EnterCredentials() (0.1s)
Then I should see the dashboard
-> done: LoginSteps.VerifyDashboard() (0.5s)
-> duration: Scenario: User logs in: 1.2s
-> duration: Feature: Authentication: 3.4s
```

I think it would normally still output the Feature and Scenario descriptions as well. If the level is set to none i'm not sure if it should exclude the scenario and feature descriptions. I need to test it some more. 

### 📋 Checklist:
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.
- [ ] I've completed manual testing
----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
