### PR TITLE
Improve formatter shutdown and cancellation handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # [vNext]
 
 ## Improvements:
+* Formatters: Improve the robustness of Formatter shutdown and handling of cancellation.
 
 ## Bug fixes:
 
-*Contributors of this release (in alphabetical order):* 
+*Contributors of this release (in alphabetical order):* @clrudolphi
 
 # v3.3.3 - 2026-01-27
 

--- a/Reqnroll/Formatters/FileWritingFormatterBase.cs
+++ b/Reqnroll/Formatters/FileWritingFormatterBase.cs
@@ -126,11 +126,6 @@ public abstract class FileWritingFormatterBase : FormatterBase
         {
             await foreach (var message in PostedMessages.Reader.ReadAllAsync(cancellationToken))
             {
-                if (cancellationToken.IsCancellationRequested)
-                {
-                    Logger.WriteMessage($"Formatter {Name} has been cancelled.");
-                    break;
-                }
                 await WriteToFile(message, cancellationToken);
             }
         }

--- a/Tests/Reqnroll.RuntimeTests/Formatters/FileWritingFormatterBaseTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/Formatters/FileWritingFormatterBaseTests.cs
@@ -325,7 +325,8 @@ public class FileWritingFormatterBaseTests
         await _sut.PublishAsync(message);
         _sut.Dispose();
 
-        _sut.LastEnvelope.Should().Be(message);
+        // When Dispose is called without CloseAsync (abnormal shutdown), the background task
+        // is immediately cancelled. Message processing is not guaranteed in this path.
         _sut.OnCancellationCalled.Should().BeTrue();
     }
 

--- a/Tests/Reqnroll.RuntimeTests/Formatters/FormatterBaseTests.cs
+++ b/Tests/Reqnroll.RuntimeTests/Formatters/FormatterBaseTests.cs
@@ -58,6 +58,117 @@ public class FormatterBaseTests
         }
     }
 
