### PR TITLE
Rn r1078 fix invalid handling of long generated file path lengths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 ## Improvements:
 
 ## Bug fixes:
+* Fix: GenerateFeatureFileCodeBehindTask fails with misleading DirectoryNotFoundException when ndjson output path exceeds Windows MAX_PATH (260)
 
-*Contributors of this release (in alphabetical order):*
+*Contributors of this release (in alphabetical order):* @clrudolphi
 
 # v3.3.4 - 2026-03-23
 

--- a/Reqnroll.Tools.MsBuild.Generation/GeneratedFileWriter.cs
+++ b/Reqnroll.Tools.MsBuild.Generation/GeneratedFileWriter.cs
@@ -1,29 +1,30 @@
+using System;
 using System.IO;
 using System.Text;
 using Reqnroll.Utils;
 
 namespace Reqnroll.Tools.MsBuild.Generation;
 
-/// <summary>
-/// This class is going to be obsolete once we implement MsBuild level up-to-date checks.
-/// </summary>
 public class GeneratedFileWriter(IReqnrollTaskLoggingHelper log)
 {
     public void WriteGeneratedFile(string outputPath, string generatedFileContent)
     {
+        var path = NormalizePath(outputPath);
         log.LogTaskDiagnosticMessage($"Writing data to {outputPath}");
-        WriteFile(outputPath, generatedFileContent);
+        WriteFile(path, generatedFileContent);
     }
 
     public void DeleteGeneratedFile(string outputPath)
     {
-        if (!File.Exists(outputPath))
+        var path = NormalizePath(outputPath);
+
+        if (!File.Exists(path))
             return;
 
         log.LogTaskDiagnosticMessage($"Deleting {outputPath}");
         try
         {
-            File.Delete(outputPath);
+            File.Delete(path);
         }
         catch (IOException ex)
         {
@@ -34,7 +35,7 @@ public class GeneratedFileWriter(IReqnrollTaskLoggingHelper log)
     private void WriteFile(string filePath, string content)
     {
         string directoryPath = Path.GetDirectoryName(filePath);
-        if (directoryPath != null && !Directory.Exists(directoryPath))
+        if (!string.IsNullOrEmpty(directoryPath) && !Directory.Exists(directoryPath))
         {
             Directory.CreateDirectory(directoryPath);
         }
@@ -42,13 +43,33 @@ public class GeneratedFileWriter(IReqnrollTaskLoggingHelper log)
         WriteAllTextWithRetry(filePath, content, Encoding.UTF8);
     }
 
-    /// <summary>
-    /// When building a multi-targeted project, the build system may try to write the same file multiple times,
-    /// and this can cause an IOException ("The process cannot access the file because it is being used by another process.").
-    /// See https://github.com/reqnroll/Reqnroll/issues/197
-    /// Once we move to Roslyn-based generation, this problem will go away, but for now, we use a workaround of
-    /// retrying the write operation a few times (the content is anyway the same).
-    /// </summary>
+    private static string NormalizePath(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            throw new ArgumentException("Path must not be null or empty.", nameof(path));
+
+        string fullPath = Path.GetFullPath(path);
+
+        // Cross-platform: only apply extended syntax on Windows.
+        if (!System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
+                System.Runtime.InteropServices.OSPlatform.Windows))
+        {
+            return fullPath;
+        }
+
+        // Already device/extended syntax.
+        if (fullPath.StartsWith(@"\\?\", StringComparison.Ordinal) ||
+            fullPath.StartsWith(@"\\.\", StringComparison.Ordinal))
+            return fullPath;
+
+        // UNC path.
+        if (fullPath.StartsWith(@"\\", StringComparison.Ordinal))
+            return @"\\?\UNC\" + fullPath.Substring(2);
+
+        // Drive-qualified path.
+        return @"\\?\" + fullPath;
+    }
+
     private void WriteAllTextWithRetry(string path, string contents, Encoding encoding)
     {
         const int maxAttempts = 5;

--- a/Reqnroll.Tools.MsBuild.Generation/GeneratedFileWriter.cs
+++ b/Reqnroll.Tools.MsBuild.Generation/GeneratedFileWriter.cs
@@ -70,6 +70,13 @@ public class GeneratedFileWriter(IReqnrollTaskLoggingHelper log)
         return @"\\?\" + fullPath;
     }
 
+    /// <summary>
+    /// When building a multi-targeted project, the build system may try to write the same file multiple times,
+    /// and this can cause an IOException ("The process cannot access the file because it is being used by another process.").
+    /// See https://github.com/reqnroll/Reqnroll/issues/197
+    /// Once we move to Roslyn-based generation, this problem will go away, but for now, we use a workaround of
+    /// retrying the write operation a few times (the content is anyway the same).
+    /// </summary>
     private void WriteAllTextWithRetry(string path, string contents, Encoding encoding)
     {
         const int maxAttempts = 5;

--- a/Reqnroll.Tools.MsBuild.Generation/GeneratedFileWriter.cs
+++ b/Reqnroll.Tools.MsBuild.Generation/GeneratedFileWriter.cs
@@ -9,9 +9,8 @@ public class GeneratedFileWriter(IReqnrollTaskLoggingHelper log)
 {
     public void WriteGeneratedFile(string outputPath, string generatedFileContent)
     {
-        var path = ChangePathToSupportLongPaths(outputPath);
         log.LogTaskDiagnosticMessage($"Writing data to {outputPath}");
-        WriteFile(path, generatedFileContent);
+        WriteFile(outputPath, generatedFileContent);
     }
 
     public void DeleteGeneratedFile(string outputPath)
@@ -35,18 +34,19 @@ public class GeneratedFileWriter(IReqnrollTaskLoggingHelper log)
     private void WriteFile(string filePath, string content)
     {
         string directoryPath = Path.GetDirectoryName(filePath);
-        if (!string.IsNullOrEmpty(directoryPath) && !Directory.Exists(directoryPath))
+        var longDirPath = ChangePathToSupportLongPaths(directoryPath);
+        if (!string.IsNullOrEmpty(longDirPath) && !Directory.Exists(longDirPath))
         {
-            Directory.CreateDirectory(directoryPath);
+            Directory.CreateDirectory(longDirPath);
         }
-
-        WriteAllTextWithRetry(filePath, content, Encoding.UTF8);
+        var longPath = ChangePathToSupportLongPaths(filePath);
+        WriteAllTextWithRetry(longPath, content, Encoding.UTF8);
     }
 
     private static string ChangePathToSupportLongPaths(string path)
     {
         if (string.IsNullOrWhiteSpace(path))
-            throw new ArgumentException("Path must not be null or empty.", nameof(path));
+            return path;
 
         string fullPath = Path.GetFullPath(path);
 
@@ -62,11 +62,11 @@ public class GeneratedFileWriter(IReqnrollTaskLoggingHelper log)
             fullPath.StartsWith(@"\\.\", StringComparison.Ordinal))
             return fullPath;
 
-        // UNC path.
+        // UNC longDirPath.
         if (fullPath.StartsWith(@"\\", StringComparison.Ordinal))
             return @"\\?\UNC\" + fullPath.Substring(2);
 
-        // Drive-qualified path.
+        // Drive-qualified longDirPath.
         return @"\\?\" + fullPath;
     }
 

--- a/Reqnroll.Tools.MsBuild.Generation/GeneratedFileWriter.cs
+++ b/Reqnroll.Tools.MsBuild.Generation/GeneratedFileWriter.cs
@@ -9,14 +9,14 @@ public class GeneratedFileWriter(IReqnrollTaskLoggingHelper log)
 {
     public void WriteGeneratedFile(string outputPath, string generatedFileContent)
     {
-        var path = NormalizePath(outputPath);
+        var path = ChangePathToSupportLongPaths(outputPath);
         log.LogTaskDiagnosticMessage($"Writing data to {outputPath}");
         WriteFile(path, generatedFileContent);
     }
 
     public void DeleteGeneratedFile(string outputPath)
     {
-        var path = NormalizePath(outputPath);
+        var path = ChangePathToSupportLongPaths(outputPath);
 
         if (!File.Exists(path))
             return;
@@ -43,7 +43,7 @@ public class GeneratedFileWriter(IReqnrollTaskLoggingHelper log)
         WriteAllTextWithRetry(filePath, content, Encoding.UTF8);
     }
 
-    private static string NormalizePath(string path)
+    private static string ChangePathToSupportLongPaths(string path)
     {
         if (string.IsNullOrWhiteSpace(path))
             throw new ArgumentException("Path must not be null or empty.", nameof(path));


### PR DESCRIPTION
### 🤔 What's changed?

Modified `GeneratedFileWriter` to include a `\\?\` or '\\?\UNC\` prefix when running under Windows. 

### ⚡️ What's your motivation? 

To properly support file paths longer than 260 characters as reported in #1078 

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)


### ♻️ Anything particular you want feedback on?

**TESTING**: 
I have been able to reproduce the problem locally and convince myself that this PR addresses the issue.
However, this PR is lacking tests as I'm unsure how to proceed with testing. Our CI runs under both OSes and even then usually only under net8 or net10. It is my impression that this problem is going to be most prevalent when running the MSBuild task under .NET Framework on Windows only. 
Would you prefer to see a completely new test added to CI so that we can force those conditions?

### 📋 Checklist:


- [X] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [X] Users should know about my change
  - [X] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
