### PR TITLE
Add overridable timeout values to FormattersBase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # [vNext]
 
 ## Improvements:
+* Refactor: Introduce virtual timeout properties FormattersBase class to allow individual formatters to override the defaults
 
 ## Bug fixes:
 
-*Contributors of this release (in alphabetical order):* 
+*Contributors of this release (in alphabetical order):* @clrudolphi
 
 # v3.3.3 - 2026-01-27
 

--- a/Tests/Reqnroll.RuntimeTests/Formatters/FileWritingFormatterBaseTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/Formatters/FileWritingFormatterBaseTests.cs
@@ -39,6 +39,9 @@ public class FileWritingFormatterBaseTests
         public bool FinalizeInitializationCalled = false;
         public Stream? LastStream;
 
+        protected override TimeSpan DisposeTimeout => TimeSpan.FromMilliseconds(100);
+        protected override TimeSpan DisposeCancellationTimeout => TimeSpan.FromMilliseconds(100);
+
         public TestFileWritingFormatter(IFormattersConfigurationProvider config, IFormatterLog logger, IFileSystem fileSystem)
             : base(config, logger, fileSystem, "testPlugin", ".txt", "default.txt") { }
 

--- a/Tests/Reqnroll.RuntimeTests/Formatters/FormatterBaseTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/Formatters/FormatterBaseTests.cs
@@ -28,6 +28,8 @@ public class FormatterBaseTests
         public bool ReportInitializedCalled = false;
         public bool CloseAsyncCalled = false;
         public bool CompleteWriterOnLaunchInner = false;
+        protected override TimeSpan DisposeTimeout => TimeSpan.FromMilliseconds(100);
+        protected override TimeSpan DisposeCancellationTimeout => TimeSpan.FromMilliseconds(100);
 
         public TestFormatter(IFormattersConfigurationProvider config, IFormatterLog logger, string name)
             : base(config, logger, name) { }


### PR DESCRIPTION
### 🤔 What's changed?

Added two virtual properties to the FormattersBase class that provide the timeout values to use during Formatter disposal. These were previously hard-coded.


### ⚡️ What's your motivation? 

This allows derivative formatters to set their own time-out values. The first real use of this is in the runtime tests in which the timeout values are set very small to allow those tests to complete much more quickly.


### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)


### ♻️ Anything particular you want feedback on?


### 📋 Checklist:


- [X] I've changed the behaviour of the code
  - [X] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [X] Users should know about my change
  - [X] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