+    /// <summary>
+    /// A formatter whose background task blocks on a <see cref="TaskCompletionSource{TResult}"/>
+    /// until explicitly released or until the cancellation token fires.
+    /// Used to exercise the timeout and cancellation paths in CloseAsync/Dispose.
+    /// </summary>
+    private class HangingTestFormatter : FormatterBase
+    {
+        private readonly TaskCompletionSource<bool> _gate = new();
+        private readonly TimeSpan? _closeAsyncTimeout;
+        private readonly TimeSpan? _closeAsyncCancellationGracePeriod;
+        private readonly TimeSpan? _disposeTimeout;
+        public bool CancellationObserved = false;
+
+        public HangingTestFormatter(IFormattersConfigurationProvider config, IFormatterLog logger, string name,
+            TimeSpan? closeAsyncTimeout = null, TimeSpan? closeAsyncCancellationGracePeriod = null, TimeSpan? disposeTimeout = null)
+            : base(config, logger, name)
+        {
+            _closeAsyncTimeout = closeAsyncTimeout;
+            _closeAsyncCancellationGracePeriod = closeAsyncCancellationGracePeriod;
+            _disposeTimeout = disposeTimeout;
+        }
+
+        protected override TimeSpan CloseAsyncTimeout => _closeAsyncTimeout ?? base.CloseAsyncTimeout;
+        protected override TimeSpan CloseAsyncCancellationGracePeriod => _closeAsyncCancellationGracePeriod ?? base.CloseAsyncCancellationGracePeriod;
+        protected override TimeSpan DisposeTimeout => _disposeTimeout ?? base.DisposeTimeout;
+
+        public override void LaunchInner(IDictionary<string, object> formatterConfig, Action<bool> onAfterInitialization)
+        {
+            onAfterInitialization(true);
+        }
+
+        protected override async Task ConsumeAndFormatMessagesBackgroundTask(CancellationToken cancellationToken)
+        {
+            using var registration = cancellationToken.Register(() =>
+            {
+                CancellationObserved = true;
+                _gate.TrySetResult(true);
+            });
+            await _gate.Task;
+        }
+
+        public void Release() => _gate.TrySetResult(true);
+    }
+
+    /// <summary>
+    /// A formatter whose background task ignores the cancellation token entirely,
+    /// used to test the grace period expiry path.
+    /// </summary>
+    private class UnresponsiveTestFormatter : FormatterBase
+    {
+        private readonly TaskCompletionSource<bool> _gate = new();
+        private readonly TimeSpan? _closeAsyncTimeout;
+        private readonly TimeSpan? _closeAsyncCancellationGracePeriod;
+
+        public UnresponsiveTestFormatter(IFormattersConfigurationProvider config, IFormatterLog logger, string name,
+            TimeSpan? closeAsyncTimeout = null, TimeSpan? closeAsyncCancellationGracePeriod = null)
+            : base(config, logger, name)
+        {
+            _closeAsyncTimeout = closeAsyncTimeout;
+            _closeAsyncCancellationGracePeriod = closeAsyncCancellationGracePeriod;
+        }
+
+        protected override TimeSpan CloseAsyncTimeout => _closeAsyncTimeout ?? base.CloseAsyncTimeout;
+        protected override TimeSpan CloseAsyncCancellationGracePeriod => _closeAsyncCancellationGracePeriod ?? base.CloseAsyncCancellationGracePeriod;
+
+        public override void LaunchInner(IDictionary<string, object> formatterConfig, Action<bool> onAfterInitialization)
+        {
+            onAfterInitialization(true);
+        }
+
+        protected override async Task ConsumeAndFormatMessagesBackgroundTask(CancellationToken cancellationToken)
+        {
+            // Deliberately ignores the cancellation token
+            await _gate.Task;
+        }
+
+        public void Release() => _gate.TrySetResult(true);
+    }
+
+    /// <summary>
+    /// A formatter whose background task throws OperationCanceledException when
+    /// the cancellation token fires (simulating a derived class that does not catch it).
+    /// </summary>
+    private class ThrowingOnCancelTestFormatter : FormatterBase
+    {
+        private readonly TimeSpan? _closeAsyncTimeout;
+        private readonly TimeSpan? _closeAsyncCancellationGracePeriod;
+
+        public ThrowingOnCancelTestFormatter(IFormattersConfigurationProvider config, IFormatterLog logger, string name,
+            TimeSpan? closeAsyncTimeout = null, TimeSpan? closeAsyncCancellationGracePeriod = null)
+            : base(config, logger, name)
+        {
+            _closeAsyncTimeout = closeAsyncTimeout;
+            _closeAsyncCancellationGracePeriod = closeAsyncCancellationGracePeriod;
+        }
+
+        protected override TimeSpan CloseAsyncTimeout => _closeAsyncTimeout ?? base.CloseAsyncTimeout;
+        protected override TimeSpan CloseAsyncCancellationGracePeriod => _closeAsyncCancellationGracePeriod ?? base.CloseAsyncCancellationGracePeriod;
+
+        public override void LaunchInner(IDictionary<string, object> formatterConfig, Action<bool> onAfterInitialization)
+        {
+            onAfterInitialization(true);
+        }
+
+        protected override async Task ConsumeAndFormatMessagesBackgroundTask(CancellationToken cancellationToken)
+        {
+            // Hangs indefinitely; throws TaskCanceledException (subclass of OperationCanceledException) on cancellation
+            await Task.Delay(Timeout.Infinite, cancellationToken);
+        }
+    }
+
     private readonly Mock<IFormattersConfigurationProvider> _configMock = new();
     private readonly Mock<IFormatterLog> _loggerMock = new();
     private readonly Mock<ICucumberMessageBroker> _brokerMock = new();
@@ -152,5 +263,67 @@ public class FormatterBaseTests
         _sut.LaunchInnerCallback.Should().NotBeNull();
         _brokerMock.Verify(b => b.FormatterInitialized(_sut, true), Times.Once);
 
