### PR TITLE
Update NuGet.CommandLine to fix build warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,8 @@
 ## Improvements:
 
 ## Bug fixes:
-* Fix: Upgraded NuGetCommandLine package causes build warnings as errors
 
-*Contributors of this release (in alphabetical order):* @clrudolphi
+*Contributors of this release (in alphabetical order):* 
 
 # v3.3.4 - 2026-03-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 ## Improvements:
 
 ## Bug fixes:
+* Fix: Upgraded NuGetCommandLine package causes build warnings as errors
 
-*Contributors of this release (in alphabetical order):*
+*Contributors of this release (in alphabetical order):* @clrudolphi
 
 # v3.3.4 - 2026-03-23
 

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/NuGet.cs
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/NuGet.cs
@@ -57,7 +57,7 @@ namespace Reqnroll.TestProjectGenerator
 
         protected virtual string GetPathToNuGetExe()
         {
-            return Path.Combine(_folders.SystemGlobalNuGetPackages, "NuGet.CommandLine".ToLower(), "6.11.2", "tools", "NuGet.exe");
+            return Path.Combine(_folders.SystemGlobalNuGetPackages, "NuGet.CommandLine".ToLower(), "7.3.1", "tools", "NuGet.exe");
         }
     }
 }

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/NuGet.cs
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/NuGet.cs
@@ -57,7 +57,7 @@ namespace Reqnroll.TestProjectGenerator
 
         protected virtual string GetPathToNuGetExe()
         {
-            return Path.Combine(_folders.SystemGlobalNuGetPackages, "NuGet.CommandLine".ToLower(), "6.11.0", "tools", "NuGet.exe");
+            return Path.Combine(_folders.SystemGlobalNuGetPackages, "NuGet.CommandLine".ToLower(), "6.11.2", "tools", "NuGet.exe");
         }
     }
 }

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator.csproj
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="NuGet.CommandLine" Version="6.11.0">
+    <PackageReference Include="NuGet.CommandLine" Version="6.11.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator.csproj
+++ b/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="NuGet.CommandLine" Version="6.11.2">
+    <PackageReference Include="NuGet.CommandLine" Version="7.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
### 🤔 What's changed?

Upgraded NuGet.CommandLine from 6.11.0 to 7.3.1 in the Reqnroll.TestProjectGenerator.csproj to resolve build warnings treated as errors.

### ⚡️ What's your motivation? 

PR builds fail as the security warning is treated as an error.
As an example, here are the last 10 lines from the Restore build step:
```
  Restored /home/runner/work/Reqnroll/Reqnroll/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator.Tests/Reqnroll.TestProjectGenerator.Tests.csproj (in 483 ms).
/home/runner/work/Reqnroll/Reqnroll/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator.csproj : error NU1901: Warning As Error: Package 'NuGet.CommandLine' 6.11.0 has a known low severity vulnerability, https://github.com/advisories/GHSA-g4vj-cjjj-v7hg [/home/runner/work/Reqnroll/Reqnroll/Reqnroll.slnx]
  Restored /home/runner/work/Reqnroll/Reqnroll/Tests/Reqnroll.RuntimeTests/Reqnroll.RuntimeTests.csproj (in 9 ms).
  Failed to restore /home/runner/work/Reqnroll/Reqnroll/Tests/TestProjectGenerator/Reqnroll.TestProjectGenerator/Reqnroll.TestProjectGenerator.csproj (in 556 ms).
  Restored /home/runner/work/Reqnroll/Reqnroll/Tests/Reqnroll.GeneratorTests/Reqnroll.GeneratorTests.csproj (in 12 ms).
  Restored /home/runner/work/Reqnroll/Reqnroll/Tests/Reqnroll.PluginTests/Reqnroll.PluginTests.csproj (in 75 ms).
  Restored /home/runner/work/Reqnroll/Reqnroll/Templates/Reqnroll.Templates.DotNet/Reqnroll.Templates.DotNet.csproj (in 247 ms).
  Restored /home/runner/work/Reqnroll/Reqnroll/Tests/Reqnroll.SystemTests/Reqnroll.SystemTests.csproj (in 763 ms).
  Restored /home/runner/work/Reqnroll/Reqnroll/Tests/Reqnroll.Formatters.Tests/Reqnroll.Formatters.Tests.csproj (in 1.25 sec).
  Restored /home/runner/work/Reqnroll/Reqnroll/Tests/Reqnroll.Specs/Reqnroll.Specs.csproj (in 1.47 sec).
Error: Process completed with exit code 1.
```

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?


### 📋 Checklist:

- [X] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
