### PR TITLE
Fix template step definition visibility

### DIFF
--- a/Templates/Reqnroll.Templates.DotNet/Reqnroll.Templates.DotNet.csproj
+++ b/Templates/Reqnroll.Templates.DotNet/Reqnroll.Templates.DotNet.csproj
@@ -29,6 +29,7 @@
     <Compile Remove="**\*" />
     <None Include="$(SolutionDir)reqnroll-icon.png" Pack="true" PackagePath="images" />
     <None Include="templates\reqnroll-project\Template.csproj" />
+    <None Include="templates\reqnroll-project\StepDefinitions\CalculatorStepDefinitions.cs" />
     <None Include="templates\reqnroll-project\.template.config\**" />
     <None Include="templates\reqnroll-config\.template.config\**" />
     <None Include="templates\reqnroll-feature\.template.config\**" />


### PR DESCRIPTION
### 🤔 What's changed?

- Re-includes `templates\reqnroll-project\StepDefinitions\CalculatorStepDefinitions.cs` as a `None` item in the template package project.
- Keeps the templated source excluded from compilation while making it visible to maintainers in Visual Studio Solution Explorer.
- Preserves the existing `MetaTemplate` item used to package and generate the source file.

### ⚡️ What's your motivation?

`CalculatorStepDefinitions.cs` contains conditional template logic but was absent from the template package project's Visual Studio tree because `<Compile Remove="**\*" />` removed its default SDK item and it was not re-included under another visible item type. This made an actively maintained template source easy to overlook.

Fixes #1065

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

Please confirm that explicitly including the templated C# source as `None` is the preferred way to expose it in Solution Explorer while retaining `MetaTemplate` for packaging.

### ✅ Validation

- Verified through MSBuild item evaluation that `CalculatorStepDefinitions.cs` is present as `None` and `MetaTemplate`, but not `Compile`.
- Installed the source template into an isolated custom hive and generated a project containing `StepDefinitions\CalculatorStepDefinitions.cs` with the expected namespace.
- Ran `git diff --check` successfully.
- A focused code review found no significant issues.

The affected template project build/pack could not restore because nuget.org failed its TLS handshake with `NU1301`; this occurred before compilation. No dedicated existing template test project was found.

AI assistance: GitHub Copilot assisted with implementation and validation; the commit also records this with a `Co-authored-by` trailer.

### 📋 Checklist:

- [x] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes. No dedicated template test surface exists; focused MSBuild evaluation and template-generation smoke validation were performed instead.
- [ ] This change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change.
  - [ ] I have added an entry to the "[vNext]" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request & included my GitHub handle to the release contributors list.

----

*This text was originally taken from the [template of the Cucumber project](https://github.com/cucumber/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), then edited by hand. [You can modify the template here.](https://github.com/reqnroll/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*