### PR TITLE
Refactor Formatters to make Shutdown explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # [vNext]
 
 ## Improvements:
-
+* Formatters: Made shutdown an explicit part of the interfaces for the Broker and Formatters. 
+* 
 ## Bug fixes:
 
-*Contributors of this release (in alphabetical order):* 
+*Contributors of this release (in alphabetical order):* @clrudolphi
 
 # v3.3.3 - 2026-01-27
 

--- a/Reqnroll/Formatters/ICucumberMessageFormatter.cs
+++ b/Reqnroll/Formatters/ICucumberMessageFormatter.cs
@@ -9,4 +9,5 @@ public interface ICucumberMessageFormatter
     void LaunchFormatter(ICucumberMessageBroker broker);
     string Name { get; }
     Task PublishAsync(Envelope message);
+    Task CloseAsync();
 }

--- a/Reqnroll/Formatters/PubSub/CucumberMessageBroker.cs
+++ b/Reqnroll/Formatters/PubSub/CucumberMessageBroker.cs
@@ -104,4 +104,21 @@ public class CucumberMessageBroker : ICucumberMessageBroker
         }
     }
 
+    public async Task CompleteAsync()
+    {
+        _logger.WriteMessage("DEBUG: Formatters - Broker: CompleteAsync called. Closing all active formatters.");
+        foreach (var formatter in _activeFormatters.Values)
+        {
+            try
+            {
+                await formatter.CloseAsync();
+            }
+            catch (System.Exception e)
+            {
+                _logger.WriteMessage($"Formatters Broker: Exception closing Formatter Plugin {formatter.Name}: {e.Message}");
+            }
+        }
+        _logger.WriteMessage("DEBUG: Formatters - Broker: CompleteAsync finished.");
+    }
+
 }

--- a/Reqnroll/Formatters/PubSub/CucumberMessagePublisher.cs
+++ b/Reqnroll/Formatters/PubSub/CucumberMessagePublisher.cs
@@ -194,6 +194,9 @@ public class CucumberMessagePublisher : IAsyncExecutionEventListener, ICucumberM
 
         await _broker.PublishAsync(Envelope.Create(MessageFactory.ToTestRunFinished(TestRunPassed, _clock.GetNowDateAndTime(), _testRunStartedId)));
         _logger.WriteMessage("DEBUG: Formatter:Publisher.TestRunComplete: TestRunFinished Message written");
+
+        await _broker.CompleteAsync();
+        _logger.WriteMessage("DEBUG: Formatter:Publisher.TestRunComplete: Broker CompleteAsync finished");
     }
 
     #region TestThreadExecutionEventPublisher Event Handling Methods

--- a/Reqnroll/Formatters/PubSub/ICucumberMessageBroker.cs
+++ b/Reqnroll/Formatters/PubSub/ICucumberMessageBroker.cs
@@ -1,4 +1,6 @@
-﻿namespace Reqnroll.Formatters.PubSub;
+﻿using System.Threading.Tasks;
+
+namespace Reqnroll.Formatters.PubSub;
 
 public interface ICucumberMessageBroker : IMessagePublisher
 {
@@ -6,4 +8,5 @@ public interface ICucumberMessageBroker : IMessagePublisher
 
     void Initialize();
     void FormatterInitialized(ICucumberMessageFormatter formatterSink, bool enabled);
+    Task CompleteAsync();
 }


### PR DESCRIPTION

### 🤔 What's changed?

The interface definitions of the Broker and FormatterBase have been modified to add explicit methods for closing.

Sending the TestRunFinished message is no longer an implicit signal to shutdown the formatters.

The Publisher will call the Broker's CompleteAsync() method which will forward that call to each active formatter by invoking their CloseAsync() methods.

### ⚡️ What's your motivation? 

Makes the design more explicit.

### 🏷️ What kind of change is this?

- :boom: Breaking change (incompatible changes to the API) (adding methods to existing interfaces)

### ♻️ Anything particular you want feedback on?


### 📋 Checklist:



- [X] I've changed the behaviour of the code
  - [X] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [X] Users should know about my change
  - [X] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