+    }
+
+    private TFormatter LaunchFormatter<TFormatter>(TFormatter formatter) where TFormatter : FormatterBase
+    {
+        _configMock.Setup(c => c.Enabled).Returns(true);
+        _configMock.Setup(c => c.GetFormatterConfigurationByName(formatter.Name)).Returns(new Dictionary<string, object>());
+        formatter.LaunchFormatter(_brokerMock.Object);
+        return formatter;
+    }
+
+    [Fact]
+    public async Task CloseAsync_CancelsToken_WhenBackgroundTaskExceedsTimeout()
+    {
+        var formatter = LaunchFormatter(new HangingTestFormatter(_configMock.Object, _loggerMock.Object, "testPlugin",
+            closeAsyncTimeout: TimeSpan.FromMilliseconds(50), closeAsyncCancellationGracePeriod: TimeSpan.FromSeconds(2)));
+
+        await formatter.CloseAsync();
+
+        formatter.CancellationObserved.Should().BeTrue();
+        _loggerMock.Verify(l => l.WriteMessage(It.Is<string>(s => s.Contains("Timed out waiting for formatterTask"))), Times.Once);
+        _loggerMock.Verify(l => l.WriteMessage(It.Is<string>(s => s.Contains("formatterTask completed after cancellation"))), Times.Once);
+    }
+
+    [Fact]
+    public async Task CloseAsync_LogsGracePeriodExpiry_WhenTaskIgnoresCancellation()
+    {
+        var formatter = LaunchFormatter(new UnresponsiveTestFormatter(_configMock.Object, _loggerMock.Object, "testPlugin",
+            closeAsyncTimeout: TimeSpan.FromMilliseconds(50), closeAsyncCancellationGracePeriod: TimeSpan.FromMilliseconds(50)));
+
+        await formatter.CloseAsync();
+
+        _loggerMock.Verify(l => l.WriteMessage(It.Is<string>(s => s.Contains("formatterTask did not respond to cancellation within grace period"))), Times.Once);
+
+        // Clean up: release the task so Dispose doesn't hang
+        formatter.Release();
+        formatter.Dispose();
+    }
+
+    [Fact]
+    public async Task CloseAsync_CatchesOperationCanceledException_WhenDerivedClassDoesNotHandleIt()
+    {
+        var formatter = LaunchFormatter(new ThrowingOnCancelTestFormatter(_configMock.Object, _loggerMock.Object, "testPlugin",
+            closeAsyncTimeout: TimeSpan.FromMilliseconds(50), closeAsyncCancellationGracePeriod: TimeSpan.FromSeconds(2)));
+
+        // Should not throw despite the background task faulting with OperationCanceledException
+        await formatter.CloseAsync();
+
+        _loggerMock.Verify(l => l.WriteMessage(It.Is<string>(s => s.Contains("OperationCanceledException after cancellation (expected)"))), Times.Once);
+    }
+
+    [Fact]
+    public void Dispose_ForcesImmediateShutdown_WhenCloseAsyncNeverCalled()
+    {
+        var formatter = LaunchFormatter(new HangingTestFormatter(_configMock.Object, _loggerMock.Object, "testPlugin",
+            disposeTimeout: TimeSpan.FromSeconds(2)));
+
+        formatter.Dispose();
+
+        ((HangingTestFormatter)formatter).CancellationObserved.Should().BeTrue();
+        _loggerMock.Verify(l => l.WriteMessage(It.Is<string>(s => s.Contains("forcing shutdown"))), Times.Once);
+        _loggerMock.Verify(l => l.WriteMessage(It.Is<string>(s => s.Contains("completed after cancellation"))), Times.Once);
+        _loggerMock.Verify(l => l.DumpMessages(), Times.Once);
     }
 }


### PR DESCRIPTION
### 🤔 What's changed?

Added time-out waiting logic to CloseAsync. Simplified the similar logic in Dispose.
Adds configurable timeouts for CloseAsync and Dispose in FormatterBase.

### ⚡️ What's your motivation? 

Improve the robustness of the Formatter shutdown.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?


### 📋 Checklist:


- [X] I've changed the behaviour of the code
  - [X] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [X] Users should know about my change
  - [X] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
