### PR TITLE
Change read visibility of PickleId property to public.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Bug fixes:
 * Fix: Formatters incorrectly handle Unicode text file content of attachments.
+* Enhancement: Changed visibility of PickleId property of ScenarioInfo to public.
 
 *Contributors of this release (in alphabetical order):* @clrudolphi
 

--- a/Reqnroll/ScenarioInfo.cs
+++ b/Reqnroll/ScenarioInfo.cs
@@ -49,7 +49,7 @@ namespace Reqnroll
         /// <summary>
         /// This holds the unique identifier for the test ("pickle") represented by this scenario info. Used internally at runtime.
         /// </summary>
-        public string PickleId { get; set; }
+        public string PickleId { get; internal set; }
 
 
         public ScenarioInfo(string title, string description, string[] tags, IOrderedDictionary arguments, string[] inheritedTags = null, string pickleIndex = null)

--- a/Reqnroll/ScenarioInfo.cs
+++ b/Reqnroll/ScenarioInfo.cs
@@ -49,7 +49,7 @@ namespace Reqnroll
         /// <summary>
         /// This holds the unique identifier for the test ("pickle") represented by this scenario info. Used internally at runtime.
         /// </summary>
-        internal string PickleId { get; set; }
+        public string PickleId { get; set; }
 
 
         public ScenarioInfo(string title, string description, string[] tags, IOrderedDictionary arguments, string[] inheritedTags = null, string pickleIndex = null)


### PR DESCRIPTION
### 🤔 What's changed?

Change visibility of PickleId property to public.

### ⚡️ What's your motivation? 

See discussion #1049 

### 🏷️ What kind of change is this?


- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)


### ♻️ Anything particular you want feedback on?

I don't see a need to add tests for this simple change.

### 📋 Checklist:



- [X] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [X] Users should know about my change
  - [X] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
