### PR TITLE
Fixes 1112. When a ScenarioOutline has a tag, the generated code does not properly global:: namespace uses of `Enumerable`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ## Bug fixes:
 * Fix: GenerateFeatureFileCodeBehindTask fails with misleading DirectoryNotFoundException when ndjson output path exceeds Windows MAX_PATH (260)
+* Fix: Scenario Outline codegen emits unqualified System.Linq references resulting in CS0234 when the user's namespace includes 'System' (#1112)
 
 *Contributors of this release (in alphabetical order):* @clrudolphi
 

--- a/Reqnroll.Generator/Generation/UnitTestMethodGenerator.cs
+++ b/Reqnroll.Generator/Generation/UnitTestMethodGenerator.cs
@@ -196,10 +196,10 @@ namespace Reqnroll.Generator.Generation
                         new CodeAssignStatement(
                             tagsExpression,
                             new CodeMethodInvokeExpression(
-                                new CodeTypeReferenceExpression(typeof(Enumerable)),
+                                new CodeTypeReferenceExpression(new CodeTypeReference(typeof(Enumerable), CodeTypeReferenceOptions.GlobalReference)),
                                 "ToArray",
                                 new CodeMethodInvokeExpression(
-                                    new CodeTypeReferenceExpression(typeof(Enumerable)),
+                                    new CodeTypeReferenceExpression(new CodeTypeReference(typeof(Enumerable), CodeTypeReferenceOptions.GlobalReference)),
                                     "Concat",
                                     tagsExpression,
                                     additionalTagsExpression)))));


### PR DESCRIPTION
### 🤔 What's changed?

Fixes #1112 This commit modifies the `UnitTestMethodGenerator` for the specific spot where Example tags are concatenated with Scenario tags.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)


### ♻️ Anything particular you want feedback on?



### 📋 Checklist:


- [X] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [X] Users should know about my change
  - [X] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
